### PR TITLE
chore: encrypt runner<>api communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .claude/settings.local.json
 .local
 bin/
+.tls/

--- a/API.md
+++ b/API.md
@@ -9,9 +9,9 @@ Runtime topology:
 - If no runner is registered (or none are healthy / within capacity), operations that need a runner return **503** with a JSON error whose message explains that no runners are available.
 - Sandbox-scoped requests are proxied to the **stored** runner HTTP URL for that sandbox. If that runner is down or unreachable, the API returns **503** with JSON `error` **`runner unavailable`** (same shape as other API errors).
 
-Environment (API): `SANDBOX_API_RUNNER_REGISTRATION_TOKEN` (required), `SANDBOX_API_GRPC_LISTEN_ADDR` (default `:9090`), `SANDBOX_API_RUNNER_HEARTBEAT_GRACE` (default `45s` — max age of last gRPC heartbeat for a runner to be eligible for placement), plus existing HTTP settings.
+Environment (API): `SANDBOX_API_RUNNER_REGISTRATION_TOKEN` (required), `SANDBOX_API_GRPC_LISTEN_ADDR` (default `:9090`), `SANDBOX_API_RUNNER_HEARTBEAT_GRACE` (default `45s` — max age of last gRPC heartbeat for a runner to be eligible for placement), plus existing HTTP settings. Optional mTLS: `SANDBOX_API_GRPC_TLS_CERT_FILE`, `SANDBOX_API_GRPC_TLS_KEY_FILE`, `SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE` (all three together).
 
-Environment (runner): `SANDBOX_RUNNER_API_GRPC_ADDR`, `SANDBOX_RUNNER_REGISTRATION_TOKEN`, `SANDBOX_RUNNER_HTTP_BASE_URL` (API-reachable base for this runner), optional `SANDBOX_RUNNER_ID`, `SANDBOX_RUNNER_CAPACITY_TOTAL`.
+Environment (runner): `SANDBOX_RUNNER_API_GRPC_ADDR`, `SANDBOX_RUNNER_REGISTRATION_TOKEN`, `SANDBOX_RUNNER_HTTP_BASE_URL` (API-reachable base for this runner), optional `SANDBOX_RUNNER_ID`, `SANDBOX_RUNNER_CAPACITY_TOTAL`. Optional mTLS: `SANDBOX_RUNNER_GRPC_TLS_CA_FILE`, `SANDBOX_RUNNER_GRPC_TLS_CERT_FILE`, `SANDBOX_RUNNER_GRPC_TLS_KEY_FILE` (all three together), optional `SANDBOX_RUNNER_GRPC_TLS_SERVER_NAME`.
 
 ## Error Response Format
 

--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,10 @@ docker-sandbox-arm64:
 docker-sandbox-amd64:
 	docker buildx build -f Dockerfile.sandbox --platform linux/amd64 -t n8n-sandbox:latest-amd64 --load .
 
-## up: Build images and start all services locally with Docker Compose.
+## up: Bootstrap local .tls/ if needed, build images, start Compose (mTLS on gRPC by default).
 up:
 	./scripts/run-locally.sh
 
-## down: Stop and remove all local Compose services.
+## down: Stop and remove all local Compose services (same compose files as make up).
 down:
-	docker compose down
+	bash scripts/docker-compose-local.sh down

--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ Build all images:
 make docker-amd64
 ```
 
-Run locally (starts the API plus **two** runners on a shared Docker network, both registered over gRPC):
-
-```bash
-./scripts/run-locally.sh
-```
+Run locally with Docker Compose (API plus two runners on a shared network). `make up` runs `scripts/bootstrap-local-mtls.sh` once to populate `.tls/` (gitignored), then start Compose with mTLS for runner→API gRPC by default. Use `SANDBOX_COMPOSE_TLS=0` if you need plaintext gRPC (for example without OpenSSL). See [Runner registration gRPC (mTLS)](#runner-registration-grpc-mtls).
 
 Verify the API:
 
@@ -100,6 +96,9 @@ curl -s -X DELETE http://localhost:8080/sandboxes/<id> \
 | `SANDBOX_API_DATA_DIR` | `/tmp/sandbox-api` | SQLite store directory |
 | `SANDBOX_API_MAX_FILE_BYTES` | `10485760` | Maximum file upload size (10 MB) |
 | `SANDBOX_API_RUNNER_HEARTBEAT_GRACE` | `45s` | How long after the last gRPC heartbeat a runner remains eligible for placement (Go [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) syntax, e.g. `45s`, `2m`) |
+| `SANDBOX_API_GRPC_TLS_CERT_FILE` | *(empty)* | Server certificate (PEM) for the registration gRPC listener; set with key + client CA for mTLS |
+| `SANDBOX_API_GRPC_TLS_KEY_FILE` | *(empty)* | Server private key (PEM) |
+| `SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE` | *(empty)* | CA bundle (PEM) that signed runner client certificates |
 
 Runners register over gRPC and report health and capacity; the API picks a runner (round-robin) when creating sandboxes and stores that runner’s HTTP base URL for later proxying.
 
@@ -123,6 +122,24 @@ Runners register over gRPC and report health and capacity; the API picks a runne
 | `SANDBOX_RUNNER_ENABLE_CGROUPS` | `true` | Whether Docker resource limits are applied |
 | `SANDBOX_RUNNER_INTER_SANDBOX_NETWORK_ENABLED` | `false` | Whether sandboxes may talk to each other on `runner-bridge` |
 | `SANDBOX_RUNNER_DOCKER_INSECURE_REGISTRIES` | *(empty)* | Comma-separated insecure registries passed to dockerd |
+| `SANDBOX_RUNNER_GRPC_TLS_CA_FILE` | *(empty)* | CA (PEM) that signed the API’s gRPC server cert |
+| `SANDBOX_RUNNER_GRPC_TLS_CERT_FILE` | *(empty)* | This runner’s client certificate (PEM) for mTLS |
+| `SANDBOX_RUNNER_GRPC_TLS_KEY_FILE` | *(empty)* | Client key (PEM) |
+| `SANDBOX_RUNNER_GRPC_TLS_SERVER_NAME` | *(empty)* | TLS name to verify on the API cert (defaults to the host from `SANDBOX_RUNNER_API_GRPC_ADDR`) |
+
+## Runner registration gRPC (mTLS)
+
+**Local Docker Compose:** `make up` runs `scripts/bootstrap-local-mtls.sh`, which writes a private CA plus leaf certs into `.tls/` at the repo root. If those files already exist, bootstrap does nothing unless you set `SANDBOX_TLS_REGEN=1`. Compose uses `compose.tls.yaml` by default to mount `.tls` and set `SANDBOX_*_GRPC_TLS_*`. Set `SANDBOX_COMPOSE_TLS=0` to skip the overlay and use plaintext gRPC.
+
+**Kubernetes:** Use your own CA (often `cert-manager`). Mount PEMs from `Certificate` secrets and set the same env vars as in the tables above. See [`deploy/k8s/cert-manager/README.md`](deploy/k8s/cert-manager/README.md).
+
+**Registration vs lifecycle over gRPC:** Today runners dial the API over gRPC for registration only; sandbox work is still proxied over HTTP.
+
+**Bearer token:** Still required in metadata (`Authorization: Bearer …`) in addition to mTLS for registration.
+
+**Why this matters for trust:** mTLS ties the registration gRPC stream to a client certificate issued by your CA. A random host on the network cannot complete TLS to the API’s registry listener, so it cannot open a stream and inject a fake `runner_id` / `http_base_url` into placement. Legitimate runners still prove possession of the registration `Bearer` token in metadata. Together, only workloads you issued credentials to can show up in the runner registry; the API therefore only forwards new sandbox and proxy traffic to runners that actually authenticated on that channel (HTTP calls to a runner still use your normal `X-Api-Key` / stored routing as today).
+
+**Rotation:** The API and runner reload leaf cert/key PEMs from disk when the files change (next TLS handshake), so in Kubernetes `cert-manager` (or any process that writes renewed files into the mounted paths) can rotate leaves without restarting pods. Local bootstrap issues long‑lived dev certs; they do not auto‑renew on a timer. When they eventually expire—or whenever you want fresh material—delete `.tls/` or set `SANDBOX_TLS_REGEN=1` and run `scripts/bootstrap-local-mtls.sh` again (then restart containers or wait for the next TLS handshake so reloaded leaf material is used). Rotating the CA both sides trust means updating the mounted CA PEMs and typically rolling workloads.
 
 ## Development
 
@@ -148,6 +165,6 @@ Run only one topology or the default single-runner suite:
 
 Extra Playwright arguments can be passed to any script (for example `./e2e/run-all.sh --grep pattern`).
 
-`run-all.sh` runs **`make docker-local` once**; the per-topology scripts skip rebuilding when invoked from it (`E2E_SKIP_BUILD=1`). To rebuild before each phase, run the topology scripts individually instead.
+`run-all.sh` runs `make docker-local` once. The per-topology scripts skip rebuilding when invoked from it (`E2E_SKIP_BUILD=1`). To rebuild before each phase, run the topology scripts individually instead.
 
-See **[e2e/README.md](e2e/README.md)** for how scripts map to specs, what a Playwright “worker” is, and how `resilience.spec.ts` uses the host `docker` CLI.
+See [e2e/README.md](e2e/README.md) for how scripts map to specs, what a Playwright “worker” is, and how `resilience.spec.ts` uses the host `docker` CLI.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/n8n-io/sandbox-service/internal/api/grpc/pb"
 	"github.com/n8n-io/sandbox-service/internal/api/registry"
 	"github.com/n8n-io/sandbox-service/internal/api/store"
+	"github.com/n8n-io/sandbox-service/internal/grpctls"
 	"google.golang.org/grpc"
 )
 
@@ -68,7 +69,21 @@ func main() {
 		slog.Error("grpc listen", "addr", cfg.GRPCListenAddr, "error", err)
 		os.Exit(1)
 	}
-	grpcSrv := grpc.NewServer()
+	var grpcOpts []grpc.ServerOption
+	if cfg.GRPCServerCertFile != "" {
+		creds, err := grpctls.NewServerTransportCredentials(
+			cfg.GRPCServerCertFile,
+			cfg.GRPCServerKeyFile,
+			cfg.GRPCClientCAFile,
+		)
+		if err != nil {
+			slog.Error("grpc tls credentials", "error", err)
+			os.Exit(1)
+		}
+		grpcOpts = append(grpcOpts, grpc.Creds(creds))
+		slog.Info("runner registry grpc mTLS enabled")
+	}
+	grpcSrv := grpc.NewServer(grpcOpts...)
 	pb.RegisterRunnerRegistryServer(grpcSrv, &grpcapi.RunnerRegistryServer{
 		Token: cfg.RegistrationToken,
 		Reg:   reg,

--- a/compose.tls.yaml
+++ b/compose.tls.yaml
@@ -1,0 +1,29 @@
+# Overlay: mTLS for runner → API registration gRPC (default with make up / scripts/run-locally.sh).
+# Material is generated under ./.tls by scripts/bootstrap-local-mtls.sh (idempotent).
+
+services:
+  api:
+    volumes:
+      - ./.tls:/grpc-tls:ro
+    environment:
+      SANDBOX_API_GRPC_TLS_CERT_FILE: /grpc-tls/grpc-server.crt
+      SANDBOX_API_GRPC_TLS_KEY_FILE: /grpc-tls/grpc-server.key
+      SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE: /grpc-tls/ca.crt
+
+  runner-1:
+    volumes:
+      - ./.tls:/grpc-tls:ro
+    environment:
+      SANDBOX_RUNNER_GRPC_TLS_CA_FILE: /grpc-tls/ca.crt
+      SANDBOX_RUNNER_GRPC_TLS_CERT_FILE: /grpc-tls/grpc-client.crt
+      SANDBOX_RUNNER_GRPC_TLS_KEY_FILE: /grpc-tls/grpc-client.key
+      SANDBOX_RUNNER_GRPC_TLS_SERVER_NAME: n8n-sandbox-api-local
+
+  runner-2:
+    volumes:
+      - ./.tls:/grpc-tls:ro
+    environment:
+      SANDBOX_RUNNER_GRPC_TLS_CA_FILE: /grpc-tls/ca.crt
+      SANDBOX_RUNNER_GRPC_TLS_CERT_FILE: /grpc-tls/grpc-client.crt
+      SANDBOX_RUNNER_GRPC_TLS_KEY_FILE: /grpc-tls/grpc-client.key
+      SANDBOX_RUNNER_GRPC_TLS_SERVER_NAME: n8n-sandbox-api-local

--- a/deploy/k8s/cert-manager/README.md
+++ b/deploy/k8s/cert-manager/README.md
@@ -1,0 +1,21 @@
+# Kubernetes: runner registration gRPC with cert-manager (mTLS)
+
+Use a private CA (cert-manager `ClusterIssuer` of type CA, or another issuer you operate) that signs leaf certificates for TLS roles:
+
+1. **API** — server cert with DNS SAN matching the Service DNS runners use (for example `sandbox-api.sandbox.svc.cluster.local`).
+2. **Runner** — client cert (`clientAuth` EKU) presented when runners dial the API.
+
+Mount PEMs from `Certificate` secrets (typically `tls.crt`, `tls.key`, and a CA bundle) and set:
+
+- **API:** `SANDBOX_API_GRPC_TLS_CERT_FILE`, `SANDBOX_API_GRPC_TLS_KEY_FILE`, `SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE` (PEM of the CA that signs runner clients).
+- **Runner:** `SANDBOX_RUNNER_GRPC_TLS_CA_FILE` (PEM of the CA that signed the API server cert), `SANDBOX_RUNNER_GRPC_TLS_CERT_FILE`, `SANDBOX_RUNNER_GRPC_TLS_KEY_FILE`, `SANDBOX_RUNNER_GRPC_TLS_SERVER_NAME` (must match a DNS SAN on the API server cert).
+
+## cert-manager sketch
+
+- One CA `Issuer` (or a CA you already run).
+- `Certificate` for the API gRPC server — `usages: [ "server auth" ]`.
+- `Certificate` for runners as TLS clients — `usages: [ "client auth" ]`, per-runner.
+
+Mount each secret’s files into the API and runner Pods at the paths referenced by the env vars above.
+
+When `cert-manager` renews a leaf, updated files appear in the volume; the service binaries reload leaf key pairs from disk on the next TLS handshake. Rotating a CA that peers trust usually means updating mounted CA PEMs and rolling workloads. Prefer short-lived leaves and keep CA rotation infrequent.

--- a/e2e/tests/file-exec-consistency.spec.ts
+++ b/e2e/tests/file-exec-consistency.spec.ts
@@ -11,6 +11,8 @@ import {
  * E2E tests verifying that the file API and exec API operate on the same
  * filesystem — files created through one are visible through the other.
  */
+test.describe.configure({ mode: 'serial' });
+
 test.describe('File API and Exec API path consistency', () => {
   let sandboxId: string;
 
@@ -91,14 +93,30 @@ test.describe('File API and Exec API path consistency', () => {
     const content = await downloadFile(request, sandboxId, path);
     expect(content).toBe('to be deleted');
 
-    await exec(request, sandboxId, `rm ${path}`);
+    const rmResult = await exec(request, sandboxId, `rm -f ${path}`);
+    expect(rmResult.exit?.exit_code).toBe(0);
 
-    // File API should return an error for the missing file
-    const resp = await request.get(
-      `/sandboxes/${sandboxId}/files/content?path=${encodeURIComponent(path)}`,
-      { headers: { 'X-Api-Key': process.env.SANDBOX_API_KEY || 'test' } },
-    );
-    expect(resp.status()).not.toBe(200);
+    // After unlink, some setups (busy CI / overlay) can briefly still serve the file;
+    // poll until the file API observes the delete. Avoid any HTTP caching surprises.
+    const noStore = {
+      'X-Api-Key': process.env.SANDBOX_API_KEY || 'test',
+      'Cache-Control': 'no-store',
+      Pragma: 'no-cache',
+    };
+    await expect
+      .poll(
+        async () => {
+          const resp = await request.get(
+            `/sandboxes/${sandboxId}/files/content?path=${encodeURIComponent(path)}`,
+            { headers: noStore },
+          );
+          const status = resp.status();
+          await resp.text().catch(() => {});
+          return status;
+        },
+        { timeout: 10_000, intervals: [20, 50, 100, 200] },
+      )
+      .not.toBe(200);
   });
 
   test('file API write and exec read agree on multiline content', async ({ request }) => {

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -40,6 +40,11 @@ type APIConfig struct {
 
 	// HeartbeatGrace is how long after the last gRPC heartbeat a runner may still be chosen for placement.
 	HeartbeatGrace time.Duration
+
+	// Runner gRPC mTLS (optional). All three must be set together.
+	GRPCServerCertFile string
+	GRPCServerKeyFile  string
+	GRPCClientCAFile   string
 }
 
 // LoadAPI reads API gateway configuration from environment variables.
@@ -100,6 +105,24 @@ func LoadAPI() (*APIConfig, error) {
 			return nil, fmt.Errorf("SANDBOX_API_RUNNER_HEARTBEAT_GRACE must be a positive duration (e.g. 45s, 2m), got %q", v)
 		}
 		cfg.HeartbeatGrace = d
+	}
+
+	cfg.GRPCServerCertFile = strings.TrimSpace(os.Getenv("SANDBOX_API_GRPC_TLS_CERT_FILE"))
+	cfg.GRPCServerKeyFile = strings.TrimSpace(os.Getenv("SANDBOX_API_GRPC_TLS_KEY_FILE"))
+	cfg.GRPCClientCAFile = strings.TrimSpace(os.Getenv("SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE"))
+
+	tlsN := 0
+	if cfg.GRPCServerCertFile != "" {
+		tlsN++
+	}
+	if cfg.GRPCServerKeyFile != "" {
+		tlsN++
+	}
+	if cfg.GRPCClientCAFile != "" {
+		tlsN++
+	}
+	if tlsN != 0 && tlsN != 3 {
+		return nil, fmt.Errorf("SANDBOX_API_GRPC_TLS_CERT_FILE, SANDBOX_API_GRPC_TLS_KEY_FILE, and SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE must all be set together for mTLS")
 	}
 
 	return cfg, nil

--- a/internal/api/config/config_test.go
+++ b/internal/api/config/config_test.go
@@ -92,6 +92,21 @@ func TestLoadAPIRequiresAPIKeys(t *testing.T) {
 	}
 }
 
+func TestLoadAPIRejectsPartialGRPCTLS(t *testing.T) {
+	os.Setenv("SANDBOX_API_KEYS", "test-key")
+	os.Setenv("SANDBOX_API_RUNNER_REGISTRATION_TOKEN", "reg-token")
+	os.Setenv("SANDBOX_API_GRPC_TLS_CERT_FILE", "/tmp/x.crt")
+	defer func() {
+		os.Unsetenv("SANDBOX_API_KEYS")
+		os.Unsetenv("SANDBOX_API_RUNNER_REGISTRATION_TOKEN")
+		os.Unsetenv("SANDBOX_API_GRPC_TLS_CERT_FILE")
+	}()
+
+	if _, err := LoadAPI(); err == nil {
+		t.Fatal("expected LoadAPI to reject partial SANDBOX_API_GRPC_TLS_*")
+	}
+}
+
 func TestLoadAPIRequiresRegistrationToken(t *testing.T) {
 	os.Setenv("SANDBOX_API_KEYS", "test-key")
 	os.Unsetenv("SANDBOX_API_RUNNER_REGISTRATION_TOKEN")

--- a/internal/grpctls/client.go
+++ b/internal/grpctls/client.go
@@ -1,0 +1,37 @@
+package grpctls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// NewClientTransportCredentials builds mTLS client credentials for dialing the API registry.
+// serverCAFile must contain PEM certificate(s) for the CA that signed the API server certificate.
+// serverName is used for certificate verification (SNI / hostname); may be empty to use the dial target host.
+func NewClientTransportCredentials(serverCAFile, clientCertFile, clientKeyFile, serverName string) (credentials.TransportCredentials, error) {
+	caPEM, err := os.ReadFile(serverCAFile)
+	if err != nil {
+		return nil, fmt.Errorf("grpctls: read server CA: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("grpctls: no PEM certificates in %s", serverCAFile)
+	}
+
+	reloader := &KeyPairReloader{CertPath: clientCertFile, KeyPath: clientKeyFile}
+	if err := reloader.Prime(); err != nil {
+		return nil, fmt.Errorf("grpctls: load client key pair: %w", err)
+	}
+
+	tlsConf := &tls.Config{
+		RootCAs:              pool,
+		ServerName:           serverName,
+		GetClientCertificate: reloader.GetClientCertificate,
+		MinVersion:           tls.VersionTLS12,
+	}
+	return credentials.NewTLS(tlsConf), nil
+}

--- a/internal/grpctls/reloader.go
+++ b/internal/grpctls/reloader.go
@@ -1,0 +1,76 @@
+package grpctls
+
+import (
+	"crypto/tls"
+	"os"
+	"sync"
+	"time"
+)
+
+// KeyPairReloader reloads PEM certificate and key from disk when either file's
+// mtime changes (leaf rotation without replacing the process).
+type KeyPairReloader struct {
+	CertPath, KeyPath string
+
+	mu       sync.RWMutex
+	cert     tls.Certificate
+	maxMtime time.Time
+}
+
+func (k *KeyPairReloader) maybeReload() error {
+	stC, errC := os.Stat(k.CertPath)
+	stK, errK := os.Stat(k.KeyPath)
+	if errC != nil {
+		return errC
+	}
+	if errK != nil {
+		return errK
+	}
+	mt := stC.ModTime()
+	if stK.ModTime().After(mt) {
+		mt = stK.ModTime()
+	}
+
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if !k.maxMtime.IsZero() && !mt.After(k.maxMtime) {
+		return nil
+	}
+	cert, err := tls.LoadX509KeyPair(k.CertPath, k.KeyPath)
+	if err != nil {
+		return err
+	}
+	k.cert = cert
+	k.maxMtime = mt
+	return nil
+}
+
+// GetCertificate implements tls.Config.GetCertificate for the server.
+func (k *KeyPairReloader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if err := k.maybeReload(); err != nil {
+		return nil, err
+	}
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	c := k.cert
+	return &c, nil
+}
+
+// GetClientCertificate implements tls.Config.GetClientCertificate for the client.
+func (k *KeyPairReloader) GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	if err := k.maybeReload(); err != nil {
+		return nil, err
+	}
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	c := k.cert
+	return &c, nil
+}
+
+// Prime forces an initial load (for tests and startup).
+func (k *KeyPairReloader) Prime() error {
+	k.mu.Lock()
+	k.maxMtime = time.Time{}
+	k.mu.Unlock()
+	return k.maybeReload()
+}

--- a/internal/grpctls/reloader_test.go
+++ b/internal/grpctls/reloader_test.go
@@ -1,0 +1,76 @@
+package grpctls
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestKeyPairReloaderReloadsOnMtime(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	writeTestPair(t, certPath, keyPath, "first")
+
+	r := &KeyPairReloader{CertPath: certPath, KeyPath: keyPath}
+	if err := r.Prime(); err != nil {
+		t.Fatal(err)
+	}
+	c1, err := r.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c1.Certificate) == 0 {
+		t.Fatal("empty cert")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	writeTestPair(t, certPath, keyPath, "second")
+	c2, err := r.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(c1.Certificate[0]) == string(c2.Certificate[0]) {
+		t.Fatal("expected certificate bytes to change after file update")
+	}
+}
+
+func writeTestPair(t *testing.T, certPath, keyPath, cn string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{cn},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/grpctls/server.go
+++ b/internal/grpctls/server.go
@@ -1,0 +1,36 @@
+package grpctls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// NewServerTransportCredentials builds mTLS server credentials for the runner registry.
+// clientCAFile must contain PEM certificate(s) for the CA that signs runner client certificates.
+func NewServerTransportCredentials(serverCertFile, serverKeyFile, clientCAFile string) (credentials.TransportCredentials, error) {
+	caPEM, err := os.ReadFile(clientCAFile)
+	if err != nil {
+		return nil, fmt.Errorf("grpctls: read client CA: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("grpctls: no PEM certificates in %s", clientCAFile)
+	}
+
+	reloader := &KeyPairReloader{CertPath: serverCertFile, KeyPath: serverKeyFile}
+	if err := reloader.Prime(); err != nil {
+		return nil, fmt.Errorf("grpctls: load server key pair: %w", err)
+	}
+
+	tlsConf := &tls.Config{
+		ClientAuth:     tls.RequireAndVerifyClientCert,
+		ClientCAs:      pool,
+		GetCertificate: reloader.GetCertificate,
+		MinVersion:     tls.VersionTLS12,
+	}
+	return credentials.NewTLS(tlsConf), nil
+}

--- a/internal/runner/config/config.go
+++ b/internal/runner/config/config.go
@@ -90,6 +90,12 @@ type Config struct {
 	// CapacityTotal is reported to the API for placement (0 means unlimited).
 	// Parsed from SANDBOX_RUNNER_CAPACITY_TOTAL (default 1000).
 	CapacityTotal int32
+
+	// mTLS for registration gRPC (optional). All three must be set together.
+	GRPCServerCAFile   string
+	GRPCClientCertFile string
+	GRPCClientKeyFile  string
+	GRPCServerName     string
 }
 
 // Load reads configuration from environment variables and returns a Config.
@@ -226,6 +232,25 @@ func Load() (*Config, error) {
 			return nil, fmt.Errorf("SANDBOX_RUNNER_CAPACITY_TOTAL must be a non-negative integer, got %q", v)
 		}
 		cfg.CapacityTotal = int32(n)
+	}
+
+	cfg.GRPCServerCAFile = strings.TrimSpace(os.Getenv("SANDBOX_RUNNER_GRPC_TLS_CA_FILE"))
+	cfg.GRPCClientCertFile = strings.TrimSpace(os.Getenv("SANDBOX_RUNNER_GRPC_TLS_CERT_FILE"))
+	cfg.GRPCClientKeyFile = strings.TrimSpace(os.Getenv("SANDBOX_RUNNER_GRPC_TLS_KEY_FILE"))
+	cfg.GRPCServerName = strings.TrimSpace(os.Getenv("SANDBOX_RUNNER_GRPC_TLS_SERVER_NAME"))
+
+	tlsN := 0
+	if cfg.GRPCServerCAFile != "" {
+		tlsN++
+	}
+	if cfg.GRPCClientCertFile != "" {
+		tlsN++
+	}
+	if cfg.GRPCClientKeyFile != "" {
+		tlsN++
+	}
+	if tlsN != 0 && tlsN != 3 {
+		return nil, fmt.Errorf("SANDBOX_RUNNER_GRPC_TLS_CA_FILE, SANDBOX_RUNNER_GRPC_TLS_CERT_FILE, and SANDBOX_RUNNER_GRPC_TLS_KEY_FILE must all be set together for mTLS")
 	}
 
 	if cfg.APIGRPCAddr != "" {

--- a/internal/runner/config/config_test.go
+++ b/internal/runner/config/config_test.go
@@ -92,14 +92,13 @@ func TestLoadRequiresSandboxImage(t *testing.T) {
 }
 
 func TestLoadRejectsPartialGRPCTLS(t *testing.T) {
-	os.Setenv("SANDBOX_RUNNER_API_KEYS", "test-key")
-	os.Setenv("SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE", "img")
-	os.Setenv("SANDBOX_RUNNER_GRPC_TLS_CA_FILE", "/tmp/ca.crt")
-	defer func() {
-		os.Unsetenv("SANDBOX_RUNNER_API_KEYS")
-		os.Unsetenv("SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE")
-		os.Unsetenv("SANDBOX_RUNNER_GRPC_TLS_CA_FILE")
-	}()
+	t.Setenv("SANDBOX_RUNNER_API_KEYS", "test-key")
+	t.Setenv("SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE", "img")
+	// Isolate from the process environment: inherited CERT+KEY would satisfy mTLS and make this test fail.
+	t.Setenv("SANDBOX_RUNNER_GRPC_TLS_CA_FILE", "/tmp/ca.crt")
+	t.Setenv("SANDBOX_RUNNER_GRPC_TLS_CERT_FILE", "")
+	t.Setenv("SANDBOX_RUNNER_GRPC_TLS_KEY_FILE", "")
+	t.Setenv("SANDBOX_RUNNER_GRPC_TLS_SERVER_NAME", "")
 
 	if _, err := Load(); err == nil {
 		t.Fatal("expected Load to reject partial SANDBOX_RUNNER_GRPC_TLS_*")

--- a/internal/runner/config/config_test.go
+++ b/internal/runner/config/config_test.go
@@ -90,3 +90,18 @@ func TestLoadRequiresSandboxImage(t *testing.T) {
 		t.Error("expected Load() to fail without SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE")
 	}
 }
+
+func TestLoadRejectsPartialGRPCTLS(t *testing.T) {
+	os.Setenv("SANDBOX_RUNNER_API_KEYS", "test-key")
+	os.Setenv("SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE", "img")
+	os.Setenv("SANDBOX_RUNNER_GRPC_TLS_CA_FILE", "/tmp/ca.crt")
+	defer func() {
+		os.Unsetenv("SANDBOX_RUNNER_API_KEYS")
+		os.Unsetenv("SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE")
+		os.Unsetenv("SANDBOX_RUNNER_GRPC_TLS_CA_FILE")
+	}()
+
+	if _, err := Load(); err == nil {
+		t.Fatal("expected Load to reject partial SANDBOX_RUNNER_GRPC_TLS_*")
+	}
+}

--- a/internal/runner/register/register.go
+++ b/internal/runner/register/register.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"time"
 
 	"google.golang.org/grpc"
@@ -12,6 +13,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/n8n-io/sandbox-service/internal/api/grpc/pb"
+	"github.com/n8n-io/sandbox-service/internal/grpctls"
 	"github.com/n8n-io/sandbox-service/internal/runner/config"
 	"github.com/n8n-io/sandbox-service/internal/runner/manager"
 )
@@ -19,7 +21,7 @@ import (
 // Run maintains a registration stream to the API until ctx is cancelled.
 func Run(ctx context.Context, cfg *config.Config, mgr *manager.Manager) {
 	if cfg.APIGRPCAddr == "" || cfg.RegistrationToken == "" {
-		slog.Warn("runner registration skipped (set SANDBOX_API_GRPC_ADDR and SANDBOX_RUNNER_REGISTRATION_TOKEN)")
+		slog.Warn("runner registration skipped (set SANDBOX_RUNNER_API_GRPC_ADDR and SANDBOX_RUNNER_REGISTRATION_TOKEN)")
 		return
 	}
 
@@ -54,7 +56,31 @@ func Run(ctx context.Context, cfg *config.Config, mgr *manager.Manager) {
 }
 
 func connectOnce(ctx context.Context, cfg *config.Config, mgr *manager.Manager) error {
-	conn, err := grpc.NewClient(cfg.APIGRPCAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	var dialOpts []grpc.DialOption
+	if cfg.GRPCServerCAFile != "" {
+		serverName := cfg.GRPCServerName
+		if serverName == "" {
+			host, _, err := net.SplitHostPort(cfg.APIGRPCAddr)
+			if err != nil {
+				return err
+			}
+			serverName = host
+		}
+		creds, err := grpctls.NewClientTransportCredentials(
+			cfg.GRPCServerCAFile,
+			cfg.GRPCClientCertFile,
+			cfg.GRPCClientKeyFile,
+			serverName,
+		)
+		if err != nil {
+			return err
+		}
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(creds))
+	} else {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	conn, err := grpc.NewClient(cfg.APIGRPCAddr, dialOpts...)
 	if err != nil {
 		return err
 	}

--- a/scripts/bootstrap-local-mtls.sh
+++ b/scripts/bootstrap-local-mtls.sh
@@ -2,7 +2,7 @@
 # Generate a private CA plus API gRPC server and runner client leaf PEMs for local mTLS.
 # Writes to the repo's .tls/ directory by default (gitignored).
 #
-# Skips generation if .tls/grpc-server.crt (and peers) already exist unless SANDBOX_TLS_REGEN=1.
+# Skips generation if the full CA + server + client PEM set already exists unless SANDBOX_TLS_REGEN=1.
 #
 # Environment:
 #   REPO_ROOT  — repository root (default: parent of scripts/)
@@ -19,7 +19,13 @@ CLIENT_DNS="${CLIENT_DNS:-sandbox-runner-mtls-client}"
 
 mkdir -p "$OUT_DIR"
 
-if [[ "${SANDBOX_TLS_REGEN:-}" != "1" ]] && [[ -f "$OUT_DIR/grpc-server.crt" ]] && [[ -f "$OUT_DIR/grpc-client.crt" ]] && [[ -f "$OUT_DIR/ca.crt" ]]; then
+tls_complete() {
+	[[ -f "$OUT_DIR/ca.crt" ]] && [[ -f "$OUT_DIR/ca.key" ]] \
+		&& [[ -f "$OUT_DIR/grpc-server.crt" ]] && [[ -f "$OUT_DIR/grpc-server.key" ]] \
+		&& [[ -f "$OUT_DIR/grpc-client.crt" ]] && [[ -f "$OUT_DIR/grpc-client.key" ]]
+}
+
+if [[ "${SANDBOX_TLS_REGEN:-}" != "1" ]] && tls_complete; then
 	echo "TLS material already present in $OUT_DIR (set SANDBOX_TLS_REGEN=1 to regenerate)"
 	exit 0
 fi

--- a/scripts/bootstrap-local-mtls.sh
+++ b/scripts/bootstrap-local-mtls.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Generate a private CA plus API gRPC server and runner client leaf PEMs for local mTLS.
+# Writes to the repo's .tls/ directory by default (gitignored).
+#
+# Skips generation if .tls/grpc-server.crt (and peers) already exist unless SANDBOX_TLS_REGEN=1.
+#
+# Environment:
+#   REPO_ROOT  — repository root (default: parent of scripts/)
+#   OUT_DIR    — output directory (default: $REPO_ROOT/.tls)
+#   API_DNS    — DNS SAN on the API gRPC server cert (default: n8n-sandbox-api-local)
+#   CLIENT_DNS — DNS SAN on the runner client cert (default: sandbox-runner-mtls-client)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+OUT_DIR="${OUT_DIR:-$REPO_ROOT/.tls}"
+API_DNS="${API_DNS:-n8n-sandbox-api-local}"
+CLIENT_DNS="${CLIENT_DNS:-sandbox-runner-mtls-client}"
+
+mkdir -p "$OUT_DIR"
+
+if [[ "${SANDBOX_TLS_REGEN:-}" != "1" ]] && [[ -f "$OUT_DIR/grpc-server.crt" ]] && [[ -f "$OUT_DIR/grpc-client.crt" ]] && [[ -f "$OUT_DIR/ca.crt" ]]; then
+	echo "TLS material already present in $OUT_DIR (set SANDBOX_TLS_REGEN=1 to regenerate)"
+	exit 0
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+	echo "openssl is required to bootstrap local mTLS"
+	exit 1
+fi
+
+umask 077
+echo "Writing mTLS material to $OUT_DIR (API SAN: DNS:$API_DNS, client SAN: DNS:$CLIENT_DNS)"
+
+openssl genrsa -out "$OUT_DIR/ca.key" 4096
+openssl req -new -x509 -days 3650 -key "$OUT_DIR/ca.key" -out "$OUT_DIR/ca.crt" \
+	-subj "/O=n8n-sandbox-local/CN=sandbox-mtls-local-ca"
+
+openssl genrsa -out "$OUT_DIR/grpc-server.key" 2048
+openssl req -new -key "$OUT_DIR/grpc-server.key" -out "$OUT_DIR/grpc-server.csr" \
+	-subj "/O=n8n-sandbox-local/CN=$API_DNS"
+
+server_ext="$OUT_DIR/grpc-server.ext"
+cat >"$server_ext" <<EOF
+[v3_req]
+subjectAltName=DNS:${API_DNS}
+extendedKeyUsage=serverAuth
+EOF
+openssl x509 -req -in "$OUT_DIR/grpc-server.csr" \
+	-CA "$OUT_DIR/ca.crt" -CAkey "$OUT_DIR/ca.key" -CAcreateserial \
+	-out "$OUT_DIR/grpc-server.crt" -days 825 \
+	-extfile "$server_ext" -extensions v3_req
+
+openssl genrsa -out "$OUT_DIR/grpc-client.key" 2048
+openssl req -new -key "$OUT_DIR/grpc-client.key" -out "$OUT_DIR/grpc-client.csr" \
+	-subj "/O=n8n-sandbox-local/CN=$CLIENT_DNS"
+
+client_ext="$OUT_DIR/grpc-client.ext"
+cat >"$client_ext" <<EOF
+[v3_req]
+subjectAltName=DNS:${CLIENT_DNS}
+extendedKeyUsage=clientAuth
+EOF
+openssl x509 -req -in "$OUT_DIR/grpc-client.csr" \
+	-CA "$OUT_DIR/ca.crt" -CAkey "$OUT_DIR/ca.key" -CAcreateserial \
+	-out "$OUT_DIR/grpc-client.crt" -days 825 \
+	-extfile "$client_ext" -extensions v3_req
+
+rm -f "$OUT_DIR"/*.csr "$OUT_DIR"/*.srl "$OUT_DIR"/*.ext
+chmod 644 "$OUT_DIR/ca.crt" "$OUT_DIR/grpc-server.crt" "$OUT_DIR/grpc-client.crt"
+chmod 600 "$OUT_DIR/ca.key" "$OUT_DIR/grpc-server.key" "$OUT_DIR/grpc-client.key"
+
+echo "Done."

--- a/scripts/docker-compose-local.sh
+++ b/scripts/docker-compose-local.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Local docker compose with ARCH set and the same -f stack as scripts/run-locally.sh.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+export ARCH
+ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
+
+COMPOSE_FILES=(-f compose.yaml)
+if [[ "$(uname)" == "Darwin" ]]; then
+	COMPOSE_FILES+=(-f compose.macos.yaml)
+else
+	COMPOSE_FILES+=(-f compose.linux.yaml)
+fi
+
+if [[ "${SANDBOX_COMPOSE_TLS:-1}" != "0" ]]; then
+	COMPOSE_FILES+=(-f compose.tls.yaml)
+fi
+
+exec docker compose "${COMPOSE_FILES[@]}" "$@"

--- a/scripts/run-locally.sh
+++ b/scripts/run-locally.sh
@@ -2,17 +2,20 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-export ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
+echo "==> Ensuring local gRPC mTLS material (.tls/) ..."
+bash scripts/bootstrap-local-mtls.sh
 
-echo "==> Building images for ${ARCH} ..."
-docker compose --profile build build
-
-COMPOSE_FILES=(-f compose.yaml)
-if [[ "$(uname)" == "Darwin" ]]; then
-  COMPOSE_FILES+=(-f compose.macos.yaml)
-else
-  COMPOSE_FILES+=(-f compose.linux.yaml)
+if [[ "${SANDBOX_COMPOSE_TLS:-1}" != "0" ]] && [[ ! -f .tls/grpc-server.crt ]]; then
+	echo "Expected .tls/grpc-server.crt after bootstrap. Install openssl or set SANDBOX_COMPOSE_TLS=0 for plaintext gRPC."
+	exit 1
+fi
+if [[ "${SANDBOX_COMPOSE_TLS:-1}" != "0" ]]; then
+	echo "==> Using compose.tls.yaml (mTLS). Set SANDBOX_COMPOSE_TLS=0 to disable."
 fi
 
+ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
+echo "==> Building images for ${ARCH} ..."
+ARCH="${ARCH}" docker compose -f compose.yaml --profile build build
+
 echo "==> Starting services ..."
-docker compose "${COMPOSE_FILES[@]}" up "$@"
+exec bash scripts/docker-compose-local.sh up "$@"

--- a/scripts/run-locally.sh
+++ b/scripts/run-locally.sh
@@ -2,15 +2,16 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-echo "==> Ensuring local gRPC mTLS material (.tls/) ..."
-bash scripts/bootstrap-local-mtls.sh
-
-if [[ "${SANDBOX_COMPOSE_TLS:-1}" != "0" ]] && [[ ! -f .tls/grpc-server.crt ]]; then
-	echo "Expected .tls/grpc-server.crt after bootstrap. Install openssl or set SANDBOX_COMPOSE_TLS=0 for plaintext gRPC."
-	exit 1
-fi
 if [[ "${SANDBOX_COMPOSE_TLS:-1}" != "0" ]]; then
+	echo "==> Ensuring local gRPC mTLS material (.tls/) ..."
+	bash scripts/bootstrap-local-mtls.sh
+	if [[ ! -f .tls/grpc-server.crt ]]; then
+		echo "Expected .tls/grpc-server.crt after bootstrap. Install openssl or set SANDBOX_COMPOSE_TLS=0 for plaintext gRPC."
+		exit 1
+	fi
 	echo "==> Using compose.tls.yaml (mTLS). Set SANDBOX_COMPOSE_TLS=0 to disable."
+else
+	echo "==> SANDBOX_COMPOSE_TLS=0, skipping local mTLS bootstrap."
 fi
 
 ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Secure runner-to-API gRPC registration with optional mTLS, on by default in local Compose. Adds hot-reload of TLS certs, strict env validation, updated docs, and local bootstrap tooling; HTTP proxying stays the same.

- **New Features**
  - Optional mTLS for runner→API gRPC:
    - API: `SANDBOX_API_GRPC_TLS_CERT_FILE`, `SANDBOX_API_GRPC_TLS_KEY_FILE`, `SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE` (all required together).
    - Runner: `SANDBOX_RUNNER_GRPC_TLS_CA_FILE`, `SANDBOX_RUNNER_GRPC_TLS_CERT_FILE`, `SANDBOX_RUNNER_GRPC_TLS_KEY_FILE` (all required together), optional `SANDBOX_RUNNER_GRPC_TLS_SERVER_NAME`. Bearer token in metadata is still required.
  - TLS reload without restart via `internal/grpctls` (server/client creds with a key-pair reloader).
  - Local DX: `.tls/` (gitignored) auto-bootstrapped by `scripts/bootstrap-local-mtls.sh`; `compose.tls.yaml` mounts `.tls/`; `SANDBOX_COMPOSE_TLS=0` disables mTLS; `make up/down` now route through consistent compose wrapper (`scripts/docker-compose-local.sh`).
  - Kubernetes: added `deploy/k8s/cert-manager/README.md` with guidance for mounting PEMs and setting env vars.

- **Bug Fixes**
  - Deflaked file/exec consistency E2E by polling until delete is observed, running the suite in serial, and disabling HTTP caching during checks.
  - Corrected runner log hint to reference `SANDBOX_RUNNER_API_GRPC_ADDR`.

<sup>Written for commit ea0302994b6b478ce8e9725dcaec4a7746eaf59f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

