### PR TITLE
fix: prevent runner proxy panic from corrupting exec NDJSON stream

### DIFF
--- a/e2e/tests/file-exec-consistency.spec.ts
+++ b/e2e/tests/file-exec-consistency.spec.ts
@@ -63,11 +63,8 @@ test.describe('File API and Exec API path consistency', () => {
     const scriptPath = `${dir}/greet.sh`;
     const scriptContent = '#!/bin/sh\necho "hello $1"';
 
-    // Create dir via exec, write script via file API
-    await exec(sandboxId, `mkdir -p ${dir}`);
     await uploadFile(sandboxId, scriptPath, scriptContent);
 
-    // Make executable and run via exec
     await exec(sandboxId, `chmod +x ${scriptPath}`);
     const result = await exec(sandboxId, `${scriptPath} world`);
     expect(result.exitCode).toBe(0);

--- a/internal/runner/proxy.go
+++ b/internal/runner/proxy.go
@@ -33,7 +33,15 @@ func UploadProxyHandler(mgr ContainerManager, cfg *config.Config) http.HandlerFu
 func proxyHandler(mgr ContainerManager, cfg *config.Config, limitBody bool) http.HandlerFunc {
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
-			pt := pr.In.Context().Value(proxyContextKey{}).(*proxyTarget)
+			// Comma-ok assertion: the context key is missing when
+			// httputil.ReverseProxy replays Rewrite on a internally-constructed
+			// request (e.g. 100-continue handshake, connection-level retry after
+			// an idle-connection reset). Bail out so the request fails at the
+			// transport layer and is handled by ErrorHandler instead of panicking.
+			pt, ok := pr.In.Context().Value(proxyContextKey{}).(*proxyTarget)
+			if !ok || pt == nil {
+				return
+			}
 			pr.SetURL(pt.url)
 			pr.Out.URL.Path = pt.path
 			pr.Out.URL.RawQuery = pr.In.URL.RawQuery

--- a/sdk/src/ndjson.ts
+++ b/sdk/src/ndjson.ts
@@ -1,6 +1,38 @@
 import type { Readable } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
-import type { ExecEvent } from "./types";
+import type {
+  ExecEvent,
+  ExecStdoutEvent,
+  ExecStderrEvent,
+  ExecExitEvent,
+  ExecErrorEvent,
+} from "./types";
+
+type JsonObject = Record<string, unknown>;
+
+function isStdoutEvent(json: JsonObject): json is ExecStdoutEvent {
+  return json.type === "stdout" && typeof json.data === "string";
+}
+
+function isStderrEvent(json: JsonObject): json is ExecStderrEvent {
+  return json.type === "stderr" && typeof json.data === "string";
+}
+
+function isExitEvent(json: JsonObject): json is ExecExitEvent {
+  return (
+    json.type === "exit" &&
+    typeof json.exit_code === "number" &&
+    typeof json.success === "boolean" &&
+    typeof json.execution_time_ms === "number" &&
+    typeof json.timed_out === "boolean" &&
+    typeof json.killed === "boolean"
+  );
+}
+
+function isErrorEvent(json: JsonObject): json is ExecErrorEvent {
+  if (typeof json.error !== "string") return false;
+  return json.type === "error" || json.type === undefined;
+}
 
 /** Yields parsed exec events from an NDJSON stream, one per line. */
 export async function* readNdjsonStream(stream: Readable): AsyncGenerator<ExecEvent> {
@@ -32,35 +64,12 @@ export async function* readNdjsonStream(stream: Readable): AsyncGenerator<ExecEv
 /** Parses a single NDJSON line into a typed exec event. Returns an error event on invalid input. */
 export function parseExecEvent(line: string): ExecEvent {
   try {
-    const json = JSON.parse(line) as Record<string, unknown>;
-    const type = json.type;
+    const json = JSON.parse(line) as JsonObject;
 
-    if (type === "stdout" && typeof json.data === "string") {
-      return { type: "stdout", data: json.data };
-    }
-    if (type === "stderr" && typeof json.data === "string") {
-      return { type: "stderr", data: json.data };
-    }
-    if (
-      type === "exit" &&
-      typeof json.exit_code === "number" &&
-      typeof json.success === "boolean" &&
-      typeof json.execution_time_ms === "number" &&
-      typeof json.timed_out === "boolean" &&
-      typeof json.killed === "boolean"
-    ) {
-      return {
-        type: "exit",
-        exit_code: json.exit_code,
-        success: json.success,
-        execution_time_ms: json.execution_time_ms,
-        timed_out: json.timed_out,
-        killed: json.killed,
-      };
-    }
-    if (type === "error" && typeof json.error === "string") {
-      return { type: "error", error: json.error };
-    }
+    if (isStdoutEvent(json)) return json;
+    if (isStderrEvent(json)) return json;
+    if (isExitEvent(json)) return json;
+    if (isErrorEvent(json)) return { type: "error", error: json.error };
 
     return { type: "error", error: `Invalid exec event payload: ${line}` };
   } catch (error) {

--- a/sdk/test/ndjson.test.ts
+++ b/sdk/test/ndjson.test.ts
@@ -161,6 +161,13 @@ describe("parseExecEvent", () => {
     });
   });
 
+  it("treats object with error property but no type as error event", () => {
+    expect(parseExecEvent('{"error":"internal server error"}')).toEqual({
+      type: "error",
+      error: "internal server error",
+    });
+  });
+
   it("returns error for exit event with wrong field types", () => {
     expect(
       parseExecEvent('{"type":"exit","exit_code":"zero","success":true,"execution_time_ms":42,"timed_out":false,"killed":false}'),


### PR DESCRIPTION
## Summary
- Fix unsafe type assertion in runner reverse proxy's `Rewrite` function (`proxy.go:36`) that panicked when `httputil.ReverseProxy` replayed `Rewrite` without the `proxyTarget` context key — the `RecoveryMiddleware` caught the panic but injected `{"error":"internal server error"}` into the already-streaming NDJSON body
- Use comma-ok assertion so a missing target falls through to `ErrorHandler` gracefully instead of panicking
- Remove redundant `mkdir -p` exec call from flaky e2e test — `uploadFile` already creates parent directories via `HandleFileWrite` → `os.MkdirAll`
- Extract NDJSON inline conditionals into named type guard functions and handle error objects missing the `type` field (e.g. `{"error":"internal server error"}` from recovery middleware)

## Test plan
- [ ] Verify `make fmt-check` and `make vet` pass
- [ ] Verify SDK typecheck and all 30 unit tests pass (`pnpm typecheck && pnpm test`)
- [ ] Verify `file-exec-consistency.spec.ts` e2e test no longer flakes on CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops runner proxy panics from corrupting exec NDJSON streams and improves SDK parsing of error events. Also removes a redundant mkdir in e2e to deflake the file-exec test.

- **Bug Fixes**
  - Runner proxy: use comma-ok assertion in `Rewrite`; missing `proxyTarget` now falls through to `ErrorHandler` instead of panicking, preventing `{"error":"internal server error"}` from being injected into the NDJSON stream.
  - SDK NDJSON: add type guards and treat objects with only `error` (no `type`) as error events.
  - E2E: remove redundant `mkdir -p` since `uploadFile` creates parent dirs, stabilizing `file-exec-consistency` test.

<sup>Written for commit 906d338d80e95451f9be377e88c6b61628c1221f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

