### PR TITLE
chore: move CORS behind SANDBOX_API_ENABLE_CORS env var

### DIFF
--- a/API.md
+++ b/API.md
@@ -9,7 +9,7 @@ Runtime topology:
 - If no runner is registered (or none are healthy / within capacity), operations that need a runner return **503** with a JSON error whose message explains that no runners are available.
 - Sandbox-scoped requests are proxied to the **stored** runner HTTP URL for that sandbox. If that runner is down or unreachable, the API returns **503** with JSON `error` **`runner unavailable`** (same shape as other API errors).
 
-Environment (API): `SANDBOX_API_RUNNER_REGISTRATION_TOKEN` (required), `SANDBOX_API_GRPC_LISTEN_ADDR` (default `:9090`), `SANDBOX_API_RUNNER_HEARTBEAT_GRACE` (default `45s` — max age of last gRPC heartbeat for a runner to be eligible for placement), plus existing HTTP settings. mTLS for registration is required: `SANDBOX_API_GRPC_TLS_CERT_FILE`, `SANDBOX_API_GRPC_TLS_KEY_FILE`, `SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE`. mTLS for dialing runner SandboxControl is required: `SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CA_FILE`, `SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CERT_FILE`, `SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_KEY_FILE`; `SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_SERVER_NAME` remains optional.
+Environment (API): `SANDBOX_API_RUNNER_REGISTRATION_TOKEN` (required), `SANDBOX_API_GRPC_LISTEN_ADDR` (default `:9090`), `SANDBOX_API_RUNNER_HEARTBEAT_GRACE` (default `45s` — max age of last gRPC heartbeat for a runner to be eligible for placement), `SANDBOX_API_ENABLE_CORS` (default `false`, enables CORS middleware allowing all origins), plus existing HTTP settings. mTLS for registration is required: `SANDBOX_API_GRPC_TLS_CERT_FILE`, `SANDBOX_API_GRPC_TLS_KEY_FILE`, `SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE`. mTLS for dialing runner SandboxControl is required: `SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CA_FILE`, `SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CERT_FILE`, `SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_KEY_FILE`; `SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_SERVER_NAME` remains optional.
 
 Environment (runner): `SANDBOX_RUNNER_API_KEYS`, `SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE`, `SANDBOX_RUNNER_API_GRPC_ADDR`, `SANDBOX_RUNNER_REGISTRATION_TOKEN`, and `SANDBOX_RUNNER_HTTP_BASE_URL` are required (`SANDBOX_RUNNER_ID`, `SANDBOX_RUNNER_CAPACITY_TOTAL` remain optional). mTLS for registration is required: `SANDBOX_RUNNER_REGISTRATION_GRPC_CA_FILE`, `SANDBOX_RUNNER_REGISTRATION_GRPC_CERT_FILE`, `SANDBOX_RUNNER_REGISTRATION_GRPC_KEY_FILE`; `SANDBOX_RUNNER_REGISTRATION_GRPC_SERVER_NAME` remains optional. SandboxControl listener defaults to `SANDBOX_RUNNER_CONTROL_GRPC_LISTEN_ADDR=:9091`; `SANDBOX_RUNNER_CONTROL_GRPC_ADVERTISE_ADDR` remains optional (derived from `SANDBOX_RUNNER_HTTP_BASE_URL` when unset). mTLS for SandboxControl is required: `SANDBOX_RUNNER_CONTROL_GRPC_TLS_CERT_FILE`, `SANDBOX_RUNNER_CONTROL_GRPC_TLS_KEY_FILE`, `SANDBOX_RUNNER_CONTROL_GRPC_TLS_CLIENT_CA_FILE`.
 
@@ -501,8 +501,9 @@ curl "http://localhost:8080/sandboxes/550e8400-e29b-41d4-a716-446655440000/stat?
 Applied to all routes in order:
 
 1. **RecoveryMiddleware** — catches panics, returns `500`
-2. **LoggingMiddleware** — logs method, path, status, duration
-3. **AuthMiddleware** — validates `X-Api-Key` header (skipped for `/healthz`)
+2. **CORSMiddleware** — allows all origins; only active when `SANDBOX_API_ENABLE_CORS=true`
+3. **LoggingMiddleware** — logs method, path, status, duration
+4. **AuthMiddleware** — validates `X-Api-Key` header (skipped for `/healthz`)
 
 ## Abort Mechanism
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ curl -s -X DELETE http://localhost:8080/sandboxes/<id> \
 | `SANDBOX_API_GRPC_LISTEN_ADDR` | `:9090` | Private gRPC listen address for runner registration streams |
 | `SANDBOX_API_DATA_DIR` | `/tmp/sandbox-api` | SQLite store directory |
 | `SANDBOX_API_MAX_FILE_BYTES` | `10485760` | Maximum file upload size (10 MB) |
+| `SANDBOX_API_ENABLE_CORS` | `false` | Enable CORS headers (allow all origins); needed for the browser playground |
 | `SANDBOX_API_RUNNER_HEARTBEAT_GRACE` | `45s` | How long after the last gRPC heartbeat a runner remains eligible for placement (Go [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) syntax, e.g. `45s`, `2m`) |
 | `SANDBOX_API_GRPC_TLS_CERT_FILE` | *(required)* | Server certificate (PEM) for the registration gRPC listener |
 | `SANDBOX_API_GRPC_TLS_KEY_FILE` | *(required)* | Server private key (PEM) |

--- a/compose.yaml
+++ b/compose.yaml
@@ -48,6 +48,7 @@ services:
       SANDBOX_API_KEYS: test
       SANDBOX_API_RUNNER_REGISTRATION_TOKEN: ${REG_TOKEN:-local-reg-token}
       SANDBOX_API_RUNNER_API_KEY: ${RUNNER_API_KEY:-runner-local-key}
+      SANDBOX_API_ENABLE_CORS: "true"
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8080/healthz"]
       interval: 2s

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -41,6 +41,9 @@ type APIConfig struct {
 	// HeartbeatGrace is how long after the last gRPC heartbeat a runner may still be chosen for placement.
 	HeartbeatGrace time.Duration
 
+	// EnableCORS enables CORS headers (allow all origins). Default false.
+	EnableCORS bool
+
 	// Runner registration gRPC mTLS (required). All three must be set.
 	GRPCServerCertFile string
 	GRPCServerKeyFile  string
@@ -103,6 +106,14 @@ func LoadAPI() (*APIConfig, error) {
 
 	if v := os.Getenv("SANDBOX_API_DATA_DIR"); v != "" {
 		cfg.DataDir = v
+	}
+
+	if v := os.Getenv("SANDBOX_API_ENABLE_CORS"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("SANDBOX_API_ENABLE_CORS must be a boolean, got %q", v)
+		}
+		cfg.EnableCORS = b
 	}
 
 	if v := os.Getenv("SANDBOX_API_RUNNER_HEARTBEAT_GRACE"); v != "" {

--- a/internal/api/gateway.go
+++ b/internal/api/gateway.go
@@ -39,7 +39,9 @@ func NewGatewayRouter(s *store.Store, cfg *config.APIConfig, reg *registry.Regis
 	var handler http.Handler = mux
 	handler = AuthMiddleware(cfg.APIKeys)(handler)
 	handler = LoggingMiddleware(handler)
-	handler = CORSMiddleware(handler)
+	if cfg.EnableCORS {
+		handler = CORSMiddleware(handler)
+	}
 	handler = RecoveryMiddleware(handler)
 	return handler, nil
 }


### PR DESCRIPTION
## Summary

- CORS was unconditionally enabled for all origins on the API gateway. This moves it behind a new `SANDBOX_API_ENABLE_CORS` env var (default `false`) so production doesn't expose CORS headers.
- Local dev compose sets the flag to `true` so the browser playground continues to work.
- Updated API.md and README.md with the new env var and corrected middleware list.

## Test plan

- [x] `make fmt-check` passes
- [x] `make vet` passes
- [x] `make test` passes (existing tests don't rely on CORS, default `false` is fine)
- [ ] `make up` + `make playground` — verify playground at localhost:5173 can still talk to the API

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated CORS behind the `SANDBOX_API_ENABLE_CORS` env var (default false) so the API no longer sends CORS headers by default in production.

- **Migration**
  - Set `SANDBOX_API_ENABLE_CORS=true` in environments that need browser access (e.g., the playground).
  - Leave unset/false for production to keep CORS disabled.

<sup>Written for commit b26fa19b6382922800b769bd04212805c4919327. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

