### PR TITLE
chore: upgrade CI actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25.0"
 
@@ -31,13 +31,13 @@ jobs:
   sdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
 
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+      - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6
         with:
           version: 10
 
@@ -60,7 +60,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build Docker image (amd64)
         run: make docker-amd64
@@ -68,17 +68,17 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25.0"
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
 
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+      - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6
         with:
           version: 10
 


### PR DESCRIPTION
## Summary

- Upgrade all GitHub Actions in CI workflow to latest major versions that support Node.js 24
- `actions/checkout` v4 → v6, `actions/setup-go` v5 → v6, `actions/setup-node` v4 → v6, `pnpm/action-setup` v4 → v6
- Resolves the Node.js 20 deprecation warning — Node.js 20 actions will be forced to Node.js 24 starting June 2nd, 2026

## Test plan

- [ ] CI passes on all jobs (check, sdk, docker, e2e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded all CI GitHub Actions to Node.js 24–compatible versions. Removes the Node 20 deprecation warning and keeps CI working when GitHub switches to Node 24 on June 2, 2026.

- **Dependencies**
  - `actions/checkout` v4 → v6
  - `actions/setup-go` v5 → v6
  - `actions/setup-node` v4 → v6
  - `pnpm/action-setup` v4 → v6

<sup>Written for commit ad966b09ed4278990469a928a9f1edbbd7ec3c2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

