### PR TITLE
Preinstall sandbox workspace dependencies

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -36,6 +36,13 @@ COPY --from=builder /out/daemon /usr/local/bin/sandbox-daemon
 
 USER 1000:1000
 WORKDIR /home/user
+
+RUN mkdir -p workspace/src workspace/chunks workspace/node-types
+COPY --chown=1000:1000 sandbox-workspace/package.json workspace/package.json
+COPY --chown=1000:1000 sandbox-workspace/tsconfig.json workspace/tsconfig.json
+COPY --chown=1000:1000 sandbox-workspace/build.mjs workspace/build.mjs
+RUN cd workspace && npm install --ignore-scripts
+
 EXPOSE 8081
 
 CMD ["/usr/local/bin/sandbox-daemon", "--listen-addr", ":8081", "--base-dir", "/"]

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -38,9 +38,7 @@ USER 1000:1000
 WORKDIR /home/user
 
 RUN mkdir -p workspace/src workspace/chunks workspace/node-types
-COPY --chown=1000:1000 sandbox-workspace/package.json workspace/package.json
-COPY --chown=1000:1000 sandbox-workspace/tsconfig.json workspace/tsconfig.json
-COPY --chown=1000:1000 sandbox-workspace/build.mjs workspace/build.mjs
+COPY --chown=1000:1000 sandbox-workspace/ workspace/
 RUN cd workspace && npm install --ignore-scripts
 
 EXPOSE 8081

--- a/sandbox-workspace/build.mjs
+++ b/sandbox-workspace/build.mjs
@@ -1,0 +1,20 @@
+const filePath = process.argv[2] || './src/workflow.ts';
+try {
+  const mod = await import(filePath);
+  const wf = mod.default;
+  if (!wf || typeof wf.toJSON !== 'function') {
+    console.log(JSON.stringify({ success: false, errors: ['Default export is not a workflow. Make sure your file has: export default workflow(...)'] }));
+    process.exit(1);
+  }
+  const validation = wf.validate();
+  const json = wf.toJSON();
+  const warnings = [...(validation.errors || []), ...(validation.warnings || [])];
+  // Preserve undefined values as null — newCredential() produces NewCredentialImpl
+  // which serializes to undefined in toJSON(). Without this, JSON.stringify drops
+  // the credential keys entirely and the server can't resolve them.
+  const replacer = (k, v) => v === undefined ? null : v;
+  console.log(JSON.stringify({ success: true, workflow: json, warnings }, replacer));
+} catch (e) {
+  console.log(JSON.stringify({ success: false, errors: [e instanceof Error ? e.message : String(e)] }));
+  process.exit(1);
+}

--- a/sandbox-workspace/package.json
+++ b/sandbox-workspace/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sandbox-workspace",
+  "private": true,
+  "dependencies": {
+    "tsx": "4.19.3",
+    "@n8n/workflow-sdk": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "24.10.1"
+  }
+}

--- a/sandbox-workspace/tsconfig.json
+++ b/sandbox-workspace/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "strictNullChecks": false,
+    "noEmit": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "chunks/**/*.ts"
+  ]
+}


### PR DESCRIPTION
Add the sandbox workspace bootstrap files to the repo so they can be baked into the sandbox image.
Copy the package.json, tsconfig.json, and build.mjs into /home/user/workspace and create the expected src/chunks/node-types directories during image build.
Run npm install in the image build so new sandboxes start with the workspace dependencies already installed instead of bootstrapping them from scratch at runtime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preinstall the sandbox workspace in the image so new sandboxes start with deps ready and skip runtime bootstrapping. Also adds a small build script to validate and serialize workflows.

- New Features
  - Bake the workspace into the image: create workspace/src, workspace/chunks, and workspace/node-types; copy `sandbox-workspace/` into `workspace/`; run `npm install --ignore-scripts` at build time.
  - Add build.mjs that loads the default-exported workflow, validates it, and prints JSON while preserving undefined as null.

- Dependencies
  - Add `tsx@4.19.3`, `@n8n/workflow-sdk@latest`, and dev `@types/node@24.10.1`.

<sup>Written for commit c3ec7eca94267af3b8d7b3026112c8edfc8a9d8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

