### PR TITLE
ci: add required-checks gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,24 @@ jobs:
 
       - name: Run e2e tests
         run: PRIVILEGED=1 e2e/run.sh
+
+  # This job is required by GitHub branch protection rules.
+  # PRs cannot be merged unless this job passes.
+  required-checks:
+    name: Required Checks
+    needs: [check, sdk, docker, e2e]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate required checks
+        run: |
+          echo "Results: $RESULTS"
+          for result in $(echo "$RESULTS" | jq -r '.[] | .result'); do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "One or more required checks failed or were cancelled"
+              exit 1
+            fi
+          done
+          echo "All required checks passed"
+        env:
+          RESULTS: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary

- Adds a `required-checks` job to the CI workflow that depends on all four existing jobs (`check`, `sdk`, `docker`, `e2e`)
- Uses `if: always()` so it runs even when upstream jobs are skipped, and fails if any dependency failed or was cancelled
- Allows GitHub branch protection to enforce a single "Required Checks" status instead of listing each job individually

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `required-checks` CI job that aggregates `check`, `sdk`, `docker`, and `e2e` into a single status for branch protection. It runs with `if: always()` and fails if any dependency failed or was cancelled.

- **Migration**
  - In branch protection, require the "Required Checks" status.
  - Remove individual required checks for `check`, `sdk`, `docker`, and `e2e`.

<sup>Written for commit afd9c01f57d03a7335db14480887546dc0fffd4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

