### PR TITLE
Replace run-locally.sh with Docker Compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 MODULE  := github.com/n8n-io/sandbox-service
 BINDIR  := bin
 
-.PHONY: all daemon runner api test clean docker docker-local docker-arm64 docker-amd64 docker-api-arm64 docker-api-amd64 docker-runner-arm64 docker-runner-amd64 docker-sandbox-arm64 docker-sandbox-amd64 fmt fmt-check vet playground
+.PHONY: all daemon runner api test clean docker docker-local docker-arm64 docker-amd64 docker-api-arm64 docker-api-amd64 docker-runner-arm64 docker-runner-amd64 docker-sandbox-arm64 docker-sandbox-amd64 fmt fmt-check vet playground up down
 
 all: daemon runner api
 
@@ -88,3 +88,11 @@ docker-sandbox-arm64:
 ## docker-sandbox-amd64: Build the sandbox image for linux/amd64.
 docker-sandbox-amd64:
 	docker buildx build -f Dockerfile.sandbox --platform linux/amd64 -t n8n-sandbox:latest-amd64 --load .
+
+## up: Build images and start all services locally with Docker Compose.
+up:
+	./scripts/run-locally.sh
+
+## down: Stop and remove all local Compose services.
+down:
+	docker compose down

--- a/compose.linux.yaml
+++ b/compose.linux.yaml
@@ -1,0 +1,5 @@
+services:
+  runner-1:
+    runtime: sysbox-runc
+  runner-2:
+    runtime: sysbox-runc

--- a/compose.macos.yaml
+++ b/compose.macos.yaml
@@ -1,0 +1,5 @@
+services:
+  runner-1:
+    privileged: true
+  runner-2:
+    privileged: true

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,119 @@
+services:
+  registry:
+    image: registry:2
+    container_name: n8n-sandbox-registry
+    ports:
+      - "5050:5000"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:5000/v2/"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    networks:
+      - sandbox
+
+  sandbox-image:
+    profiles: ["build"]
+    build:
+      context: .
+      dockerfile: Dockerfile.sandbox
+    image: n8n-sandbox:latest-${ARCH}
+
+  sandbox-push:
+    image: docker:29.3.1-cli
+    depends_on:
+      registry:
+        condition: service_healthy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    entrypoint: sh
+    command:
+      - -c
+      - >-
+        docker tag n8n-sandbox:latest-${ARCH} localhost:5050/n8n-sandbox:latest-${ARCH} &&
+        docker push localhost:5050/n8n-sandbox:latest-${ARCH}
+    networks:
+      - sandbox
+
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    image: n8n-sandbox-api:latest-${ARCH}
+    container_name: n8n-sandbox-api-local
+    ports:
+      - "8080:8080"
+    environment:
+      SANDBOX_API_KEYS: test
+      SANDBOX_API_RUNNER_REGISTRATION_TOKEN: ${REG_TOKEN:-local-reg-token}
+      SANDBOX_API_RUNNER_API_KEY: ${RUNNER_API_KEY:-runner-local-key}
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8080/healthz"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+    networks:
+      - sandbox
+
+  runner-1:
+    build:
+      context: .
+      dockerfile: Dockerfile.runner
+    image: n8n-sandbox-runner:latest-${ARCH}
+    container_name: n8n-sandbox-runner-local-1
+    depends_on:
+      api:
+        condition: service_healthy
+      sandbox-push:
+        condition: service_completed_successfully
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      SANDBOX_RUNNER_API_KEYS: ${RUNNER_API_KEY:-runner-local-key}
+      SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE: registry:5000/n8n-sandbox:latest-${ARCH}
+      SANDBOX_RUNNER_DOCKER_INSECURE_REGISTRIES: registry:5000
+      SANDBOX_RUNNER_INTER_SANDBOX_NETWORK_ENABLED: "false"
+      SANDBOX_RUNNER_API_GRPC_ADDR: n8n-sandbox-api-local:9090
+      SANDBOX_RUNNER_REGISTRATION_TOKEN: ${REG_TOKEN:-local-reg-token}
+      SANDBOX_RUNNER_HTTP_BASE_URL: http://n8n-sandbox-runner-local-1:8080
+      SANDBOX_RUNNER_ID: local-runner-1
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "--header=X-Api-Key: ${RUNNER_API_KEY:-runner-local-key}", "http://localhost:8080/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 20s
+    networks:
+      - sandbox
+
+  runner-2:
+    image: n8n-sandbox-runner:latest-${ARCH}
+    container_name: n8n-sandbox-runner-local-2
+    depends_on:
+      runner-1:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      SANDBOX_RUNNER_API_KEYS: ${RUNNER_API_KEY:-runner-local-key}
+      SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE: registry:5000/n8n-sandbox:latest-${ARCH}
+      SANDBOX_RUNNER_DOCKER_INSECURE_REGISTRIES: registry:5000
+      SANDBOX_RUNNER_INTER_SANDBOX_NETWORK_ENABLED: "false"
+      SANDBOX_RUNNER_API_GRPC_ADDR: n8n-sandbox-api-local:9090
+      SANDBOX_RUNNER_REGISTRATION_TOKEN: ${REG_TOKEN:-local-reg-token}
+      SANDBOX_RUNNER_HTTP_BASE_URL: http://n8n-sandbox-runner-local-2:8080
+      SANDBOX_RUNNER_ID: local-runner-2
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "--header=X-Api-Key: ${RUNNER_API_KEY:-runner-local-key}", "http://localhost:8080/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 20s
+    networks:
+      - sandbox
+
+networks:
+  sandbox:
+    driver: bridge

--- a/scripts/run-locally.sh
+++ b/scripts/run-locally.sh
@@ -1,128 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
+cd "$(dirname "$0")/.."
 
-ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
-REGISTRY_NAME=${N8N_SANDBOX_REGISTRY_NAME:-n8n-sandbox-registry}
-REGISTRY_ADDR=${N8N_SANDBOX_REGISTRY_ADDR:-host.docker.internal:5050}
-API_IMAGE_LOCAL="n8n-sandbox-api:latest-${ARCH}"
-RUNNER_IMAGE_LOCAL="n8n-sandbox-runner:latest-${ARCH}"
-SANDBOX_IMAGE_LOCAL="n8n-sandbox:latest-${ARCH}"
-REGISTRY_PORT=${REGISTRY_ADDR##*:}
-SANDBOX_IMAGE_PUSH="localhost:${REGISTRY_PORT}/n8n-sandbox:latest-${ARCH}"
-SANDBOX_IMAGE_REMOTE="${REGISTRY_ADDR}/n8n-sandbox:latest-${ARCH}"
-API_CONTAINER_NAME=${N8N_SANDBOX_API_CONTAINER_NAME:-n8n-sandbox-api-local}
-RUNNER1_CONTAINER_NAME=${N8N_SANDBOX_RUNNER1_CONTAINER_NAME:-n8n-sandbox-runner-local-1}
-RUNNER2_CONTAINER_NAME=${N8N_SANDBOX_RUNNER2_CONTAINER_NAME:-n8n-sandbox-runner-local-2}
-NETWORK_NAME=${N8N_SANDBOX_LOCAL_NETWORK:-n8n-sandbox-local}
-RUNNER_INTERNAL_API_KEY=${N8N_SANDBOX_RUNNER_API_KEY:-runner-local-key}
-REG_TOKEN=${SANDBOX_API_RUNNER_REGISTRATION_TOKEN:-local-reg-token}
+export ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
 
-echo "==> Building API, runner, and sandbox images for ${ARCH} ..."
-make docker-local
+echo "==> Building images for ${ARCH} ..."
+docker compose --profile build build
 
-if ! docker ps --format '{{.Names}}' | grep -qx "${REGISTRY_NAME}"; then
-  echo "==> Starting local registry ${REGISTRY_NAME} on port 5050 ..."
-  docker rm -f "${REGISTRY_NAME}" >/dev/null 2>&1 || true
-  docker run -d --restart unless-stopped --name "${REGISTRY_NAME}" -p 5050:5000 registry:2 >/dev/null
-fi
-
-echo "==> Pushing sandbox image to local registry ..."
-docker tag "${SANDBOX_IMAGE_LOCAL}" "${SANDBOX_IMAGE_PUSH}"
-docker push "${SANDBOX_IMAGE_PUSH}"
-
-if ! docker network inspect "${NETWORK_NAME}" >/dev/null 2>&1; then
-  echo "==> Creating local network ${NETWORK_NAME} ..."
-  docker network create "${NETWORK_NAME}" >/dev/null
-fi
-
-docker rm -f "${API_CONTAINER_NAME}" >/dev/null 2>&1 || true
-docker rm -f "${RUNNER1_CONTAINER_NAME}" >/dev/null 2>&1 || true
-docker rm -f "${RUNNER2_CONTAINER_NAME}" >/dev/null 2>&1 || true
-
-RUNTIME_ARGS=()
+COMPOSE_FILES=(-f compose.yaml)
 if [[ "$(uname)" == "Darwin" ]]; then
-  echo "==> Running runner containers with --privileged (macOS, no sysbox) ..."
-  RUNTIME_ARGS+=(--privileged)
+  COMPOSE_FILES+=(-f compose.macos.yaml)
 else
-  echo "==> Running runner containers with sysbox ..."
-  RUNTIME_ARGS+=(--runtime=sysbox-runc)
+  COMPOSE_FILES+=(-f compose.linux.yaml)
 fi
 
-echo "==> Starting API container on localhost:8080 ..."
-docker run -d \
-  --name "${API_CONTAINER_NAME}" \
-  --network "${NETWORK_NAME}" \
-  -p 8080:8080 \
-  -e SANDBOX_API_KEYS=test \
-  -e SANDBOX_API_RUNNER_REGISTRATION_TOKEN="${REG_TOKEN}" \
-  -e SANDBOX_API_RUNNER_API_KEY="${RUNNER_INTERNAL_API_KEY}" \
-  "${API_IMAGE_LOCAL}" >/dev/null
-
-echo "==> Waiting for API healthz ..."
-for i in $(seq 1 60); do
-  if curl -sf http://localhost:8080/healthz >/dev/null 2>&1; then
-    break
-  fi
-  if [ "$i" -eq 60 ]; then
-    echo "API failed to start within 60s"
-    docker logs "${API_CONTAINER_NAME}"
-    exit 1
-  fi
-  sleep 1
-done
-
-start_runner() {
-  local name=$1
-  local runner_id=$2
-  echo "==> Starting runner container ${name} ..."
-  docker run -d \
-    "${RUNTIME_ARGS[@]}" \
-    --name "${name}" \
-    --network "${NETWORK_NAME}" \
-    --add-host host.docker.internal:host-gateway \
-    -e SANDBOX_RUNNER_API_KEYS="${RUNNER_INTERNAL_API_KEY}" \
-    -e SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE="${SANDBOX_IMAGE_REMOTE}" \
-    -e SANDBOX_RUNNER_DOCKER_INSECURE_REGISTRIES="${REGISTRY_ADDR}" \
-    -e SANDBOX_RUNNER_INTER_SANDBOX_NETWORK_ENABLED=false \
-    -e SANDBOX_RUNNER_API_GRPC_ADDR="${API_CONTAINER_NAME}:9090" \
-    -e SANDBOX_RUNNER_REGISTRATION_TOKEN="${REG_TOKEN}" \
-    -e SANDBOX_RUNNER_HTTP_BASE_URL="http://${name}:8080" \
-    -e SANDBOX_RUNNER_ID="${runner_id}" \
-    "${RUNNER_IMAGE_LOCAL}" >/dev/null
-}
-
-wait_runner_health() {
-  local name=$1
-  echo "==> Waiting for ${name} healthz ..."
-  # AuthMiddleware requires X-Api-Key even for /healthz (same as e2e/run.sh).
-  for i in $(seq 1 60); do
-    if docker exec "${name}" wget -q -O - --header="X-Api-Key: ${RUNNER_INTERNAL_API_KEY}" http://localhost:8080/healthz >/dev/null 2>&1; then
-      echo "==> ${name} is ready."
-      return 0
-    fi
-    if [ "$i" -eq 60 ]; then
-      echo "Runner ${name} failed to start within 60s"
-      docker logs "${name}"
-      exit 1
-    fi
-    sleep 1
-  done
-}
-
-# Start runners one at a time: each DinD instance is heavy; parallel starts often miss the 60s window.
-start_runner "${RUNNER1_CONTAINER_NAME}" "local-runner-1"
-wait_runner_health "${RUNNER1_CONTAINER_NAME}"
-
-start_runner "${RUNNER2_CONTAINER_NAME}" "local-runner-2"
-wait_runner_health "${RUNNER2_CONTAINER_NAME}"
-
-sleep 2
-
-echo
-echo "API and runners are up."
-echo "API:      http://localhost:8080"
-echo "Runner 1: ${RUNNER1_CONTAINER_NAME} (internal)"
-echo "Runner 2: ${RUNNER2_CONTAINER_NAME} (internal)"
-echo
-echo "Try:"
-echo "curl -s -X POST http://localhost:8080/sandboxes -H 'X-Api-Key: test' | jq"
+echo "==> Starting services ..."
+docker compose "${COMPOSE_FILES[@]}" up "$@"


### PR DESCRIPTION
## Summary

- Replaces the ~130-line imperative `scripts/run-locally.sh` with declarative Docker Compose files (`compose.yaml`, `compose.macos.yaml`, `compose.linux.yaml`)
- The wrapper script shrinks to ~18 lines: detect arch, build images, select platform override, `docker compose up`
- Compose handles networking, health checks, dependency ordering, and container lifecycle natively
- A one-shot `sandbox-push` service tags and pushes the sandbox image to the local registry before runners start
- Adds `make up` / `make down` convenience targets

## Test plan

- [ ] `make up` brings up all services, API responds at `localhost:8080`
- [ ] `make up` with `-- -d` works for detached mode
- [ ] `make down` cleans everything up
- [ ] `curl -s -X POST http://localhost:8080/sandboxes -H 'X-Api-Key: test' | jq` creates a sandbox