### PR TITLE
Add playground

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 MODULE  := github.com/n8n-io/sandbox-service
 BINDIR  := bin
 
-.PHONY: all daemon runner api test clean docker docker-local docker-arm64 docker-amd64 docker-api-arm64 docker-api-amd64 docker-runner-arm64 docker-runner-amd64 docker-sandbox-arm64 docker-sandbox-amd64 fmt fmt-check vet
+.PHONY: all daemon runner api test clean docker docker-local docker-arm64 docker-amd64 docker-api-arm64 docker-api-amd64 docker-runner-arm64 docker-runner-amd64 docker-sandbox-arm64 docker-sandbox-amd64 fmt fmt-check vet playground
 
 all: daemon runner api
 
@@ -38,6 +38,10 @@ runner:
 ## api: Build the public API gateway server (Linux).
 api:
 	GOOS=linux go build -o $(BINDIR)/api ./cmd/api
+
+## playground: Start the playground UI (http://localhost:3000).
+playground:
+	cd playground && npm ci && npm start
 
 ## test: Run all tests.
 test:

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,28 @@
+# Sandbox Playground
+
+A browser-based UI for interacting with the sandbox service API. Useful for manually testing sandboxes without writing code.
+
+## Features
+
+- Create sandboxes (from a base image or with custom Dockerfile steps)
+- List, select, and delete sandboxes
+- Execute commands in a selected sandbox with streaming output (stdout/stderr)
+- Command history (arrow keys)
+- Abort running commands with Ctrl+C
+- Browse and view/edit files inside a sandbox
+- List and delete images
+
+## Usage
+
+```sh
+npm ci
+npm start
+```
+
+Then open `http://localhost:3000` in your browser.
+
+Enter the **Base URL** of the sandbox service (default: `http://localhost:8080`) and your **API Key** in the sidebar, then create or select a sandbox to start.
+
+## Settings persistence
+
+The base URL and API key are saved to `localStorage` and restored on page load.

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -1,0 +1,969 @@
+{
+  "name": "playground",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "serve": "14.2.6"
+      }
+    },
+    "node_modules/@zeit/schemas": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+      "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/boxen": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
+      "integrity": "sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.0",
+        "chalk": "^5.0.1",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "license": "MIT",
+      "dependencies": {
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-port-reachable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-4.0.0.tgz",
+      "integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.33.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/serve": {
+      "version": "14.2.6",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.6.tgz",
+      "integrity": "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@zeit/schemas": "2.36.0",
+        "ajv": "8.18.0",
+        "arg": "5.0.2",
+        "boxen": "7.0.0",
+        "chalk": "5.0.1",
+        "chalk-template": "0.4.0",
+        "clipboardy": "3.0.0",
+        "compression": "1.8.1",
+        "is-port-reachable": "4.0.0",
+        "serve-handler": "6.1.7",
+        "update-check": "1.5.4"
+      },
+      "bin": {
+        "serve": "build/main.js"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/serve-handler": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.5",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "3.3.0",
+        "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/update-check": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
+      "integrity": "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    }
+  }
+}

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "scripts": {
+    "start": "serve src"
+  },
+  "dependencies": {
+    "serve": "14.2.6"
+  }
+}

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -1,0 +1,716 @@
+const $ = (sel) => document.querySelector(sel);
+const baseUrlInput = $('#base-url');
+const apiKeyInput = $('#api-key');
+const createBtn = $('#create-btn');
+const refreshBtn = $('#refresh-btn');
+const sandboxList = $('#sandbox-list');
+const output = $('#output');
+const cmdInput = $('#cmd-input');
+const runBtn = $('#run-btn');
+const statusEl = $('#status');
+
+let selectedSandboxId = null;
+let commandHistory = [];
+let historyIndex = -1;
+let currentAbortController = null;
+
+// --- Persistence ---
+
+function loadSettings() {
+  const url = localStorage.getItem('sandbox-base-url');
+  const key = localStorage.getItem('sandbox-api-key');
+  if (url) baseUrlInput.value = url;
+  if (key) apiKeyInput.value = key;
+}
+
+function saveSettings() {
+  localStorage.setItem('sandbox-base-url', baseUrlInput.value.trim());
+  localStorage.setItem('sandbox-api-key', apiKeyInput.value.trim());
+}
+
+baseUrlInput.addEventListener('change', saveSettings);
+apiKeyInput.addEventListener('change', saveSettings);
+
+// --- API helpers ---
+
+function apiBase() {
+  return baseUrlInput.value.trim().replace(/\/+$/, '');
+}
+
+function headers() {
+  return {
+    'X-Api-Key': apiKeyInput.value.trim(),
+    'Content-Type': 'application/json',
+  };
+}
+
+async function apiRequest(method, path, body) {
+  const opts = { method, headers: headers() };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+  const res = await fetch(`${apiBase()}${path}`, opts);
+  if (res.status === 204) return null;
+  if (!res.ok) {
+    const text = await res.text();
+    let msg = `${res.status} ${res.statusText}`;
+    try {
+      const err = JSON.parse(text);
+      if (err.error) msg = `${err.code || res.status}: ${err.error}`;
+    } catch { msg += `: ${text}`; }
+    throw new Error(msg);
+  }
+  const contentType = res.headers.get('content-type');
+  if (contentType && contentType.includes('application/json')) {
+    return res.json();
+  }
+  return res.text();
+}
+
+// --- Output ---
+
+function appendOutput(text, cls) {
+  const wasAtBottom = output.scrollTop + output.clientHeight >= output.scrollHeight - 20;
+  const span = document.createElement('span');
+  span.className = cls;
+  span.textContent = text + '\n';
+  const empty = output.querySelector('.empty-state');
+  if (empty) empty.remove();
+  output.appendChild(span);
+  if (wasAtBottom) output.scrollTop = output.scrollHeight;
+}
+
+// --- Sandbox list ---
+
+async function refreshSandboxes() {
+  if (!apiKeyInput.value.trim()) {
+    setStatus('Enter an API key first');
+    return;
+  }
+  try {
+    setStatus('Loading sandboxes...');
+    const sandboxes = await apiRequest('GET', '/sandboxes');
+    renderSandboxes(Array.isArray(sandboxes) ? sandboxes : []);
+    setStatus(`${sandboxes.length} sandbox(es)`);
+  } catch (e) {
+    setStatus(`Error: ${e.message}`);
+  }
+}
+
+function renderSandboxes(sandboxes) {
+  sandboxList.innerHTML = '';
+  sandboxes.forEach((sb) => {
+    const li = document.createElement('li');
+    li.dataset.id = sb.id;
+    if (sb.id === selectedSandboxId) li.classList.add('selected');
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'sandbox-name';
+    nameSpan.textContent = sb.id.slice(0, 12);
+    nameSpan.title = sb.id;
+
+    const stateSpan = document.createElement('span');
+    const state = (sb.status || '').toLowerCase();
+    stateSpan.className = 'sandbox-state';
+    if (state === 'running' || state === 'ready') {
+      stateSpan.classList.add('state-running');
+    } else if (state === 'stopped' || state === 'exited') {
+      stateSpan.classList.add('state-stopped');
+    } else {
+      stateSpan.classList.add('state-other');
+    }
+    stateSpan.textContent = sb.status || 'unknown';
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'sandbox-delete';
+    deleteBtn.textContent = 'x';
+    deleteBtn.title = 'Delete sandbox';
+    deleteBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      deleteSandbox(sb.id);
+    });
+
+    li.appendChild(nameSpan);
+    li.appendChild(stateSpan);
+    li.appendChild(deleteBtn);
+
+    li.addEventListener('click', () => selectSandbox(sb));
+    sandboxList.appendChild(li);
+  });
+}
+
+function selectSandbox(sb) {
+  selectedSandboxId = sb.id;
+  document.querySelectorAll('#sandbox-list li').forEach((li) => {
+    li.classList.toggle('selected', li.dataset.id === sb.id);
+  });
+  cmdInput.disabled = false;
+  runBtn.disabled = false;
+  cmdInput.focus();
+  setStatus(`Selected: ${sb.id.slice(0, 12)}`);
+}
+
+// --- Create sandbox ---
+
+const imageIdInput = $('#image-id-input');
+const setupCmdsInput = $('#setup-cmds-input');
+
+async function execInSandbox(sandboxId, command, timeoutMs = 300000, signal) {
+  const res = await fetch(`${apiBase()}/sandboxes/${sandboxId}/exec`, {
+    method: 'POST',
+    headers: headers(),
+    body: JSON.stringify({ command, timeout_ms: timeoutMs }),
+    signal,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    let msg = `${res.status}`;
+    try {
+      const err = JSON.parse(text);
+      if (err.error) msg = err.error;
+    } catch { msg = text; }
+    throw new Error(msg);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let exitCode = null;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop();
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const event = JSON.parse(line);
+        handleExecEvent(event);
+        if (event.type === 'exit') exitCode = event.exit_code;
+      } catch {
+        appendOutput(line, 'stdout');
+      }
+    }
+  }
+
+  if (buffer.trim()) {
+    try {
+      const event = JSON.parse(buffer);
+      handleExecEvent(event);
+      if (event.type === 'exit') exitCode = event.exit_code;
+    } catch {
+      appendOutput(buffer, 'stdout');
+    }
+  }
+
+  return exitCode;
+}
+
+async function createSandbox() {
+  if (!apiKeyInput.value.trim()) {
+    setStatus('Enter an API key first');
+    return;
+  }
+  const imageId = imageIdInput.value.trim();
+  const setupRaw = setupCmdsInput.value.trim();
+  const dockerfileSteps = setupRaw
+    ? setupRaw.split('\n').map((l) => l.trim()).filter(Boolean)
+    : [];
+
+  const body = {};
+  if (imageId) body.image_id = imageId;
+  if (dockerfileSteps.length > 0) body.dockerfile_steps = dockerfileSteps;
+
+  createBtn.disabled = true;
+  try {
+    if (dockerfileSteps.length > 0) {
+      setStatus('Creating sandbox (building image)...');
+      appendOutput(`Creating sandbox with Dockerfile steps:\n  ${dockerfileSteps.join('\n  ')}`, 'info');
+    } else if (imageId) {
+      setStatus('Creating sandbox from image...');
+      appendOutput(`Creating sandbox from image: ${imageId}`, 'info');
+    } else {
+      setStatus('Creating sandbox...');
+      appendOutput('Creating sandbox...', 'info');
+    }
+    const t0 = performance.now();
+    const sb = await apiRequest('POST', '/sandboxes', body);
+    const elapsed = ((performance.now() - t0) / 1000).toFixed(2);
+    let msg = `Sandbox created: ${sb.id} (${sb.status}) in ${elapsed}s`;
+    if (sb.image_id) msg += ` [image: ${sb.image_id}]`;
+    appendOutput(msg, 'info');
+    setStatus(`Created: ${sb.id.slice(0, 12)} (${elapsed}s)`);
+    await refreshSandboxes();
+    selectSandbox(sb);
+  } catch (e) {
+    appendOutput(`Error creating sandbox: ${e.message}`, 'error');
+    setStatus(`Create failed: ${e.message}`);
+  } finally {
+    createBtn.disabled = false;
+  }
+}
+
+// --- Delete sandbox ---
+
+async function deleteSandbox(id) {
+  try {
+    setStatus(`Deleting ${id.slice(0, 12)}...`);
+    const t0 = performance.now();
+    await apiRequest('DELETE', `/sandboxes/${id}`);
+    const elapsed = ((performance.now() - t0) / 1000).toFixed(2);
+    if (selectedSandboxId === id) {
+      selectedSandboxId = null;
+      cmdInput.disabled = true;
+      runBtn.disabled = true;
+    }
+    appendOutput(`Sandbox deleted: ${id} (${elapsed}s)`, 'info');
+    await refreshSandboxes();
+  } catch (e) {
+    appendOutput(`Error deleting sandbox: ${e.message}`, 'error');
+    setStatus(`Delete failed: ${e.message}`);
+  }
+}
+
+// --- Images ---
+
+const imageListEl = $('#image-list');
+const imagesRefreshBtn = $('#images-refresh-btn');
+
+async function refreshImages() {
+  if (!apiKeyInput.value.trim()) return;
+  try {
+    const images = await apiRequest('GET', '/images');
+    renderImages(Array.isArray(images) ? images : []);
+  } catch (e) {
+    imageListEl.innerHTML = `<li style="color:#f44747;">Error: ${e.message}</li>`;
+  }
+}
+
+function renderImages(images) {
+  imageListEl.innerHTML = '';
+  if (images.length === 0) {
+    const li = document.createElement('li');
+    li.style.color = '#666';
+    li.textContent = 'No images';
+    imageListEl.appendChild(li);
+    return;
+  }
+  for (const img of images) {
+    const li = document.createElement('li');
+
+    const idSpan = document.createElement('span');
+    idSpan.className = 'image-id';
+    idSpan.textContent = img.id;
+    idSpan.title = `Click to copy ID\nStatus: ${img.status}\nSource: ${img.source_sandbox_id || 'n/a'}`;
+    idSpan.addEventListener('click', () => {
+      navigator.clipboard.writeText(img.id);
+      imageIdInput.value = img.id;
+      setStatus(`Copied ${img.id}`);
+    });
+
+    const sizeSpan = document.createElement('span');
+    sizeSpan.className = 'image-size';
+    sizeSpan.textContent = img.size_bytes != null ? formatSize(img.size_bytes) : '';
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'image-delete';
+    deleteBtn.textContent = 'x';
+    deleteBtn.title = 'Delete image';
+    deleteBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      deleteImage(img.id);
+    });
+
+    li.appendChild(idSpan);
+    li.appendChild(sizeSpan);
+    li.appendChild(deleteBtn);
+    imageListEl.appendChild(li);
+  }
+}
+
+async function deleteImage(id) {
+  try {
+    setStatus(`Deleting image ${id}...`);
+    await apiRequest('DELETE', `/images/${id}`);
+    appendOutput(`Image deleted: ${id}`, 'info');
+    setStatus(`Deleted: ${id}`);
+    await refreshImages();
+  } catch (e) {
+    appendOutput(`Error deleting image: ${e.message}`, 'error');
+    setStatus(`Delete failed: ${e.message}`);
+  }
+}
+
+imagesRefreshBtn.addEventListener('click', refreshImages);
+
+// --- Execute command (streaming NDJSON) ---
+
+async function executeCommand() {
+  const cmd = cmdInput.value.trim();
+  if (!cmd || !selectedSandboxId) return;
+
+  commandHistory.push(cmd);
+  historyIndex = commandHistory.length;
+  cmdInput.value = '';
+  cmdInput.disabled = true;
+  runBtn.disabled = true;
+
+  appendOutput(`$ ${cmd}`, 'cmd');
+
+  currentAbortController = new AbortController();
+
+  try {
+    await execInSandbox(selectedSandboxId, cmd, 300000, currentAbortController.signal);
+  } catch (e) {
+    if (e.name !== 'AbortError') {
+      appendOutput(`Error: ${e.message}`, 'error');
+    }
+  } finally {
+    currentAbortController = null;
+    cmdInput.disabled = false;
+    runBtn.disabled = false;
+    cmdInput.focus();
+  }
+}
+
+function handleExecEvent(event) {
+  switch (event.type) {
+    case 'stdout':
+      if (event.data) appendOutput(event.data.replace(/\n$/, ''), 'stdout');
+      break;
+    case 'stderr':
+      if (event.data) appendOutput(event.data.replace(/\n$/, ''), 'stderr');
+      break;
+    case 'exit':
+      if (event.exit_code === 0) {
+        appendOutput(`[exit ${event.exit_code} in ${event.execution_time_ms}ms]`, 'exit-ok');
+      } else {
+        appendOutput(`[exit ${event.exit_code}${event.timed_out ? ' (timed out)' : ''}${event.killed ? ' (killed)' : ''} in ${event.execution_time_ms}ms]`, 'exit-fail');
+      }
+      break;
+    case 'error':
+      appendOutput(`Error: ${event.error}`, 'error');
+      break;
+  }
+}
+
+// --- Command history ---
+
+cmdInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    executeCommand();
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    if (historyIndex > 0) {
+      historyIndex--;
+      cmdInput.value = commandHistory[historyIndex];
+    }
+  } else if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    if (historyIndex < commandHistory.length - 1) {
+      historyIndex++;
+      cmdInput.value = commandHistory[historyIndex];
+    } else {
+      historyIndex = commandHistory.length;
+      cmdInput.value = '';
+    }
+  } else if (e.key === 'c' && e.ctrlKey) {
+    // Ctrl+C aborts the current command
+    if (currentAbortController) {
+      currentAbortController.abort();
+      appendOutput('^C', 'error');
+    }
+  }
+});
+
+// --- File browser ---
+
+const filePathInput = $('#file-path-input');
+const fileGoBtn = $('#file-go-btn');
+const fileRefreshBtn = $('#file-refresh-btn');
+const fileListEl = $('#file-list');
+const fileViewer = $('#file-viewer');
+const fileViewerName = $('#file-viewer-name');
+const fileContentEl = $('#file-content');
+const fileEditBtn = $('#file-edit-btn');
+const fileCloseBtn = $('#file-close-btn');
+const fileEditor = $('#file-editor');
+const fileEditorTextarea = $('#file-editor-textarea');
+const fileSaveBtn = $('#file-save-btn');
+const fileCancelBtn = $('#file-cancel-btn');
+const newFilePathInput = $('#new-file-path');
+const newFileBtn = $('#new-file-btn');
+
+let currentViewingFile = null;
+
+function normalizePath(p) {
+  return p.replace(/\/+/g, '/').replace(/\/$/, '') || '/';
+}
+
+async function browseFiles(dir) {
+  if (!selectedSandboxId) return;
+  dir = normalizePath(dir || '/');
+  filePathInput.value = dir;
+
+  try {
+    const files = await apiRequest('GET', `/sandboxes/${selectedSandboxId}/files?path=${encodeURIComponent(dir)}`);
+    renderFileList(dir, files);
+  } catch (e) {
+    fileListEl.innerHTML = `<li style="color:#f44747; padding:8px 12px; font-size:12px;">Error: ${e.message}</li>`;
+  }
+}
+
+function renderFileList(dir, files) {
+  fileListEl.innerHTML = '';
+
+  // parent directory entry
+  if (dir !== '/') {
+    const parentLi = document.createElement('li');
+    parentLi.innerHTML = '<span class="file-icon">..</span><span class="file-entry-name">..</span>';
+    parentLi.addEventListener('click', () => {
+      const parent = dir.split('/').slice(0, -1).join('/') || '/';
+      browseFiles(parent);
+    });
+    fileListEl.appendChild(parentLi);
+  }
+
+  if (!files || files.length === 0) {
+    const emptyLi = document.createElement('li');
+    emptyLi.style.color = '#666';
+    emptyLi.textContent = '(empty)';
+    fileListEl.appendChild(emptyLi);
+    return;
+  }
+
+  // sort: directories first, then alphabetically
+  files.sort((a, b) => {
+    if (a.is_dir && !b.is_dir) return -1;
+    if (!a.is_dir && b.is_dir) return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  for (const f of files) {
+    const li = document.createElement('li');
+
+    const icon = document.createElement('span');
+    icon.className = 'file-icon';
+    icon.textContent = f.is_dir ? '\u{1F4C1}' : '\u{1F4C4}';
+
+    const name = document.createElement('span');
+    name.className = 'file-entry-name';
+    name.textContent = f.name;
+
+    li.appendChild(icon);
+    li.appendChild(name);
+
+    if (!f.is_dir) {
+      const size = document.createElement('span');
+      size.className = 'file-entry-size';
+      size.textContent = formatSize(f.size);
+      li.appendChild(size);
+    }
+
+    const fullPath = normalizePath(dir + '/' + f.name);
+
+    if (f.is_dir) {
+      li.addEventListener('click', () => browseFiles(fullPath));
+    } else {
+      li.addEventListener('click', () => viewFile(fullPath));
+    }
+
+    fileListEl.appendChild(li);
+  }
+}
+
+function formatSize(bytes) {
+  if (bytes == null) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+async function viewFile(filePath) {
+  if (!selectedSandboxId) return;
+  currentViewingFile = filePath;
+  fileViewerName.textContent = filePath;
+  fileViewerName.title = filePath;
+  fileContentEl.textContent = 'Loading...';
+  fileEditor.classList.remove('active');
+  fileViewer.classList.add('active');
+
+  try {
+    const res = await fetch(
+      `${apiBase()}/sandboxes/${selectedSandboxId}/files/content?path=${encodeURIComponent(filePath)}`,
+      { headers: { 'X-Api-Key': apiKeyInput.value.trim() } }
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text);
+    }
+    const text = await res.text();
+    fileContentEl.textContent = text;
+  } catch (e) {
+    fileContentEl.textContent = `Error loading file: ${e.message}`;
+  }
+}
+
+function startEditing() {
+  if (!currentViewingFile) return;
+  fileEditorTextarea.value = fileContentEl.textContent;
+  fileEditor.classList.add('active');
+  fileContentEl.style.display = 'none';
+  fileEditorTextarea.focus();
+}
+
+function cancelEditing() {
+  fileEditor.classList.remove('active');
+  fileContentEl.style.display = '';
+}
+
+async function saveFile() {
+  if (!selectedSandboxId || !currentViewingFile) return;
+
+  const content = fileEditorTextarea.value;
+  fileSaveBtn.disabled = true;
+
+  try {
+    const res = await fetch(
+      `${apiBase()}/sandboxes/${selectedSandboxId}/files?path=${encodeURIComponent(currentViewingFile)}`,
+      {
+        method: 'PUT',
+        headers: {
+          'X-Api-Key': apiKeyInput.value.trim(),
+          'Content-Type': 'application/octet-stream',
+        },
+        body: content,
+      }
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text);
+    }
+    fileContentEl.textContent = content;
+    cancelEditing();
+    setStatus(`Saved: ${currentViewingFile}`);
+  } catch (e) {
+    setStatus(`Save failed: ${e.message}`);
+  } finally {
+    fileSaveBtn.disabled = false;
+  }
+}
+
+async function createNewFile() {
+  if (!selectedSandboxId) return;
+  const filePath = newFilePathInput.value.trim();
+  if (!filePath) return;
+
+  const fullPath = filePath.startsWith('/') ? filePath : normalizePath(filePathInput.value + '/' + filePath);
+
+  try {
+    const res = await fetch(
+      `${apiBase()}/sandboxes/${selectedSandboxId}/files?path=${encodeURIComponent(fullPath)}`,
+      {
+        method: 'PUT',
+        headers: {
+          'X-Api-Key': apiKeyInput.value.trim(),
+          'Content-Type': 'application/octet-stream',
+        },
+        body: '',
+      }
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text);
+    }
+    newFilePathInput.value = '';
+    setStatus(`Created: ${fullPath}`);
+    browseFiles(filePathInput.value);
+    viewFile(fullPath);
+  } catch (e) {
+    setStatus(`Create failed: ${e.message}`);
+  }
+}
+
+function closeFileViewer() {
+  fileViewer.classList.remove('active');
+  fileEditor.classList.remove('active');
+  fileContentEl.style.display = '';
+  currentViewingFile = null;
+}
+
+fileGoBtn.addEventListener('click', () => browseFiles(filePathInput.value));
+fileRefreshBtn.addEventListener('click', () => browseFiles(filePathInput.value));
+filePathInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') browseFiles(filePathInput.value);
+});
+fileEditBtn.addEventListener('click', startEditing);
+fileCloseBtn.addEventListener('click', closeFileViewer);
+fileSaveBtn.addEventListener('click', saveFile);
+fileCancelBtn.addEventListener('click', cancelEditing);
+newFileBtn.addEventListener('click', createNewFile);
+newFilePathInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') createNewFile();
+});
+
+// Auto-browse files when selecting a sandbox
+const _origSelectSandbox = selectSandbox;
+selectSandbox = function(sb) {
+  _origSelectSandbox(sb);
+  browseFiles('/');
+};
+
+// --- Status ---
+
+function setStatus(msg) {
+  statusEl.textContent = msg;
+}
+
+// --- Event listeners ---
+
+createBtn.addEventListener('click', createSandbox);
+refreshBtn.addEventListener('click', () => { refreshSandboxes(); refreshImages(); });
+runBtn.addEventListener('click', executeCommand);
+
+// --- File panel resize ---
+
+(function () {
+  const resizer = document.getElementById('file-panel-resizer');
+  const panel = document.getElementById('file-panel');
+  const MIN_WIDTH = 200;
+  const MAX_WIDTH = 800;
+
+  let startX, startWidth;
+
+  resizer.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    startX = e.clientX;
+    startWidth = panel.offsetWidth;
+    resizer.classList.add('dragging');
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  });
+
+  function onMouseMove(e) {
+    const delta = startX - e.clientX;
+    const newWidth = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, startWidth + delta));
+    panel.style.width = newWidth + 'px';
+  }
+
+  function onMouseUp() {
+    resizer.classList.remove('dragging');
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+  }
+})();
+
+// --- Init ---
+
+loadSettings();

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -1,0 +1,625 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sandbox Playground</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html, body {
+      height: 100%;
+      background: #1e1e1e;
+      color: #d4d4d4;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }
+
+    body {
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    #header {
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 8px 16px;
+      background: #252526;
+      border-bottom: 1px solid #404040;
+      min-height: 42px;
+    }
+
+    #header h1 {
+      font-size: 13px;
+      font-weight: 600;
+      color: #cccccc;
+      white-space: nowrap;
+    }
+
+    #header .spacer { flex: 1; }
+
+    #status {
+      font-size: 12px;
+      color: #999;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    #main {
+      flex: 1;
+      display: flex;
+      overflow: hidden;
+    }
+
+    #sidebar {
+      width: 280px;
+      flex-shrink: 0;
+      background: #252526;
+      border-right: 1px solid #404040;
+      display: flex;
+      flex-direction: column;
+      overflow-y: auto;
+    }
+
+    .panel {
+      padding: 12px;
+      border-bottom: 1px solid #404040;
+    }
+
+    .panel-title {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: #999;
+      margin-bottom: 8px;
+    }
+
+    label {
+      display: block;
+      font-size: 12px;
+      color: #aaa;
+      margin-bottom: 4px;
+    }
+
+    input[type="text"], input[type="password"] {
+      width: 100%;
+      padding: 5px 8px;
+      font-size: 12px;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      background: #3c3c3c;
+      border: 1px solid #555;
+      border-radius: 3px;
+      color: #d4d4d4;
+      outline: none;
+      margin-bottom: 8px;
+    }
+
+    input:focus, textarea:focus { border-color: #007acc; }
+
+    textarea {
+      width: 100%;
+      padding: 5px 8px;
+      font-size: 12px;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      background: #3c3c3c;
+      border: 1px solid #555;
+      border-radius: 3px;
+      color: #d4d4d4;
+      outline: none;
+      margin-bottom: 8px;
+      resize: vertical;
+    }
+
+    button {
+      padding: 5px 12px;
+      font-size: 12px;
+      border: none;
+      border-radius: 3px;
+      cursor: pointer;
+      color: #fff;
+      background: #0e639c;
+      transition: background 0.15s;
+    }
+
+    button:hover { background: #1177bb; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    button.danger { background: #c72e2e; }
+    button.danger:hover { background: #e04040; }
+
+    .btn-row {
+      display: flex;
+      gap: 6px;
+      margin-top: 4px;
+    }
+
+    .btn-row button { flex: 1; }
+
+    #sandbox-list {
+      list-style: none;
+      margin-top: 8px;
+    }
+
+    #sandbox-list li {
+      padding: 6px 8px;
+      font-size: 12px;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      border-radius: 3px;
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 6px;
+    }
+
+    #sandbox-list li:hover { background: #2a2d2e; }
+    #sandbox-list li.selected { background: #094771; }
+
+    .sandbox-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .sandbox-state {
+      font-size: 10px;
+      padding: 1px 5px;
+      border-radius: 3px;
+      flex-shrink: 0;
+    }
+
+    .state-running { background: #2ea04370; color: #7ee787; }
+    .state-stopped { background: #c7302e50; color: #f08080; }
+    .state-other { background: #555; color: #ccc; }
+
+    .sandbox-delete {
+      font-size: 10px;
+      padding: 2px 6px;
+      background: transparent;
+      color: #888;
+      flex-shrink: 0;
+    }
+
+    .sandbox-delete:hover { color: #f44747; background: #3c3c3c; }
+
+    #image-list {
+      list-style: none;
+      margin-top: 8px;
+    }
+
+    #image-list li {
+      padding: 4px 8px;
+      font-size: 11px;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      border-radius: 3px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    #image-list li:hover { background: #2a2d2e; }
+
+    .image-id {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      cursor: pointer;
+    }
+
+    .image-id:hover { color: #569cd6; }
+
+    .image-size {
+      font-size: 10px;
+      color: #666;
+      flex-shrink: 0;
+      margin-left: auto;
+    }
+
+    .image-delete {
+      font-size: 10px;
+      padding: 2px 6px;
+      background: transparent;
+      color: #888;
+      flex-shrink: 0;
+    }
+
+    .image-delete:hover { color: #f44747; background: #3c3c3c; }
+
+    #center {
+      flex: 1;
+      display: flex;
+      overflow: hidden;
+    }
+
+    #terminal-area {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      min-width: 0;
+    }
+
+    #output {
+      flex: 1;
+      overflow-y: auto;
+      padding: 12px;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      font-size: 13px;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+
+    #output .cmd { color: #569cd6; }
+    #output .stdout { color: #d4d4d4; }
+    #output .stderr { color: #f48771; }
+    #output .info { color: #6a9955; }
+    #output .error { color: #f44747; }
+    #output .exit-ok { color: #6a9955; font-size: 11px; }
+    #output .exit-fail { color: #f44747; font-size: 11px; }
+
+    #input-bar {
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      gap: 0;
+      padding: 8px 12px;
+      background: #1e1e1e;
+      border-top: 1px solid #404040;
+    }
+
+    #prompt-label {
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      font-size: 13px;
+      color: #569cd6;
+      margin-right: 6px;
+      flex-shrink: 0;
+    }
+
+    #cmd-input {
+      flex: 1;
+      padding: 5px 8px;
+      font-size: 13px;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      background: #3c3c3c;
+      border: 1px solid #555;
+      border-radius: 3px;
+      color: #d4d4d4;
+      outline: none;
+    }
+
+    #cmd-input:focus { border-color: #007acc; }
+
+    #run-btn {
+      margin-left: 6px;
+      flex-shrink: 0;
+    }
+
+    .empty-state {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: #666;
+      font-size: 13px;
+      text-align: center;
+      padding: 24px;
+    }
+
+    /* --- File panel resizer --- */
+
+    #file-panel-resizer {
+      width: 4px;
+      flex-shrink: 0;
+      cursor: col-resize;
+      background: transparent;
+      transition: background 0.15s;
+      position: relative;
+    }
+
+    #file-panel-resizer::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: -2px;
+      right: -2px;
+    }
+
+    #file-panel-resizer:hover,
+    #file-panel-resizer.dragging {
+      background: #007acc;
+    }
+
+    /* --- File browser --- */
+
+    #file-panel {
+      width: 380px;
+      flex-shrink: 0;
+      background: #252526;
+      border-left: 1px solid #404040;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    #file-panel .panel-title {
+      padding: 10px 12px 6px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    #file-browser-path {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 12px 8px;
+      border-bottom: 1px solid #404040;
+    }
+
+    #file-browser-path input {
+      flex: 1;
+      margin-bottom: 0;
+    }
+
+    #file-browser-path button {
+      padding: 4px 8px;
+      font-size: 11px;
+      flex-shrink: 0;
+    }
+
+    #file-list-container {
+      flex: 1;
+      overflow-y: auto;
+      min-height: 0;
+    }
+
+    #file-list {
+      list-style: none;
+    }
+
+    #file-list li {
+      padding: 4px 12px;
+      font-size: 12px;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      white-space: nowrap;
+    }
+
+    #file-list li:hover { background: #2a2d2e; }
+
+    .file-icon {
+      flex-shrink: 0;
+      font-size: 11px;
+      width: 16px;
+      text-align: center;
+      color: #999;
+    }
+
+    .file-entry-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .file-entry-size {
+      margin-left: auto;
+      font-size: 10px;
+      color: #666;
+      flex-shrink: 0;
+    }
+
+    #file-viewer {
+      display: none;
+      flex-direction: column;
+      overflow: hidden;
+      border-top: 1px solid #404040;
+    }
+
+    #file-viewer.active {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+    }
+
+    #file-viewer-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 12px;
+      background: #1e1e1e;
+      border-bottom: 1px solid #404040;
+      gap: 6px;
+    }
+
+    #file-viewer-name {
+      font-size: 12px;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: #cccccc;
+    }
+
+    #file-viewer-actions {
+      display: flex;
+      gap: 4px;
+      flex-shrink: 0;
+    }
+
+    #file-viewer-actions button {
+      padding: 3px 8px;
+      font-size: 11px;
+    }
+
+    #file-content {
+      flex: 1;
+      overflow: auto;
+      padding: 8px 12px;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      font-size: 12px;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-all;
+      background: #1e1e1e;
+      color: #d4d4d4;
+      min-height: 0;
+    }
+
+    #file-editor {
+      flex: 1;
+      display: none;
+      flex-direction: column;
+      min-height: 0;
+    }
+
+    #file-editor.active { display: flex; }
+
+    #file-editor textarea {
+      flex: 1;
+      resize: none;
+      padding: 8px 12px;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      font-size: 12px;
+      line-height: 1.5;
+      background: #1e1e1e;
+      color: #d4d4d4;
+      border: none;
+      outline: none;
+      min-height: 0;
+    }
+
+    #file-editor-bar {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      background: #252526;
+      border-top: 1px solid #404040;
+    }
+
+    #file-editor-bar .spacer { flex: 1; }
+
+    #file-editor-bar button { font-size: 11px; padding: 3px 10px; }
+
+    #new-file-bar {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 12px 8px;
+      border-bottom: 1px solid #404040;
+    }
+
+    #new-file-bar input {
+      flex: 1;
+      margin-bottom: 0;
+      font-size: 11px;
+      padding: 3px 6px;
+    }
+
+    #new-file-bar button {
+      padding: 3px 8px;
+      font-size: 11px;
+      flex-shrink: 0;
+    }
+  </style>
+</head>
+<body>
+  <div id="header">
+    <h1>Sandbox Playground</h1>
+    <div class="spacer"></div>
+    <span id="status">Not connected</span>
+  </div>
+  <div id="main">
+    <div id="sidebar">
+      <div class="panel">
+        <div class="panel-title">Connection</div>
+        <label for="base-url">Base URL</label>
+        <input type="text" id="base-url" value="http://localhost:8080" />
+        <label for="api-key">API Key</label>
+        <input type="password" id="api-key" placeholder="Enter your API key" />
+      </div>
+      <div class="panel">
+        <div class="panel-title">Create Sandbox</div>
+        <label for="image-id-input">Image ID (optional)</label>
+        <input type="text" id="image-id-input" placeholder="img-..." />
+        <label for="setup-cmds-input">Dockerfile Steps (one per line)</label>
+        <textarea id="setup-cmds-input" rows="3" placeholder="RUN apt-get update &amp;&amp; apt-get install -y curl&#10;RUN npm install -g typescript"></textarea>
+        <div class="btn-row">
+          <button id="create-btn">Create</button>
+        </div>
+      </div>
+      <div class="panel" style="flex:1; min-height:120px;">
+        <div class="panel-title">
+          Sandboxes
+          <button id="refresh-btn" style="float:right; padding:2px 8px; font-size:10px;">Refresh</button>
+        </div>
+        <ul id="sandbox-list"></ul>
+      </div>
+      <div class="panel" style="flex:1; border-bottom:none; min-height:100px;">
+        <div class="panel-title">
+          Images
+          <button id="images-refresh-btn" style="float:right; padding:2px 8px; font-size:10px;">Refresh</button>
+        </div>
+        <ul id="image-list"></ul>
+      </div>
+    </div>
+    <div id="center">
+      <div id="terminal-area">
+        <div id="output">
+          <div class="empty-state">Select or create a sandbox to start executing commands.</div>
+        </div>
+        <div id="input-bar">
+          <span id="prompt-label">$</span>
+          <input type="text" id="cmd-input" placeholder="Enter command..." disabled />
+          <button id="run-btn" disabled>Run</button>
+        </div>
+      </div>
+      <div id="file-panel-resizer"></div>
+      <div id="file-panel">
+        <div class="panel-title">
+          <span>Files</span>
+          <button id="file-refresh-btn" style="padding:2px 8px; font-size:10px;">Refresh</button>
+        </div>
+        <div id="file-browser-path">
+          <input type="text" id="file-path-input" value="/" placeholder="/" />
+          <button id="file-go-btn">Go</button>
+        </div>
+        <div id="new-file-bar">
+          <input type="text" id="new-file-path" placeholder="path/to/new-file.txt" />
+          <button id="new-file-btn">New File</button>
+        </div>
+        <div id="file-list-container">
+          <ul id="file-list"></ul>
+        </div>
+        <div id="file-viewer">
+          <div id="file-viewer-header">
+            <span id="file-viewer-name"></span>
+            <div id="file-viewer-actions">
+              <button id="file-edit-btn">Edit</button>
+              <button id="file-close-btn">Close</button>
+            </div>
+          </div>
+          <div id="file-content"></div>
+          <div id="file-editor">
+            <textarea id="file-editor-textarea"></textarea>
+            <div id="file-editor-bar">
+              <div class="spacer"></div>
+              <button id="file-save-btn">Save</button>
+              <button id="file-cancel-btn">Cancel</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
<img width="1175" height="842" alt="image" src="https://github.com/user-attachments/assets/db447196-8f15-471e-add4-ecb31da09e32" />


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a browser-based Playground UI to create/manage sandboxes, run commands with streaming output, and browse/edit files. Includes a `make playground` target to start it locally at http://localhost:3000.

- **New Features**
  - Create sandboxes from an image or Dockerfile steps; manage sandboxes and images.
  - Run commands with live stdout/stderr, command history, and Ctrl+C to abort.
  - Browse files in a sandbox; view/edit and create files.
  - Persist base URL and API key in `localStorage`.

<sup>Written for commit 9c65a1265946f360a083d7278d55251ed13acaee. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/3?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

