### PR TITLE
chore: restart sandbox on kill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 node_modules
 *.tsbuildinfo
 .tls/
+.gomodcache/

--- a/API.md
+++ b/API.md
@@ -6,6 +6,7 @@ Runtime topology:
 - Public clients call the API container over HTTP (authenticated with `X-Api-Key`).
 - Each runner opens a **private gRPC** bidirectional stream to the API (`RunnerRegistry.Connect`), authenticated with `Authorization: Bearer <SANDBOX_RUNNER_REGISTRATION_TOKEN>`. Heartbeats carry `runner_id`, `http_base_url`, required `control_grpc_addr`, health, and capacity. Each heartbeat must include an absolute `http` or `https` `http_base_url` and a non-empty `control_grpc_addr` (or omit either after the first to reuse the stream’s last value); otherwise the RPC fails with `InvalidArgument`.
 - The API keeps an in-memory registry of runners and selects one using **round-robin** when it needs a runner (sandbox creation, image proxy pick). Creating a sandbox persists which runner owns it. Sandbox **create/delete** use gRPC (`SandboxControl` on the runner). Sandbox-scoped **proxy** requests (exec, files, mkdir, stat, …) always go to **that** runner’s HTTP base URL.
+- If a sandbox container exits on its assigned runner (for example crash/OOM), Docker restart policy restarts it and the same sandbox ID remains bound to that runner.
 - If no runner is registered (or none are healthy / within capacity), operations that need a runner return **503** with a JSON error whose message explains that no runners are available.
 - Sandbox-scoped requests are proxied to the **stored** runner HTTP URL for that sandbox. If that runner is down or unreachable, the API returns **503** with JSON `error` **`runner unavailable`** (same shape as other API errors).
 

--- a/API.md
+++ b/API.md
@@ -11,6 +11,15 @@ All endpoints except `/healthz` require the `X-Api-Key` header for authenticatio
 }
 ```
 
+### HTTP 503 (transient) vs 502 (not retryable)
+
+The API and runner use two buckets so clients (including the SDK) can decide **when to retry the same request** vs **when to change strategy** (e.g. create a new sandbox, fix routing, surface an error to the user).
+
+- **503 Service Unavailable** — **Transient / retry**: overload, no capacity yet, network or upstream not ready, or the sandbox daemon is not reachable *for the moment* while the container is otherwise expected to be usable. Safe to back off and retry the same operation.
+- **502 Bad Gateway** — **Not retryable as “wait and retry”**: the request does not make sense to repeat unchanged; fix state first (new sandbox, repair registry/routing, or handle the reported error). Examples: inner container **exists but is not running**, stored sandbox has **no runner HTTP base URL**, or **delete** failed on the runner control plane.
+
+**404** `sandbox not found` is unchanged (unknown id). Exec and file routes may return **503** or **502** from the runner after the API successfully reaches the runner; the API may return **503** `runner unavailable` before the runner is contacted.
+
 ---
 
 ## Endpoints
@@ -208,7 +217,7 @@ via `GET /sandboxes/{id}/exec/{exec_id}?after=<seq>&follow=true`. Completed exec
 are retained for 10 minutes. If the buffer is exhausted, old events are discarded and
 stale resume requests return `410 Gone`.
 
-**Errors:** `400` invalid id or missing command, `404` sandbox not found, `410` if execution exists but history is no longer retained
+**Errors:** `400` invalid id or missing command, `404` sandbox not found, `410` if execution exists but history is no longer retained. Transient failures use **503**; **502** means the sandbox is not usable without a client-side change — see [HTTP 503 (transient) vs 502 (not retryable)](#http-503-transient-vs-502-not-retryable).
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ The n8n Sandbox Service provides isolated execution environments via a REST API.
 - Sandboxes are started from a separate Debian sandbox image referenced by `SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE`.
 - The API forwards sandbox and image requests to the runner; the runner talks to sandbox daemons over the inner Docker bridge on port `8081`.
 
+## Failure Behavior
+
+- API restarts: sandbox IDs remain valid. Once API is back, existing sandboxes continue working.
+- Runner stops/dies: sandboxes on that runner become unavailable. When a runner returns, previously assigned sandboxes are not guaranteed to be recoverable and should be treated as lost.
+- Sandbox container exits (for example OOM): Docker restart policy restarts it; the same sandbox ID remains on the same runner.
+
 ## Quick Start
 
 Build all images:

--- a/e2e/run-two-runners.sh
+++ b/e2e/run-two-runners.sh
@@ -200,4 +200,4 @@ BASE_URL="http://localhost:$PORT" SANDBOX_API_KEY="$API_KEY" npx playwright test
 
 echo "Running runner failure resilience e2e..."
 BASE_URL="http://localhost:$PORT" SANDBOX_API_KEY="$API_KEY" \
-	npx playwright test tests/resilience.spec.ts -g "stopped runner" "$@"
+	npx playwright test tests/resilience.spec.ts --grep '@e2e-stopped-runner' "$@"

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -184,4 +184,4 @@ BASE_URL="http://localhost:$PORT" SANDBOX_API_KEY="$API_KEY" npx playwright test
 
 echo "Running API resilience e2e..."
 BASE_URL="http://localhost:$PORT" SANDBOX_API_KEY="$API_KEY" \
-	npx playwright test tests/resilience.spec.ts -g "API container restart" "$@"
+	npx playwright test tests/resilience.spec.ts --grep '@e2e-api-restart' "$@"

--- a/e2e/tests/file-exec-consistency.spec.ts
+++ b/e2e/tests/file-exec-consistency.spec.ts
@@ -3,6 +3,7 @@ import {
   createSandbox,
   deleteSandbox,
   exec,
+  execWithTransientRetry,
   uploadFile,
   downloadFile,
   apiRequest,
@@ -19,6 +20,7 @@ test.describe('File API and Exec API path consistency', () => {
 
   test.beforeAll(async () => {
     sandboxId = await createSandbox();
+    await execWithTransientRetry(sandboxId, 'true', { timeoutMs: 5_000, retryWindowMs: 12_000 });
   });
 
   test.afterAll(async () => {

--- a/e2e/tests/file-exec-consistency.spec.ts
+++ b/e2e/tests/file-exec-consistency.spec.ts
@@ -126,12 +126,18 @@ test.describe('File API and Exec API path consistency', () => {
     await uploadFile(sandboxId, path, content);
 
     // Use wc -l via exec to confirm line count
-    const result = await exec(sandboxId, `wc -l < ${path}`);
+    const result = await execWithTransientRetry(sandboxId, `wc -l < ${path}`, {
+      timeoutMs: 10_000,
+      retryWindowMs: 12_000,
+    });
     expect(result.exitCode).toBe(0);
     expect(result.stdout.trim()).toBe('2');
 
     // Confirm full content via exec
-    const catResult = await exec(sandboxId, `cat ${path}`);
+    const catResult = await execWithTransientRetry(sandboxId, `cat ${path}`, {
+      timeoutMs: 10_000,
+      retryWindowMs: 12_000,
+    });
     expect(catResult.stdout.trim()).toBe(content);
   });
 });

--- a/e2e/tests/file-exec-consistency.spec.ts
+++ b/e2e/tests/file-exec-consistency.spec.ts
@@ -68,7 +68,10 @@ test.describe('File API and Exec API path consistency', () => {
     await uploadFile(sandboxId, scriptPath, scriptContent);
 
     await exec(sandboxId, `chmod +x ${scriptPath}`);
-    const result = await exec(sandboxId, `${scriptPath} world`);
+    const result = await execWithTransientRetry(sandboxId, `${scriptPath} world`, {
+      timeoutMs: 10_000,
+      retryWindowMs: 12_000,
+    });
     expect(result.exitCode).toBe(0);
     expect(result.stdout.trim()).toBe('hello world');
   });

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -39,14 +39,15 @@ export async function exec(
 
 function isTransientExecError(err: unknown): boolean {
   const status = (err as { status?: number })?.status;
-  if (status === 502 || status === 503) {
+  if (status === 503) {
     return true;
   }
   const msg = String((err as Error)?.message || '').toLowerCase();
   return (
     msg.includes('internal server error') ||
-    msg.includes('daemon unreachable') ||
+    msg.includes('daemon temporarily unavailable') ||
     msg.includes('runner unavailable') ||
+    msg.includes('sandbox temporarily unavailable') ||
     msg.includes('sandbox exec stream ended without an exit event')
   );
 }

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,5 +1,6 @@
 import { APIRequestContext } from '@playwright/test';
 import { SandboxClient, type ExecResult } from '@n8n/sandbox-client';
+import { execFileSync } from 'node:child_process';
 
 const API_KEY = process.env.SANDBOX_API_KEY || 'test';
 const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
@@ -70,4 +71,29 @@ export async function apiRequest(
     body,
     json: () => Promise.resolve(JSON.parse(body)),
   };
+}
+
+export function docker(args: string[]): string {
+  return execFileSync('docker', args, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  });
+}
+
+export function dockerOutput(args: string[]): string {
+  try {
+    return execFileSync('docker', args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    });
+  } catch (err: unknown) {
+    const e = err as { stdout?: unknown; stderr?: unknown };
+    const stdout = e.stdout ? String(e.stdout) : '';
+    const stderr = e.stderr ? String(e.stderr) : '';
+    return `${stdout}\n${stderr}`.trim();
+  }
+}
+
+export function innerContainerName(sandboxID: string): string {
+  return `sandbox-${sandboxID.slice(0, 12)}`;
 }

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -35,6 +35,42 @@ export async function exec(
   });
 }
 
+function isTransientExecError(err: unknown): boolean {
+  const status = (err as { status?: number })?.status;
+  if (status === 502 || status === 503) {
+    return true;
+  }
+  const msg = String((err as Error)?.message || '').toLowerCase();
+  return (
+    msg.includes('internal server error') ||
+    msg.includes('daemon unreachable') ||
+    msg.includes('runner unavailable') ||
+    msg.includes('sandbox exec stream ended without an exit event')
+  );
+}
+
+export async function execWithTransientRetry(
+  id: string,
+  command: string,
+  opts?: { env?: Record<string, string>; workdir?: string; timeoutMs?: number; retryWindowMs?: number },
+): Promise<ExecResult> {
+  const deadlineMs = opts?.retryWindowMs ?? 12_000;
+  const deadline = Date.now() + deadlineMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      return await exec(id, command, opts);
+    } catch (err) {
+      lastErr = err;
+      if (!isTransientExecError(err)) {
+        throw err;
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }
+  throw new Error(`exec did not recover within ${deadlineMs}ms: ${String(lastErr)}`);
+}
+
 export async function uploadFile(
   id: string,
   path: string,

--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -11,6 +11,41 @@ const pyConnect = (ip: string, port: number = 80, timeout: number = 3) =>
 const pyResolve = (host: string) =>
   `python3 -c "import socket; print(socket.gethostbyname('${host}'))"`;
 
+function isTransientExecError(err: unknown): boolean {
+  const status = (err as { status?: number })?.status;
+  if (status === 502 || status === 503) {
+    return true;
+  }
+  const msg = String((err as Error)?.message || '').toLowerCase();
+  return (
+    msg.includes('internal server error') ||
+    msg.includes('daemon unreachable') ||
+    msg.includes('sandbox exec stream ended without an exit event')
+  );
+}
+
+async function execWithTransientRetry(
+  id: string,
+  command: string,
+  timeoutMs: number,
+  retryWindowMs: number = 12_000,
+) {
+  const deadline = Date.now() + retryWindowMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      return await exec(id, command, { timeoutMs });
+    } catch (err) {
+      lastErr = err;
+      if (!isTransientExecError(err)) {
+        throw err;
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }
+  throw new Error(`exec did not recover within ${retryWindowMs}ms: ${String(lastErr)}`);
+}
+
 test.describe('Network isolation', () => {
   test('sandbox can reach public internet', async () => {
     const id = await createSandbox();
@@ -36,9 +71,7 @@ test.describe('Network isolation', () => {
       ];
 
       for (const ip of privateIPs) {
-        const result = await exec(id, pyConnect(ip, 80, 3), {
-          timeoutMs: 10_000,
-        });
+        const result = await execWithTransientRetry(id, pyConnect(ip, 80, 3), 10_000);
         expect(result.exitCode, `expected private IP ${ip} to be unreachable`).not.toBe(0);
       }
     } finally {
@@ -51,25 +84,23 @@ test.describe('Network isolation', () => {
     const id2 = await createSandbox();
     try {
       // Get sandbox 2's IP
-      const ipResult = await exec(id2, 'hostname -I', { timeoutMs: 5_000 });
+      const ipResult = await execWithTransientRetry(id2, 'hostname -I', 5_000);
       expect(ipResult.exitCode).toBe(0);
       const sandbox2IP = ipResult.stdout.trim();
       expect(sandbox2IP).toBeTruthy();
 
       // Start a TCP listener in sandbox 2 on port 9999
-      await exec(id2, `python3 -c "
+      await execWithTransientRetry(id2, `python3 -c "
 import socket, threading
 s = socket.socket()
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 s.bind(('0.0.0.0', 9999))
 s.listen(1)
 import time; time.sleep(30)
-" &`, { timeoutMs: 5_000 });
+" &`, 5_000);
 
       // Sandbox 1 should not be able to reach sandbox 2
-      const result = await exec(id1, pyConnect(sandbox2IP, 9999, 3), {
-        timeoutMs: 10_000,
-      });
+      const result = await execWithTransientRetry(id1, pyConnect(sandbox2IP, 9999, 3), 10_000);
       expect(result.exitCode, `expected sandbox 1 to not reach sandbox 2 at ${sandbox2IP}`).not.toBe(0);
     } finally {
       await deleteSandbox(id1);
@@ -80,7 +111,7 @@ import time; time.sleep(30)
   test('DNS resolution works', async () => {
     const id = await createSandbox();
     try {
-      const result = await exec(id, pyResolve('example.com'), { timeoutMs: 10_000 });
+      const result = await execWithTransientRetry(id, pyResolve('example.com'), 10_000);
       expect(result.exitCode).toBe(0);
       // Should resolve to an IP address
       expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+\.\d+$/);

--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -90,14 +90,14 @@ test.describe('Network isolation', () => {
       expect(sandbox2IP).toBeTruthy();
 
       // Start a TCP listener in sandbox 2 on port 9999
-      await execWithTransientRetry(id2, `python3 -c "
+      await exec(id2, `python3 -c "
 import socket, threading
 s = socket.socket()
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 s.bind(('0.0.0.0', 9999))
 s.listen(1)
 import time; time.sleep(30)
-" &`, 5_000);
+" &`, { timeoutMs: 5_000 });
 
       // Sandbox 1 should not be able to reach sandbox 2
       const result = await execWithTransientRetry(id1, pyConnect(sandbox2IP, 9999, 3), 10_000);

--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { createSandbox, deleteSandbox, exec } from './helpers';
+import { createSandbox, deleteSandbox, exec, execWithTransientRetry } from './helpers';
 
 // Helper: use python3 for HTTP requests since curl is not in the sandbox rootfs
 const pyGet = (url: string, timeout: number = 5) =>
@@ -10,41 +10,6 @@ const pyConnect = (ip: string, port: number = 80, timeout: number = 3) =>
 
 const pyResolve = (host: string) =>
   `python3 -c "import socket; print(socket.gethostbyname('${host}'))"`;
-
-function isTransientExecError(err: unknown): boolean {
-  const status = (err as { status?: number })?.status;
-  if (status === 502 || status === 503) {
-    return true;
-  }
-  const msg = String((err as Error)?.message || '').toLowerCase();
-  return (
-    msg.includes('internal server error') ||
-    msg.includes('daemon unreachable') ||
-    msg.includes('sandbox exec stream ended without an exit event')
-  );
-}
-
-async function execWithTransientRetry(
-  id: string,
-  command: string,
-  timeoutMs: number,
-  retryWindowMs: number = 12_000,
-) {
-  const deadline = Date.now() + retryWindowMs;
-  let lastErr: unknown;
-  while (Date.now() < deadline) {
-    try {
-      return await exec(id, command, { timeoutMs });
-    } catch (err) {
-      lastErr = err;
-      if (!isTransientExecError(err)) {
-        throw err;
-      }
-      await new Promise((r) => setTimeout(r, 200));
-    }
-  }
-  throw new Error(`exec did not recover within ${retryWindowMs}ms: ${String(lastErr)}`);
-}
 
 test.describe('Network isolation', () => {
   test('sandbox can reach public internet', async () => {
@@ -71,7 +36,7 @@ test.describe('Network isolation', () => {
       ];
 
       for (const ip of privateIPs) {
-        const result = await execWithTransientRetry(id, pyConnect(ip, 80, 3), 10_000);
+        const result = await execWithTransientRetry(id, pyConnect(ip, 80, 3), { timeoutMs: 10_000 });
         expect(result.exitCode, `expected private IP ${ip} to be unreachable`).not.toBe(0);
       }
     } finally {
@@ -84,7 +49,7 @@ test.describe('Network isolation', () => {
     const id2 = await createSandbox();
     try {
       // Get sandbox 2's IP
-      const ipResult = await execWithTransientRetry(id2, 'hostname -I', 5_000);
+      const ipResult = await execWithTransientRetry(id2, 'hostname -I', { timeoutMs: 5_000 });
       expect(ipResult.exitCode).toBe(0);
       const sandbox2IP = ipResult.stdout.trim();
       expect(sandbox2IP).toBeTruthy();
@@ -100,7 +65,7 @@ import time; time.sleep(30)
 " &`, { timeoutMs: 5_000 });
 
       // Sandbox 1 should not be able to reach sandbox 2
-      const result = await execWithTransientRetry(id1, pyConnect(sandbox2IP, 9999, 3), 10_000);
+      const result = await execWithTransientRetry(id1, pyConnect(sandbox2IP, 9999, 3), { timeoutMs: 10_000 });
       expect(result.exitCode, `expected sandbox 1 to not reach sandbox 2 at ${sandbox2IP}`).not.toBe(0);
     } finally {
       await deleteSandbox(id1);
@@ -111,7 +76,7 @@ import time; time.sleep(30)
   test('DNS resolution works', async () => {
     const id = await createSandbox();
     try {
-      const result = await execWithTransientRetry(id, pyResolve('example.com'), 10_000);
+      const result = await execWithTransientRetry(id, pyResolve('example.com'), { timeoutMs: 10_000 });
       expect(result.exitCode).toBe(0);
       // Should resolve to an IP address
       expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+\.\d+$/);

--- a/e2e/tests/resilience.spec.ts
+++ b/e2e/tests/resilience.spec.ts
@@ -98,7 +98,7 @@ function runnerHostListsSandbox(runnerContainer: string, sandboxUUID: string): b
 }
 
 test.describe('API restart resilience', () => {
-  test('sandboxes keep working after API container restart', async ({ request }) => {
+  test('sandboxes keep working after API container restart', { tag: '@e2e-api-restart' }, async ({ request }) => {
     test.skip(!process.env.E2E_API_CONTAINER_NAME, 'needs E2E_API_CONTAINER_NAME (from e2e/run.sh)');
     test.setTimeout(100_000);
 
@@ -122,7 +122,10 @@ test.describe('API restart resilience', () => {
 });
 
 test.describe('Runner failure resilience', () => {
-  test('stopped runner: 503 on sandboxes there; other runner and new sandboxes still work', async ({ request }) => {
+  test(
+    'stopped runner: 503 on sandboxes there; other runner and new sandboxes still work',
+    { tag: '@e2e-stopped-runner' },
+    async ({ request }) => {
     test.skip(
       !process.env.E2E_RUNNER1_CONTAINER_NAME || !process.env.E2E_RUNNER2_CONTAINER_NAME,
       'needs E2E_RUNNER1_CONTAINER_NAME and E2E_RUNNER2_CONTAINER_NAME (from e2e/run-two-runners.sh)',

--- a/e2e/tests/sandbox-api.spec.ts
+++ b/e2e/tests/sandbox-api.spec.ts
@@ -660,7 +660,10 @@ test.describe('File operations', () => {
 
   test('file uploaded via API is visible to exec', async () => {
     await uploadFile(sandboxId, '/tmp/exec-visible.txt', 'from api');
-    const result = await exec(sandboxId, 'cat /tmp/exec-visible.txt');
+    const result = await execWithTransientRetry(sandboxId, 'cat /tmp/exec-visible.txt', {
+      timeoutMs: 10_000,
+      retryWindowMs: 12_000,
+    });
     expect(result.stdout).toBe('from api\n');
     expect(result.success).toBe(true);
   });
@@ -675,7 +678,10 @@ test.describe('File operations', () => {
     await uploadFile(sandboxId, '/tmp/space dir/space file.txt', 'spaced content');
     const downloaded = await downloadFile(sandboxId, '/tmp/space dir/space file.txt');
     expect(downloaded).toBe('spaced content');
-    const result = await exec(sandboxId, "cat '/tmp/space dir/space file.txt'");
+    const result = await execWithTransientRetry(sandboxId, "cat '/tmp/space dir/space file.txt'", {
+      timeoutMs: 10_000,
+      retryWindowMs: 12_000,
+    });
     expect(result.stdout).toBe('spaced content\n');
     expect(result.success).toBe(true);
   });

--- a/e2e/tests/sandbox-api.spec.ts
+++ b/e2e/tests/sandbox-api.spec.ts
@@ -100,6 +100,34 @@ test.describe('Exec', () => {
     expect(result.success).toBe(false);
   });
 
+  test('killed command process returns structured exec failure', async () => {
+    const result = await exec(
+      sandboxId,
+      `python3 -c "import os, signal; os.kill(os.getpid(), signal.SIGKILL)"`,
+    );
+    expect(result.success).toBe(false);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.timedOut).toBe(false);
+  });
+
+  test('killing daemon mid-exec returns sandbox exec stream error', async () => {
+    let execErr: unknown;
+    try {
+      // Kill PID1 shortly after exec starts so the stream usually ends mid-flight.
+      // Depending on timing/runtime, this can surface as a stream error or a
+      // structured failed exec result.
+      const result = await exec(sandboxId, 'sh -c "(sleep 0.1; kill -9 1) & sleep 5"');
+      expect(result.success).toBe(false);
+      expect(result.exitCode).not.toBe(0);
+    } catch (err) {
+      execErr = err;
+    }
+
+    if (execErr) {
+      expect(execErr).toBeInstanceOf(Error);
+    }
+  });
+
   test('environment variables as map', async () => {
     const result = await exec(sandboxId, 'echo $MY_VAR', {
       env: { MY_VAR: 'sandbox_test' },

--- a/e2e/tests/sandbox-api.spec.ts
+++ b/e2e/tests/sandbox-api.spec.ts
@@ -97,7 +97,10 @@ test.describe('Exec', () => {
   });
 
   test('non-zero exit code', async () => {
-    const result = await exec(sandboxId, 'exit 42');
+    const result = await execWithTransientRetry(sandboxId, 'exit 42', {
+      timeoutMs: 10_000,
+      retryWindowMs: 12_000,
+    });
     expect(result.exitCode).toBe(42);
     expect(result.success).toBe(false);
   });
@@ -209,6 +212,7 @@ test.describe('File operations', () => {
 
   test.beforeEach(async () => {
     sandboxId = await createSandbox();
+    await execWithTransientRetry(sandboxId, 'true', { timeoutMs: 5_000, retryWindowMs: 12_000 });
   });
 
   test.afterEach(async () => {
@@ -669,7 +673,10 @@ test.describe('File operations', () => {
   });
 
   test('file created by exec is downloadable via API', async () => {
-    await exec(sandboxId, 'echo -n "from exec" > /tmp/api-visible.txt');
+    await execWithTransientRetry(sandboxId, 'echo -n "from exec" > /tmp/api-visible.txt', {
+      timeoutMs: 10_000,
+      retryWindowMs: 12_000,
+    });
     const downloaded = await downloadFile(sandboxId, '/tmp/api-visible.txt');
     expect(downloaded).toBe('from exec');
   });

--- a/e2e/tests/sandbox-api.spec.ts
+++ b/e2e/tests/sandbox-api.spec.ts
@@ -153,12 +153,18 @@ test.describe('Exec', () => {
   });
 
   test('pipe commands via shell', async () => {
-    const result = await exec(sandboxId, 'echo hello | tr a-z A-Z');
+    const result = await execWithTransientRetry(sandboxId, 'echo hello | tr a-z A-Z', {
+      timeoutMs: 10_000,
+      retryWindowMs: 12_000,
+    });
     expect(result.stdout).toBe('HELLO\n');
   });
 
   test('tilde expands in shell command', async () => {
-    const result = await exec(sandboxId, 'echo ~/');
+    const result = await execWithTransientRetry(sandboxId, 'echo ~/', {
+      timeoutMs: 10_000,
+      retryWindowMs: 12_000,
+    });
     expect(result.stdout.trim()).toBe('/home/user/');
     expect(result.success).toBe(true);
   });

--- a/e2e/tests/sandbox-api.spec.ts
+++ b/e2e/tests/sandbox-api.spec.ts
@@ -4,6 +4,7 @@ import {
   createSandbox,
   deleteSandbox,
   exec,
+  execWithTransientRetry,
   uploadFile,
   downloadFile,
   apiRequest,
@@ -71,6 +72,7 @@ test.describe('Exec', () => {
 
   test.beforeEach(async () => {
     sandboxId = await createSandbox();
+    await execWithTransientRetry(sandboxId, 'true', { timeoutMs: 5_000, retryWindowMs: 12_000 });
   });
 
   test.afterEach(async () => {

--- a/e2e/tests/sandbox-recovery.spec.ts
+++ b/e2e/tests/sandbox-recovery.spec.ts
@@ -1,31 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { execFileSync } from 'node:child_process';
-import { createSandbox, deleteSandbox, exec } from './helpers';
-
-function docker(args: string[]): string {
-  return execFileSync('docker', args, {
-    stdio: ['pipe', 'pipe', 'pipe'],
-    encoding: 'utf8',
-  });
-}
-
-function innerContainerName(sandboxID: string): string {
-  return `sandbox-${sandboxID.slice(0, 12)}`;
-}
-
-function dockerOutput(args: string[]): string {
-  try {
-    return execFileSync('docker', args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      encoding: 'utf8',
-    });
-  } catch (err: unknown) {
-    const e = err as { stdout?: unknown; stderr?: unknown };
-    const stdout = e.stdout ? String(e.stdout) : '';
-    const stderr = e.stderr ? String(e.stderr) : '';
-    return `${stdout}\n${stderr}`.trim();
-  }
-}
+import { createSandbox, deleteSandbox, docker, dockerOutput, exec, innerContainerName } from './helpers';
 
 async function waitExecOK(sandboxID: string, command: string, deadlineMs: number): Promise<void> {
   const deadline = Date.now() + deadlineMs;
@@ -187,7 +161,6 @@ test.describe('Sandbox recovery on runner', () => {
     const id = await createSandbox();
     const innerName = innerContainerName(id);
     try {
-      docker(['exec', runnerContainer, 'docker', 'update', '--restart', 'no', innerName]);
       docker(['exec', runnerContainer, 'docker', 'stop', '--time', '0', innerName]);
 
       for (let i = 0; i < 2; i++) {

--- a/e2e/tests/sandbox-recovery.spec.ts
+++ b/e2e/tests/sandbox-recovery.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { execFileSync } from 'node:child_process';
 import { createSandbox, deleteSandbox, exec } from './helpers';
 
@@ -43,6 +43,23 @@ async function waitExecOK(sandboxID: string, command: string, deadlineMs: number
     await new Promise((r) => setTimeout(r, 500));
   }
   throw new Error(`sandbox ${sandboxID} did not recover in ${deadlineMs}ms: ${String(lastErr)}`);
+}
+
+async function waitExec503(sandboxID: string, command: string, deadlineMs: number): Promise<void> {
+  const deadline = Date.now() + deadlineMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await exec(sandboxID, command);
+    } catch (err) {
+      lastErr = err;
+      if ((err as { status?: number })?.status === 503) {
+        return;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  throw new Error(`sandbox ${sandboxID} did not return 503 within ${deadlineMs}ms: ${String(lastErr)}`);
 }
 
 function inspectRestartState(
@@ -137,6 +154,50 @@ test.describe('Sandbox recovery on runner', () => {
 
       await waitContainerRestarted(runnerContainer, innerName, before, 90_000);
       await waitExecOK(id, `printf '%s' after-restart`, 90_000);
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+
+  test('client sees 503 while sandbox is restarting, then recovers', async () => {
+    test.skip(!process.env.E2E_RUNNER_CONTAINER_NAME, 'needs E2E_RUNNER_CONTAINER_NAME (from e2e/run.sh)');
+    test.setTimeout(60_000);
+
+    const runnerContainer = process.env.E2E_RUNNER_CONTAINER_NAME!;
+    const id = await createSandbox();
+    const innerName = innerContainerName(id);
+    try {
+      // Restart sequence, phase 1: stop -> expect 503.
+      docker(['exec', runnerContainer, 'docker', 'stop', '--time', '0', innerName]);
+      await waitExec503(id, 'true', 5_000);
+
+      // Restart sequence, phase 2: start -> expect recovery.
+      docker(['exec', runnerContainer, 'docker', 'start', innerName]);
+      await waitExecOK(id, `printf '%s' recovered`, 30_000);
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+
+  test('client sees 503 when sandbox is permanently stopped', async () => {
+    test.skip(!process.env.E2E_RUNNER_CONTAINER_NAME, 'needs E2E_RUNNER_CONTAINER_NAME (from e2e/run.sh)');
+    test.setTimeout(60_000);
+
+    const runnerContainer = process.env.E2E_RUNNER_CONTAINER_NAME!;
+    const id = await createSandbox();
+    const innerName = innerContainerName(id);
+    try {
+      docker(['exec', runnerContainer, 'docker', 'update', '--restart', 'no', innerName]);
+      docker(['exec', runnerContainer, 'docker', 'stop', '--time', '0', innerName]);
+
+      for (let i = 0; i < 2; i++) {
+        try {
+          await exec(id, 'true');
+          throw new Error('expected 503 while sandbox is stopped');
+        } catch (err) {
+          expect((err as { status?: number })?.status).toBe(503);
+        }
+      }
     } finally {
       await deleteSandbox(id);
     }

--- a/e2e/tests/sandbox-recovery.spec.ts
+++ b/e2e/tests/sandbox-recovery.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import { execFileSync } from 'node:child_process';
 import { createSandbox, deleteSandbox, exec } from './helpers';
 
@@ -27,22 +27,6 @@ function dockerOutput(args: string[]): string {
   }
 }
 
-function enableOOMGroupIfSupported(runnerContainer: string, innerName: string): boolean {
-  const out = dockerOutput([
-    'exec',
-    runnerContainer,
-    'docker',
-    'exec',
-    '--user',
-    '0:0',
-    innerName,
-    'sh',
-    '-c',
-    "if [ -w /sys/fs/cgroup/memory.oom.group ]; then echo 1 > /sys/fs/cgroup/memory.oom.group; cat /sys/fs/cgroup/memory.oom.group; else echo UNSUPPORTED; fi",
-  ]).trim();
-  return out === '1';
-}
-
 async function waitExecOK(sandboxID: string, command: string, deadlineMs: number): Promise<void> {
   const deadline = Date.now() + deadlineMs;
   let lastErr: unknown;
@@ -61,28 +45,32 @@ async function waitExecOK(sandboxID: string, command: string, deadlineMs: number
   throw new Error(`sandbox ${sandboxID} did not recover in ${deadlineMs}ms: ${String(lastErr)}`);
 }
 
-function inspectRestartState(runnerContainer: string, innerName: string): { restartCount: number; running: boolean; oomKilled: boolean } {
+function inspectRestartState(
+  runnerContainer: string,
+  innerName: string,
+): { restartCount: number; running: boolean; oomKilled: boolean; startedAt: string } {
   const out = docker([
     'exec',
     runnerContainer,
     'docker',
     'inspect',
     '--format',
-    '{{.RestartCount}} {{.State.Running}} {{.State.OOMKilled}}',
+    '{{.RestartCount}} {{.State.Running}} {{.State.OOMKilled}} {{.State.StartedAt}}',
     innerName,
   ]).trim();
-  const [restartCountRaw, runningRaw, oomKilledRaw] = out.split(/\s+/);
+  const [restartCountRaw, runningRaw, oomKilledRaw, startedAtRaw] = out.split(/\s+/);
   return {
     restartCount: Number.parseInt(restartCountRaw || '0', 10),
     running: runningRaw === 'true',
     oomKilled: oomKilledRaw === 'true',
+    startedAt: startedAtRaw || '',
   };
 }
 
-async function waitContainerRestartedByOOM(
+async function waitContainerRestarted(
   runnerContainer: string,
   innerName: string,
-  baselineRestartCount: number,
+  baseline: { restartCount: number; startedAt: string },
   deadlineMs: number,
 ): Promise<void> {
   const deadline = Date.now() + deadlineMs;
@@ -91,11 +79,9 @@ async function waitContainerRestartedByOOM(
   while (Date.now() < deadline) {
     try {
       const st = inspectRestartState(runnerContainer, innerName);
-      lastState = `restartCount=${st.restartCount} running=${st.running} oomKilled=${st.oomKilled}`;
+      lastState = `restartCount=${st.restartCount} running=${st.running} oomKilled=${st.oomKilled} startedAt=${st.startedAt}`;
       timeline.push(`${new Date().toISOString()} ${lastState}`);
-      // Some Docker/cgroup setups don't keep OOMKilled=true after restart, so the
-      // robust signal is restart count increase + running again.
-      if (st.restartCount > baselineRestartCount && st.running) {
+      if (st.running && (st.restartCount > baseline.restartCount || st.startedAt != baseline.startedAt)) {
         return;
       }
     } catch {
@@ -120,7 +106,7 @@ async function waitContainerRestartedByOOM(
     innerName,
   ]);
   throw new Error(
-    `container ${innerName} was not observed as OOM-restarted within ${deadlineMs}ms (${lastState})\n\n` +
+    `container ${innerName} was not observed as restarted within ${deadlineMs}ms (${lastState})\n\n` +
       `===== state timeline =====\n${timeline.join('\n')}\n\n` +
       `===== docker inspect ${innerName} =====\n${inspectDump}\n\n` +
       `===== docker logs ${innerName} =====\n${logsDump}`,
@@ -128,7 +114,7 @@ async function waitContainerRestartedByOOM(
 }
 
 test.describe('Sandbox recovery on runner', () => {
-  test('OOM-killed sandbox container is restarted and reachable with same sandbox id', async () => {
+  test('sandbox container restart keeps same sandbox id reachable', async () => {
     test.skip(!process.env.E2E_RUNNER_CONTAINER_NAME, 'needs E2E_RUNNER_CONTAINER_NAME (from e2e/run.sh)');
     test.setTimeout(150_000);
 
@@ -137,34 +123,20 @@ test.describe('Sandbox recovery on runner', () => {
     const innerName = innerContainerName(id);
     try {
       const before = inspectRestartState(runnerContainer, innerName);
-      // Tighten memory so the allocation loop OOM-kills the container quickly.
-      docker(['exec', runnerContainer, 'docker', 'update', '--memory', '64m', '--memory-swap', '64m', innerName]);
-      // Restart assertion is only deterministic when we can set memory.oom.group=1:
-      // then OOM kills the whole sandbox cgroup (including PID1/daemon), triggering
-      // Docker restart policy. Without this support, OOM may kill only the child process.
-      test.skip(
-        !enableOOMGroupIfSupported(runnerContainer, innerName),
-        'cgroup memory.oom.group not supported; cannot deterministically assert container restart on OOM',
-      );
+      // Force a full container restart from runner-side Docker and verify the
+      // sandbox ID remains usable afterwards.
+      docker([
+        'exec',
+        runnerContainer,
+        'docker',
+        'restart',
+        '--time',
+        '0',
+        innerName,
+      ]);
 
-      // Trigger memory pressure from inside the sandbox.
-      try {
-        docker([
-          'exec',
-          runnerContainer,
-          'docker',
-          'exec',
-          innerName,
-          'python3',
-          '-c',
-          "chunks=[]\nwhile True:\n chunks.append('x'*16*1024*1024)",
-        ]);
-      } catch {
-        // Expected: process/container should be killed by OOM.
-      }
-
-      await waitContainerRestartedByOOM(runnerContainer, innerName, before.restartCount, 90_000);
-      await waitExecOK(id, `printf '%s' after-oom`, 90_000);
+      await waitContainerRestarted(runnerContainer, innerName, before, 90_000);
+      await waitExecOK(id, `printf '%s' after-restart`, 90_000);
     } finally {
       await deleteSandbox(id);
     }

--- a/e2e/tests/sandbox-recovery.spec.ts
+++ b/e2e/tests/sandbox-recovery.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import { createSandbox, deleteSandbox, exec } from './helpers';
+
+function docker(args: string[]): string {
+  return execFileSync('docker', args, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  });
+}
+
+function innerContainerName(sandboxID: string): string {
+  return `sandbox-${sandboxID.slice(0, 12)}`;
+}
+
+function dockerOutput(args: string[]): string {
+  try {
+    return execFileSync('docker', args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    });
+  } catch (err: unknown) {
+    const e = err as { stdout?: unknown; stderr?: unknown };
+    const stdout = e.stdout ? String(e.stdout) : '';
+    const stderr = e.stderr ? String(e.stderr) : '';
+    return `${stdout}\n${stderr}`.trim();
+  }
+}
+
+function enableOOMGroupIfSupported(runnerContainer: string, innerName: string): boolean {
+  const out = dockerOutput([
+    'exec',
+    runnerContainer,
+    'docker',
+    'exec',
+    '--user',
+    '0:0',
+    innerName,
+    'sh',
+    '-c',
+    "if [ -w /sys/fs/cgroup/memory.oom.group ]; then echo 1 > /sys/fs/cgroup/memory.oom.group; cat /sys/fs/cgroup/memory.oom.group; else echo UNSUPPORTED; fi",
+  ]).trim();
+  return out === '1';
+}
+
+async function waitExecOK(sandboxID: string, command: string, deadlineMs: number): Promise<void> {
+  const deadline = Date.now() + deadlineMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const out = await exec(sandboxID, command);
+      if (out.exitCode === 0) {
+        return;
+      }
+      lastErr = new Error(`non-zero exit code ${out.exitCode}`);
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`sandbox ${sandboxID} did not recover in ${deadlineMs}ms: ${String(lastErr)}`);
+}
+
+function inspectRestartState(runnerContainer: string, innerName: string): { restartCount: number; running: boolean; oomKilled: boolean } {
+  const out = docker([
+    'exec',
+    runnerContainer,
+    'docker',
+    'inspect',
+    '--format',
+    '{{.RestartCount}} {{.State.Running}} {{.State.OOMKilled}}',
+    innerName,
+  ]).trim();
+  const [restartCountRaw, runningRaw, oomKilledRaw] = out.split(/\s+/);
+  return {
+    restartCount: Number.parseInt(restartCountRaw || '0', 10),
+    running: runningRaw === 'true',
+    oomKilled: oomKilledRaw === 'true',
+  };
+}
+
+async function waitContainerRestartedByOOM(
+  runnerContainer: string,
+  innerName: string,
+  baselineRestartCount: number,
+  deadlineMs: number,
+): Promise<void> {
+  const deadline = Date.now() + deadlineMs;
+  let lastState = 'unavailable';
+  const timeline: string[] = [];
+  while (Date.now() < deadline) {
+    try {
+      const st = inspectRestartState(runnerContainer, innerName);
+      lastState = `restartCount=${st.restartCount} running=${st.running} oomKilled=${st.oomKilled}`;
+      timeline.push(`${new Date().toISOString()} ${lastState}`);
+      // Some Docker/cgroup setups don't keep OOMKilled=true after restart, so the
+      // robust signal is restart count increase + running again.
+      if (st.restartCount > baselineRestartCount && st.running) {
+        return;
+      }
+    } catch {
+      // transient inspect failures while container is restarting
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  const inspectDump = dockerOutput([
+    'exec',
+    runnerContainer,
+    'docker',
+    'inspect',
+    innerName,
+  ]);
+  const logsDump = dockerOutput([
+    'exec',
+    runnerContainer,
+    'docker',
+    'logs',
+    '--tail',
+    '200',
+    innerName,
+  ]);
+  throw new Error(
+    `container ${innerName} was not observed as OOM-restarted within ${deadlineMs}ms (${lastState})\n\n` +
+      `===== state timeline =====\n${timeline.join('\n')}\n\n` +
+      `===== docker inspect ${innerName} =====\n${inspectDump}\n\n` +
+      `===== docker logs ${innerName} =====\n${logsDump}`,
+  );
+}
+
+test.describe('Sandbox recovery on runner', () => {
+  test('OOM-killed sandbox container is restarted and reachable with same sandbox id', async () => {
+    test.skip(!process.env.E2E_RUNNER_CONTAINER_NAME, 'needs E2E_RUNNER_CONTAINER_NAME (from e2e/run.sh)');
+    test.setTimeout(150_000);
+
+    const runnerContainer = process.env.E2E_RUNNER_CONTAINER_NAME!;
+    const id = await createSandbox();
+    const innerName = innerContainerName(id);
+    try {
+      const before = inspectRestartState(runnerContainer, innerName);
+      // Tighten memory so the allocation loop OOM-kills the container quickly.
+      docker(['exec', runnerContainer, 'docker', 'update', '--memory', '64m', '--memory-swap', '64m', innerName]);
+      // Restart assertion is only deterministic when we can set memory.oom.group=1:
+      // then OOM kills the whole sandbox cgroup (including PID1/daemon), triggering
+      // Docker restart policy. Without this support, OOM may kill only the child process.
+      test.skip(
+        !enableOOMGroupIfSupported(runnerContainer, innerName),
+        'cgroup memory.oom.group not supported; cannot deterministically assert container restart on OOM',
+      );
+
+      // Trigger memory pressure from inside the sandbox.
+      try {
+        docker([
+          'exec',
+          runnerContainer,
+          'docker',
+          'exec',
+          innerName,
+          'python3',
+          '-c',
+          "chunks=[]\nwhile True:\n chunks.append('x'*16*1024*1024)",
+        ]);
+      } catch {
+        // Expected: process/container should be killed by OOM.
+      }
+
+      await waitContainerRestartedByOOM(runnerContainer, innerName, before.restartCount, 90_000);
+      await waitExecOK(id, `printf '%s' after-oom`, 90_000);
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+});

--- a/e2e/tests/sandbox-recovery.spec.ts
+++ b/e2e/tests/sandbox-recovery.spec.ts
@@ -19,7 +19,8 @@ async function waitExecOK(sandboxID: string, command: string, deadlineMs: number
   throw new Error(`sandbox ${sandboxID} did not recover in ${deadlineMs}ms: ${String(lastErr)}`);
 }
 
-async function waitExec503(sandboxID: string, command: string, deadlineMs: number): Promise<void> {
+/** Wait until exec fails with 502 (inner container stopped — not retryable per API contract). */
+async function waitExec502(sandboxID: string, command: string, deadlineMs: number): Promise<void> {
   const deadline = Date.now() + deadlineMs;
   let lastErr: unknown;
   while (Date.now() < deadline) {
@@ -27,13 +28,13 @@ async function waitExec503(sandboxID: string, command: string, deadlineMs: numbe
       await exec(sandboxID, command);
     } catch (err) {
       lastErr = err;
-      if ((err as { status?: number })?.status === 503) {
+      if ((err as { status?: number })?.status === 502) {
         return;
       }
     }
     await new Promise((r) => setTimeout(r, 150));
   }
-  throw new Error(`sandbox ${sandboxID} did not return 503 within ${deadlineMs}ms: ${String(lastErr)}`);
+  throw new Error(`sandbox ${sandboxID} did not return 502 within ${deadlineMs}ms: ${String(lastErr)}`);
 }
 
 function inspectRestartState(
@@ -133,7 +134,7 @@ test.describe('Sandbox recovery on runner', () => {
     }
   });
 
-  test('client sees 503 while sandbox is restarting, then recovers', async () => {
+  test('client sees 502 while inner container is stopped, then recovers', async () => {
     test.skip(!process.env.E2E_RUNNER_CONTAINER_NAME, 'needs E2E_RUNNER_CONTAINER_NAME (from e2e/run.sh)');
     test.setTimeout(60_000);
 
@@ -141,9 +142,9 @@ test.describe('Sandbox recovery on runner', () => {
     const id = await createSandbox();
     const innerName = innerContainerName(id);
     try {
-      // Restart sequence, phase 1: stop -> expect 503.
+      // Restart sequence, phase 1: stop -> expect 502 (sandbox not running).
       docker(['exec', runnerContainer, 'docker', 'stop', '--time', '0', innerName]);
-      await waitExec503(id, 'true', 5_000);
+      await waitExec502(id, 'true', 5_000);
 
       // Restart sequence, phase 2: start -> expect recovery.
       docker(['exec', runnerContainer, 'docker', 'start', innerName]);
@@ -153,7 +154,7 @@ test.describe('Sandbox recovery on runner', () => {
     }
   });
 
-  test('client sees 503 when sandbox is permanently stopped', async () => {
+  test('client sees 502 when sandbox is permanently stopped', async () => {
     test.skip(!process.env.E2E_RUNNER_CONTAINER_NAME, 'needs E2E_RUNNER_CONTAINER_NAME (from e2e/run.sh)');
     test.setTimeout(60_000);
 
@@ -166,9 +167,9 @@ test.describe('Sandbox recovery on runner', () => {
       for (let i = 0; i < 2; i++) {
         try {
           await exec(id, 'true');
-          throw new Error('expected 503 while sandbox is stopped');
+          throw new Error('expected 502 while sandbox is stopped');
         } catch (err) {
-          expect((err as { status?: number })?.status).toBe(503);
+          expect((err as { status?: number })?.status).toBe(502);
         }
       }
     } finally {

--- a/internal/runner/grpc_control.go
+++ b/internal/runner/grpc_control.go
@@ -89,14 +89,7 @@ func (s *SandboxControlGRPC) DeleteSandbox(ctx context.Context, req *pb.DeleteSa
 		}
 		return nil, toGRPCError(err)
 	}
-	cinfo, err := s.Mgr.GetContainerInfo(ctx, containerID)
-	if err != nil {
-		if errors.Is(err, manager.ErrSandboxNotFound) {
-			return &pb.DeleteSandboxResponse{}, nil
-		}
-		return nil, toGRPCError(err)
-	}
-	if err := s.Mgr.DeleteContainer(ctx, containerID, cinfo.IP); err != nil {
+	if err := s.Mgr.DeleteContainer(ctx, containerID); err != nil {
 		return nil, toGRPCError(err)
 	}
 	return &pb.DeleteSandboxResponse{}, nil

--- a/internal/runner/handlers.go
+++ b/internal/runner/handlers.go
@@ -129,18 +129,7 @@ func DeleteSandbox(mgr ContainerManager) http.HandlerFunc {
 			return
 		}
 
-		// Get container info to get IP
-		containerInfo, err := mgr.GetContainerInfo(r.Context(), containerID)
-		if err != nil {
-			if errors.Is(err, manager.ErrSandboxNotFound) {
-				writeError(w, http.StatusNotFound, err.Error())
-			} else {
-				writeError(w, http.StatusInternalServerError, err.Error())
-			}
-			return
-		}
-
-		if err := mgr.DeleteContainer(r.Context(), containerID, containerInfo.IP); err != nil {
+		if err := mgr.DeleteContainer(r.Context(), containerID); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}

--- a/internal/runner/manager/manager.go
+++ b/internal/runner/manager/manager.go
@@ -210,7 +210,7 @@ func (m *Manager) DaemonURL(ctx context.Context, sandboxID string) (string, erro
 
 	network, ok := inspect.NetworkSettings.Networks[runnerBridgeNetwork]
 	if !ok || network.IPAddress == "" {
-		return "", fmt.Errorf("container %s has no IP on %s", containerID, runnerBridgeNetwork)
+		return "", fmt.Errorf("%w: container %s has no IP on %s", ErrSandboxNetworkUnavailable, containerID, runnerBridgeNetwork)
 	}
 
 	baseURL := fmt.Sprintf("http://%s:%d", network.IPAddress, daemonPort)

--- a/internal/runner/manager/manager.go
+++ b/internal/runner/manager/manager.go
@@ -301,11 +301,15 @@ func waitForDaemon(ctx context.Context, baseURL string) error {
 				continue
 			}
 			// Daemon /exec streams NDJSON events; require a successful exit event.
-			if bytes.Contains(body, []byte(`"type":"exit"`)) && bytes.Contains(body, []byte(`"exit_code":0`)) {
+			if isSuccessfulExit(body) {
 				return nil
 			}
 		}
 	}
+}
+
+func isSuccessfulExit(body []byte) bool {
+	return bytes.Contains(body, []byte(`"type":"exit"`)) && bytes.Contains(body, []byte(`"exit_code":0`))
 }
 
 func (m *Manager) reconcileContainers(ctx context.Context) error {

--- a/internal/runner/manager/manager.go
+++ b/internal/runner/manager/manager.go
@@ -19,12 +19,15 @@ import (
 	"github.com/n8n-io/sandbox-service/internal/runner/netrules"
 )
 
-// ErrSandboxNotFound is returned when a sandbox ID is not found or not running.
+// ErrSandboxNotFound is returned when a sandbox ID is not found.
 var ErrSandboxNotFound = errors.New("sandbox not found")
 
 // ErrSandboxNetworkUnavailable is returned when a container exists but has no
 // network attachment/IP yet.
 var ErrSandboxNetworkUnavailable = errors.New("sandbox network unavailable")
+
+// ErrSandboxNotRunning is returned when a sandbox container exists but is not running.
+var ErrSandboxNotRunning = errors.New("sandbox not running")
 
 const (
 	StatusRunning            = "running"
@@ -202,7 +205,7 @@ func (m *Manager) DaemonURL(ctx context.Context, sandboxID string) (string, erro
 		return "", err
 	}
 	if !inspect.State.Running {
-		return "", ErrSandboxNotFound
+		return "", ErrSandboxNotRunning
 	}
 
 	network, ok := inspect.NetworkSettings.Networks[runnerBridgeNetwork]

--- a/internal/runner/manager/manager.go
+++ b/internal/runner/manager/manager.go
@@ -201,22 +201,8 @@ func (m *Manager) DaemonURL(ctx context.Context, sandboxID string) (string, erro
 		}
 		return "", err
 	}
-	wasStarted := false
 	if !inspect.State.Running {
-		if err := m.startContainer(ctx, containerID); err != nil {
-			if isDockerNotFound(err) {
-				return "", ErrSandboxNotFound
-			}
-			return "", err
-		}
-		wasStarted = true
-		inspect, err = m.inspectContainer(ctx, containerID)
-		if err != nil {
-			if isDockerNotFound(err) {
-				return "", ErrSandboxNotFound
-			}
-			return "", err
-		}
+		return "", ErrSandboxNotFound
 	}
 
 	network, ok := inspect.NetworkSettings.Networks[runnerBridgeNetwork]
@@ -225,12 +211,6 @@ func (m *Manager) DaemonURL(ctx context.Context, sandboxID string) (string, erro
 	}
 
 	baseURL := fmt.Sprintf("http://%s:%d", network.IPAddress, daemonPort)
-	if wasStarted {
-		// When recovering a stopped container, wait for daemon readiness before proxying.
-		if err := waitForDaemon(ctx, baseURL); err != nil {
-			return "", err
-		}
-	}
 	return baseURL, nil
 }
 

--- a/internal/runner/manager/manager.go
+++ b/internal/runner/manager/manager.go
@@ -22,6 +22,10 @@ import (
 // ErrSandboxNotFound is returned when a sandbox ID is not found or not running.
 var ErrSandboxNotFound = errors.New("sandbox not found")
 
+// ErrSandboxNetworkUnavailable is returned when a container exists but has no
+// network attachment/IP yet.
+var ErrSandboxNetworkUnavailable = errors.New("sandbox network unavailable")
+
 const (
 	StatusRunning            = "running"
 	StatusTerminated         = "terminated"
@@ -121,11 +125,7 @@ func (m *Manager) CreateContainer(ctx context.Context, sandboxID string, opts *C
 	}
 
 	cleanupOnError := func(containerIP string) {
-		if containerIP != "" {
-			if err := netrules.Teardown(containerID, containerIP); err != nil {
-				slog.Warn("teardown network rules", "container_id", containerID, "err", err)
-			}
-		} else if err := netrules.Teardown(containerID, ""); err != nil {
+		if err := netrules.Teardown(containerID); err != nil {
 			slog.Warn("teardown network rules", "container_id", containerID, "err", err)
 		}
 		if err := m.removeContainer(ctx, containerID); err != nil {
@@ -177,7 +177,7 @@ func (m *Manager) GetContainerInfo(ctx context.Context, containerID string) (*Co
 
 	network, ok := inspect.NetworkSettings.Networks[runnerBridgeNetwork]
 	if !ok || network.IPAddress == "" {
-		return nil, fmt.Errorf("container %s has no IP on %s", containerID, runnerBridgeNetwork)
+		return nil, fmt.Errorf("%w: container %s has no IP on %s", ErrSandboxNetworkUnavailable, containerID, runnerBridgeNetwork)
 	}
 
 	return &ContainerInfo{
@@ -235,8 +235,8 @@ func (m *Manager) DaemonURL(ctx context.Context, sandboxID string) (string, erro
 }
 
 // DeleteContainer stops and removes a container.
-func (m *Manager) DeleteContainer(ctx context.Context, containerID, containerIP string) error {
-	if err := netrules.Teardown(containerID, containerIP); err != nil {
+func (m *Manager) DeleteContainer(ctx context.Context, containerID string) error {
+	if err := netrules.Teardown(containerID); err != nil {
 		slog.Warn("teardown network rules", "container_id", containerID, "err", err)
 	}
 
@@ -270,7 +270,7 @@ func (m *Manager) defaultLimits() *ResourceLimits {
 }
 
 func waitForDaemon(ctx context.Context, baseURL string) error {
-	httpClient := &http.Client{Timeout: time.Second}
+	httpClient := &http.Client{Timeout: 3 * time.Second}
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
 	deadline := time.After(30 * time.Second)
@@ -292,7 +292,33 @@ func waitForDaemon(ctx context.Context, baseURL string) error {
 			}
 			io.Copy(io.Discard, resp.Body)
 			resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
+			if resp.StatusCode != http.StatusOK {
+				continue
+			}
+
+			// /healthz can become ready slightly before command execution is fully
+			// usable under load; require a tiny exec round-trip before returning.
+			execReq, err := http.NewRequestWithContext(
+				ctx,
+				http.MethodPost,
+				baseURL+"/exec",
+				bytes.NewBufferString(`{"command":"true","timeout_ms":2000}`),
+			)
+			if err != nil {
+				return err
+			}
+			execReq.Header.Set("Content-Type", "application/json")
+			execResp, err := httpClient.Do(execReq)
+			if err != nil {
+				continue
+			}
+			body, _ := io.ReadAll(execResp.Body)
+			execResp.Body.Close()
+			if execResp.StatusCode != http.StatusOK {
+				continue
+			}
+			// Daemon /exec streams NDJSON events; require a successful exit event.
+			if bytes.Contains(body, []byte(`"type":"exit"`)) && bytes.Contains(body, []byte(`"exit_code":0`)) {
 				return nil
 			}
 		}
@@ -305,12 +331,12 @@ func (m *Manager) reconcileContainers(ctx context.Context) error {
 		return err
 	}
 	for _, id := range ids {
-		inspect, inspectErr := m.inspectContainer(ctx, id)
+		_, inspectErr := m.inspectContainer(ctx, id)
 		if inspectErr == nil {
-			if err := netrules.Teardown(id, inspect.NetworkSettings.Networks[runnerBridgeNetwork].IPAddress); err != nil {
+			if err := netrules.Teardown(id); err != nil {
 				slog.Warn("teardown rules during reconcile", "container_id", id, "err", err)
 			}
-		} else if err := netrules.Teardown(id, ""); err != nil {
+		} else if err := netrules.Teardown(id); err != nil {
 			slog.Warn("teardown rules during reconcile", "container_id", id, "err", err)
 		}
 		if err := m.removeContainer(ctx, id); err != nil {

--- a/internal/runner/manager/manager.go
+++ b/internal/runner/manager/manager.go
@@ -49,8 +49,11 @@ type Manager struct {
 }
 
 type containerInspect struct {
-	ID     string `json:"Id"`
-	Name   string `json:"Name"`
+	ID    string `json:"Id"`
+	Name  string `json:"Name"`
+	State struct {
+		Running bool `json:"Running"`
+	} `json:"State"`
 	Config struct {
 		Labels map[string]string `json:"Labels"`
 	} `json:"Config"`
@@ -190,11 +193,45 @@ func (m *Manager) DaemonURL(ctx context.Context, sandboxID string) (string, erro
 	if err != nil {
 		return "", err
 	}
-	info, err := m.GetContainerInfo(ctx, containerID)
+
+	inspect, err := m.inspectContainer(ctx, containerID)
 	if err != nil {
+		if isDockerNotFound(err) {
+			return "", ErrSandboxNotFound
+		}
 		return "", err
 	}
-	return fmt.Sprintf("http://%s:%d", info.IP, daemonPort), nil
+	wasStarted := false
+	if !inspect.State.Running {
+		if err := m.startContainer(ctx, containerID); err != nil {
+			if isDockerNotFound(err) {
+				return "", ErrSandboxNotFound
+			}
+			return "", err
+		}
+		wasStarted = true
+		inspect, err = m.inspectContainer(ctx, containerID)
+		if err != nil {
+			if isDockerNotFound(err) {
+				return "", ErrSandboxNotFound
+			}
+			return "", err
+		}
+	}
+
+	network, ok := inspect.NetworkSettings.Networks[runnerBridgeNetwork]
+	if !ok || network.IPAddress == "" {
+		return "", fmt.Errorf("container %s has no IP on %s", containerID, runnerBridgeNetwork)
+	}
+
+	baseURL := fmt.Sprintf("http://%s:%d", network.IPAddress, daemonPort)
+	if wasStarted {
+		// When recovering a stopped container, wait for daemon readiness before proxying.
+		if err := waitForDaemon(ctx, baseURL); err != nil {
+			return "", err
+		}
+	}
+	return baseURL, nil
 }
 
 // DeleteContainer stops and removes a container.
@@ -343,6 +380,7 @@ func (m *Manager) createContainer(ctx context.Context, sandboxID, containerName,
 		"container", "create",
 		"--name", containerName,
 		"--hostname", "sandbox",
+		"--restart", "unless-stopped",
 		"--network", runnerBridgeNetwork,
 		"--label", containerLabelManaged + "=" + containerLabelManagedVal,
 		"--label", containerLabelSandboxID + "=" + sandboxID,

--- a/internal/runner/netrules/netrules.go
+++ b/internal/runner/netrules/netrules.go
@@ -46,7 +46,7 @@ func ApplyPolicy(containerID, sourceIP, gatewayIP string, daemonPort int) error 
 	if err := ensureDockerUserChain(); err != nil {
 		return err
 	}
-	if err := Teardown(containerID, sourceIP); err != nil {
+	if err := Teardown(containerID); err != nil {
 		return err
 	}
 
@@ -90,7 +90,7 @@ func ApplyPolicy(containerID, sourceIP, gatewayIP string, daemonPort int) error 
 }
 
 // Teardown removes per-sandbox iptables rules and chains.
-func Teardown(containerID, sourceIP string) error {
+func Teardown(containerID string) error {
 	if containerID == "" {
 		return nil
 	}

--- a/internal/runner/proxy.go
+++ b/internal/runner/proxy.go
@@ -57,7 +57,7 @@ func proxyHandler(mgr ContainerManager, cfg *config.Config, limitBody bool) http
 				writeError(w, http.StatusBadRequest, "failed to read request body: http: request body too large")
 				return
 			}
-			writeError(w, http.StatusBadGateway, "daemon unreachable")
+			writeError(w, http.StatusServiceUnavailable, "daemon temporarily unavailable")
 		},
 	}
 
@@ -72,8 +72,10 @@ func proxyHandler(mgr ContainerManager, cfg *config.Config, limitBody bool) http
 		if err != nil {
 			if errors.Is(err, manager.ErrSandboxNotFound) {
 				writeError(w, http.StatusNotFound, err.Error())
-			} else if errors.Is(err, manager.ErrSandboxNotRunning) || errors.Is(err, manager.ErrSandboxNetworkUnavailable) {
-				writeError(w, http.StatusServiceUnavailable, "sandbox unavailable")
+			} else if errors.Is(err, manager.ErrSandboxNotRunning) {
+				writeError(w, http.StatusBadGateway, manager.ErrSandboxNotRunning.Error())
+			} else if errors.Is(err, manager.ErrSandboxNetworkUnavailable) {
+				writeError(w, http.StatusServiceUnavailable, "sandbox temporarily unavailable")
 			} else {
 				writeError(w, http.StatusInternalServerError, err.Error())
 			}

--- a/internal/runner/proxy.go
+++ b/internal/runner/proxy.go
@@ -72,6 +72,8 @@ func proxyHandler(mgr ContainerManager, cfg *config.Config, limitBody bool) http
 		if err != nil {
 			if errors.Is(err, manager.ErrSandboxNotFound) {
 				writeError(w, http.StatusNotFound, err.Error())
+			} else if errors.Is(err, manager.ErrSandboxNotRunning) || errors.Is(err, manager.ErrSandboxNetworkUnavailable) {
+				writeError(w, http.StatusServiceUnavailable, "sandbox unavailable")
 			} else {
 				writeError(w, http.StatusInternalServerError, err.Error())
 			}

--- a/internal/runner/server.go
+++ b/internal/runner/server.go
@@ -13,7 +13,7 @@ import (
 type ContainerManager interface {
 	CreateContainer(ctx context.Context, sandboxID string, opts *manager.CreateOptions) (*manager.ContainerInfo, error)
 	GetContainerInfo(ctx context.Context, containerID string) (*manager.ContainerInfo, error)
-	DeleteContainer(ctx context.Context, containerID, containerIP string) error
+	DeleteContainer(ctx context.Context, containerID string) error
 	DaemonURL(ctx context.Context, containerID string) (string, error)
 	FindContainerIDByLabel(ctx context.Context, sandboxID string) (string, error)
 }

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -19,6 +19,18 @@ const client = new SandboxClient({
 });
 ```
 
+### Retries (`retry` option)
+
+By default the client retries transient failures: 3 extra attempts (four tries total), backoff with jitter, and HTTP statuses `429` and `503` (plus transport errors, represented as status `0`). `502` is not in the default retry set — the service uses it when repeating the same request is unlikely to help.
+
+- Turn off retries: `retry: { attempts: 0 }`.
+- Tune backoff: `retry: { attempts: 5, baseDelayMs: 100, maxDelayMs: 30_000, jitter: false }`.
+- Also retry other statuses (only if you accept the risk): `retry: { retryOnStatuses: [429, 502, 503] }`.
+- Idempotent methods (`GET`, `HEAD`, `OPTIONS`, `PUT`, `DELETE`) use this policy automatically.
+- `POST` is not retried unless you set `isSafeToRetry: true` on that specific request (for example when the server makes the operation idempotent, as with `exec_id` on exec).
+
+`exec` still has its own stream resume loop (`exec_id`, `POST` then `GET` follow). Constructor `retry` applies to each underlying HTTP call (so `GET` resume lines benefit from the default policy). It does not replace the exec event/state machine.
+
 ### Sandbox lifecycle
 
 ```ts

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -36,7 +36,7 @@ export class SandboxClient {
    * Creates a sandbox service client.
    */
   constructor(options: SandboxClientOptions) {
-    this.http = new HttpClient(options.baseUrl ?? "", options.apiKey);
+    this.http = new HttpClient(options.baseUrl ?? "", options.apiKey, options.retry);
   }
 
   // #region Sandbox lifecycle

--- a/sdk/src/http.ts
+++ b/sdk/src/http.ts
@@ -9,7 +9,7 @@ export interface RequestOptions {
   headers?: Record<string, string>;
   signal?: AbortSignal;
   /** Allow retry on non-idempotent methods (e.g. POST). Default false. */
-  retryUnsafe?: boolean;
+  isSafeToRetry?: boolean;
 }
 
 interface NormalizedRetryOptions {
@@ -37,7 +37,7 @@ export class HttpClient {
     this.retry = {
       attempts: Math.max(0, retry?.attempts ?? 0),
       baseDelayMs: Math.max(0, retry?.baseDelayMs ?? 200),
-      maxDelayMs: Math.max(0, retry?.maxDelayMs ?? 2000),
+      maxDelayMs: Math.max(0, retry?.maxDelayMs ?? 10000),
       retryOnStatuses: new Set(retry?.retryOnStatuses ?? [429, 502, 503]),
       jitter: retry?.jitter ?? true,
     };
@@ -54,7 +54,7 @@ export class HttpClient {
         signal: options.signal,
       });
       return response.data;
-    }, method, options.signal, options.retryUnsafe === true);
+    }, method, options.signal, options.isSafeToRetry === true);
   }
 
   async requestStream(
@@ -80,7 +80,7 @@ export class HttpClient {
       }
 
       return { stream: response.data, status: response.status };
-    }, method, options.signal, options.retryUnsafe === true);
+    }, method, options.signal, options.isSafeToRetry === true);
   }
 
   async requestBuffer(method: Method, path: string, options: Omit<RequestOptions, "data"> = {}): Promise<Buffer> {
@@ -101,7 +101,7 @@ export class HttpClient {
       }
 
       return body;
-    }, method, options.signal, options.retryUnsafe === true);
+    }, method, options.signal, options.isSafeToRetry === true);
   }
 
   async requestVoid(method: Method, path: string, options: RequestOptions = {}): Promise<void> {
@@ -114,7 +114,7 @@ export class HttpClient {
         headers: options.headers,
         signal: options.signal,
       });
-    }, method, options.signal, options.retryUnsafe === true);
+    }, method, options.signal, options.isSafeToRetry === true);
   }
 
   private toServiceError(error: unknown): SandboxServiceError {
@@ -132,7 +132,7 @@ export class HttpClient {
     operation: () => Promise<T>,
     method: Method,
     signal?: AbortSignal,
-    retryUnsafe: boolean = false,
+    isSafeToRetry: boolean = false,
   ): Promise<T> {
     let attempt = 0;
     while (true) {
@@ -140,7 +140,7 @@ export class HttpClient {
         return await operation();
       } catch (error) {
         const serviceError = this.toServiceError(error);
-        if (!this.shouldRetry(serviceError, attempt, method, signal, retryUnsafe)) {
+        if (!this.shouldRetry(serviceError, attempt, method, signal, isSafeToRetry)) {
           throw serviceError;
         }
 
@@ -156,11 +156,11 @@ export class HttpClient {
     attempt: number,
     method: Method,
     signal?: AbortSignal,
-    retryUnsafe: boolean = false,
+    isSafeToRetry: boolean = false,
   ): boolean {
     if (signal?.aborted) return false;
     if (attempt >= this.retry.attempts) return false;
-    if (!retryUnsafe && !this.isMethodIdempotent(method)) return false;
+    if (!isSafeToRetry && !this.isMethodIdempotent(method)) return false;
     if (error.status === 0) return true;
     return this.retry.retryOnStatuses.has(error.status);
   }

--- a/sdk/src/http.ts
+++ b/sdk/src/http.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosInstance, type Method, isAxiosError } from "axios";
 import type { Readable } from "node:stream";
 import { SandboxServiceError, createErrorFromResponse } from "./errors";
+import type { RetryOptions } from "./types";
 
 export interface RequestOptions {
   data?: unknown;
@@ -9,10 +10,19 @@ export interface RequestOptions {
   signal?: AbortSignal;
 }
 
+interface NormalizedRetryOptions {
+  attempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  retryOnStatuses: Set<number>;
+  jitter: boolean;
+}
+
 export class HttpClient {
   private readonly instance: AxiosInstance;
+  private readonly retry: NormalizedRetryOptions;
 
-  constructor(baseUrl: string, apiKey?: string) {
+  constructor(baseUrl: string, apiKey?: string, retry?: RetryOptions) {
     const normalizedBase = baseUrl.replace(/\/+$/, "");
     if (!normalizedBase) {
       throw new Error("Sandbox service URL is not configured");
@@ -22,10 +32,17 @@ export class HttpClient {
       baseURL: normalizedBase,
       headers: apiKey ? { "X-Api-Key": apiKey } : {},
     });
+    this.retry = {
+      attempts: Math.max(0, retry?.attempts ?? 0),
+      baseDelayMs: Math.max(0, retry?.baseDelayMs ?? 200),
+      maxDelayMs: Math.max(0, retry?.maxDelayMs ?? 2000),
+      retryOnStatuses: new Set(retry?.retryOnStatuses ?? [429, 502, 503]),
+      jitter: retry?.jitter ?? true,
+    };
   }
 
   async requestJson<T>(method: Method, path: string, options: RequestOptions = {}): Promise<T> {
-    try {
+    return this.withRetry(async () => {
       const response = await this.instance.request<T>({
         method,
         url: path,
@@ -35,9 +52,7 @@ export class HttpClient {
         signal: options.signal,
       });
       return response.data;
-    } catch (error) {
-      throw this.toServiceError(error);
-    }
+    }, options.signal);
   }
 
   async requestStream(
@@ -45,7 +60,7 @@ export class HttpClient {
     path: string,
     options: RequestOptions = {},
   ): Promise<{ stream: Readable; status: number }> {
-    try {
+    return this.withRetry(async () => {
       const response = await this.instance.request<Readable>({
         method,
         url: path,
@@ -63,14 +78,11 @@ export class HttpClient {
       }
 
       return { stream: response.data, status: response.status };
-    } catch (error) {
-      if (error instanceof SandboxServiceError) throw error;
-      throw this.toServiceError(error);
-    }
+    }, options.signal);
   }
 
   async requestBuffer(method: Method, path: string, options: Omit<RequestOptions, "data"> = {}): Promise<Buffer> {
-    try {
+    return this.withRetry(async () => {
       const response = await this.instance.request<ArrayBuffer>({
         method,
         url: path,
@@ -87,13 +99,11 @@ export class HttpClient {
       }
 
       return body;
-    } catch (error) {
-      throw this.toServiceError(error);
-    }
+    }, options.signal);
   }
 
   async requestVoid(method: Method, path: string, options: RequestOptions = {}): Promise<void> {
-    try {
+    return this.withRetry(async () => {
       await this.instance.request({
         method,
         url: path,
@@ -102,9 +112,7 @@ export class HttpClient {
         headers: options.headers,
         signal: options.signal,
       });
-    } catch (error) {
-      throw this.toServiceError(error);
-    }
+    }, options.signal);
   }
 
   private toServiceError(error: unknown): SandboxServiceError {
@@ -116,6 +124,60 @@ export class HttpClient {
 
     const message = error instanceof Error ? error.message : "Unknown sandbox service error";
     return new SandboxServiceError(message, 0);
+  }
+
+  private async withRetry<T>(
+    operation: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    let attempt = 0;
+    while (true) {
+      try {
+        return await operation();
+      } catch (error) {
+        const serviceError = this.toServiceError(error);
+        if (!this.shouldRetry(serviceError, attempt, signal)) {
+          throw serviceError;
+        }
+
+        const delayMs = this.retryDelayMs(attempt);
+        await this.sleep(delayMs, signal);
+        attempt += 1;
+      }
+    }
+  }
+
+  private shouldRetry(error: SandboxServiceError, attempt: number, signal?: AbortSignal): boolean {
+    if (signal?.aborted) return false;
+    if (attempt >= this.retry.attempts) return false;
+    if (error.status === 0) return true;
+    return this.retry.retryOnStatuses.has(error.status);
+  }
+
+  private retryDelayMs(attempt: number): number {
+    const base = this.retry.baseDelayMs * (2 ** attempt);
+    const capped = Math.min(base, this.retry.maxDelayMs);
+    if (!this.retry.jitter) return capped;
+    const factor = 0.5 + Math.random(); // [0.5, 1.5)
+    return Math.floor(capped * factor);
+  }
+
+  private sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    if (ms <= 0) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
+        reject(new SandboxServiceError("Request aborted", 0));
+      };
+      if (signal) {
+        signal.addEventListener("abort", onAbort);
+      }
+    });
   }
 
   private async drainStream(stream: Readable): Promise<string> {

--- a/sdk/src/http.ts
+++ b/sdk/src/http.ts
@@ -35,26 +35,31 @@ export class HttpClient {
       headers: apiKey ? { "X-Api-Key": apiKey } : {},
     });
     this.retry = {
-      attempts: Math.max(0, retry?.attempts ?? 0),
+      attempts: Math.max(0, retry?.attempts ?? 3),
       baseDelayMs: Math.max(0, retry?.baseDelayMs ?? 200),
       maxDelayMs: Math.max(0, retry?.maxDelayMs ?? 10000),
-      retryOnStatuses: new Set(retry?.retryOnStatuses ?? [429, 502, 503]),
+      retryOnStatuses: new Set(retry?.retryOnStatuses ?? [429, 503]),
       jitter: retry?.jitter ?? true,
     };
   }
 
   async requestJson<T>(method: Method, path: string, options: RequestOptions = {}): Promise<T> {
-    return this.withRetry(async () => {
-      const response = await this.instance.request<T>({
-        method,
-        url: path,
-        data: options.data,
-        params: options.params,
-        headers: options.headers,
-        signal: options.signal,
-      });
-      return response.data;
-    }, method, options.signal, options.isSafeToRetry === true);
+    return this.withRetry(
+      async () => {
+        const response = await this.instance.request<T>({
+          method,
+          url: path,
+          data: options.data,
+          params: options.params,
+          headers: options.headers,
+          signal: options.signal,
+        });
+        return response.data;
+      },
+      method,
+      options.signal,
+      options.isSafeToRetry === true,
+    );
   }
 
   async requestStream(
@@ -62,63 +67,78 @@ export class HttpClient {
     path: string,
     options: RequestOptions = {},
   ): Promise<{ stream: Readable; status: number }> {
-    return this.withRetry(async () => {
-      const response = await this.instance.request<Readable>({
-        method,
-        url: path,
-        data: options.data,
-        params: options.params,
-        headers: options.headers,
-        signal: options.signal,
-        responseType: "stream",
-        validateStatus: () => true,
-      });
+    return this.withRetry(
+      async () => {
+        const response = await this.instance.request<Readable>({
+          method,
+          url: path,
+          data: options.data,
+          params: options.params,
+          headers: options.headers,
+          signal: options.signal,
+          responseType: "stream",
+          validateStatus: () => true,
+        });
 
-      if (response.status >= 400) {
-        const body = await this.drainStream(response.data);
-        throw createErrorFromResponse(response.status, this.tryParseJson(body));
-      }
+        if (response.status >= 400) {
+          const body = await this.drainStream(response.data);
+          throw createErrorFromResponse(response.status, this.tryParseJson(body));
+        }
 
-      return { stream: response.data, status: response.status };
-    }, method, options.signal, options.isSafeToRetry === true);
+        return { stream: response.data, status: response.status };
+      },
+      method,
+      options.signal,
+      options.isSafeToRetry === true,
+    );
   }
 
   async requestBuffer(
     method: Method,
     path: string,
-    options: Omit<RequestOptions, "data"> = {}
+    options: Omit<RequestOptions, "data"> = {},
   ): Promise<Buffer> {
-    return this.withRetry(async () => {
-      const response = await this.instance.request<ArrayBuffer>({
-        method,
-        url: path,
-        params: options.params,
-        headers: options.headers,
-        signal: options.signal,
-        responseType: "arraybuffer",
-        validateStatus: () => true,
-      });
+    return this.withRetry(
+      async () => {
+        const response = await this.instance.request<ArrayBuffer>({
+          method,
+          url: path,
+          params: options.params,
+          headers: options.headers,
+          signal: options.signal,
+          responseType: "arraybuffer",
+          validateStatus: () => true,
+        });
 
-      const body = Buffer.from(response.data);
-      if (response.status >= 400) {
-        throw createErrorFromResponse(response.status, this.tryParseJson(body.toString("utf-8")));
-      }
+        const body = Buffer.from(response.data);
+        if (response.status >= 400) {
+          throw createErrorFromResponse(response.status, this.tryParseJson(body.toString("utf-8")));
+        }
 
-      return body;
-    }, method, options.signal, options.isSafeToRetry === true);
+        return body;
+      },
+      method,
+      options.signal,
+      options.isSafeToRetry === true,
+    );
   }
 
   async requestVoid(method: Method, path: string, options: RequestOptions = {}): Promise<void> {
-    return this.withRetry(async () => {
-      await this.instance.request({
-        method,
-        url: path,
-        data: options.data,
-        params: options.params,
-        headers: options.headers,
-        signal: options.signal,
-      });
-    }, method, options.signal, options.isSafeToRetry === true);
+    return this.withRetry(
+      async () => {
+        await this.instance.request({
+          method,
+          url: path,
+          data: options.data,
+          params: options.params,
+          headers: options.headers,
+          signal: options.signal,
+        });
+      },
+      method,
+      options.signal,
+      options.isSafeToRetry === true,
+    );
   }
 
   private toServiceError(error: unknown): SandboxServiceError {
@@ -175,7 +195,7 @@ export class HttpClient {
   }
 
   private retryDelayMs(attempt: number): number {
-    const base = this.retry.baseDelayMs * (2 ** attempt);
+    const base = this.retry.baseDelayMs * 2 ** attempt;
     const capped = Math.min(base, this.retry.maxDelayMs);
     if (!this.retry.jitter) return capped;
     const factor = 0.5 + Math.random(); // [0.5, 1.5)

--- a/sdk/src/http.ts
+++ b/sdk/src/http.ts
@@ -8,6 +8,8 @@ export interface RequestOptions {
   params?: Record<string, string>;
   headers?: Record<string, string>;
   signal?: AbortSignal;
+  /** Allow retry on non-idempotent methods (e.g. POST). Default false. */
+  retryUnsafe?: boolean;
 }
 
 interface NormalizedRetryOptions {
@@ -52,7 +54,7 @@ export class HttpClient {
         signal: options.signal,
       });
       return response.data;
-    }, options.signal);
+    }, method, options.signal, options.retryUnsafe === true);
   }
 
   async requestStream(
@@ -78,7 +80,7 @@ export class HttpClient {
       }
 
       return { stream: response.data, status: response.status };
-    }, options.signal);
+    }, method, options.signal, options.retryUnsafe === true);
   }
 
   async requestBuffer(method: Method, path: string, options: Omit<RequestOptions, "data"> = {}): Promise<Buffer> {
@@ -99,7 +101,7 @@ export class HttpClient {
       }
 
       return body;
-    }, options.signal);
+    }, method, options.signal, options.retryUnsafe === true);
   }
 
   async requestVoid(method: Method, path: string, options: RequestOptions = {}): Promise<void> {
@@ -112,7 +114,7 @@ export class HttpClient {
         headers: options.headers,
         signal: options.signal,
       });
-    }, options.signal);
+    }, method, options.signal, options.retryUnsafe === true);
   }
 
   private toServiceError(error: unknown): SandboxServiceError {
@@ -128,7 +130,9 @@ export class HttpClient {
 
   private async withRetry<T>(
     operation: () => Promise<T>,
+    method: Method,
     signal?: AbortSignal,
+    retryUnsafe: boolean = false,
   ): Promise<T> {
     let attempt = 0;
     while (true) {
@@ -136,7 +140,7 @@ export class HttpClient {
         return await operation();
       } catch (error) {
         const serviceError = this.toServiceError(error);
-        if (!this.shouldRetry(serviceError, attempt, signal)) {
+        if (!this.shouldRetry(serviceError, attempt, method, signal, retryUnsafe)) {
           throw serviceError;
         }
 
@@ -147,11 +151,23 @@ export class HttpClient {
     }
   }
 
-  private shouldRetry(error: SandboxServiceError, attempt: number, signal?: AbortSignal): boolean {
+  private shouldRetry(
+    error: SandboxServiceError,
+    attempt: number,
+    method: Method,
+    signal?: AbortSignal,
+    retryUnsafe: boolean = false,
+  ): boolean {
     if (signal?.aborted) return false;
     if (attempt >= this.retry.attempts) return false;
+    if (!retryUnsafe && !this.isMethodIdempotent(method)) return false;
     if (error.status === 0) return true;
     return this.retry.retryOnStatuses.has(error.status);
+  }
+
+  private isMethodIdempotent(method: Method): boolean {
+    const m = String(method).toUpperCase();
+    return m === "GET" || m === "HEAD" || m === "OPTIONS" || m === "PUT" || m === "DELETE";
   }
 
   private retryDelayMs(attempt: number): number {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -2,6 +2,7 @@ export { SandboxClient } from "./client";
 export { SandboxServiceError } from "./errors";
 export type {
   SandboxClientOptions,
+  RetryOptions,
   SandboxRecord,
   FileEntry,
   FileStat,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -4,6 +4,28 @@ export interface SandboxClientOptions {
   apiKey?: string;
   /** Base URL of the sandbox service API. */
   baseUrl?: string;
+  /** Optional retry policy for transient request failures. */
+  retry?: RetryOptions;
+}
+
+/** Retry policy for transient HTTP failures. */
+export interface RetryOptions {
+  /**
+   * Number of retry attempts after the initial request.
+   * Example: 3 means at most 4 total attempts.
+   */
+  attempts?: number;
+  /** Initial backoff delay in milliseconds. Defaults to 200. */
+  baseDelayMs?: number;
+  /** Maximum backoff delay in milliseconds. Defaults to 2000. */
+  maxDelayMs?: number;
+  /**
+   * HTTP statuses that should be retried. Defaults to [429, 502, 503].
+   * Network/transport errors (status 0) are always considered retryable.
+   */
+  retryOnStatuses?: number[];
+  /** Enable delay jitter (0.5x..1.5x). Defaults to true. */
+  jitter?: boolean;
 }
 
 /** Metadata for a sandbox instance. */

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -17,7 +17,7 @@ export interface RetryOptions {
   attempts?: number;
   /** Initial backoff delay in milliseconds. Defaults to 200. */
   baseDelayMs?: number;
-  /** Maximum backoff delay in milliseconds. Defaults to 2000. */
+  /** Maximum backoff delay in milliseconds. Defaults to 10000. */
   maxDelayMs?: number;
   /**
    * HTTP statuses that should be retried. Defaults to [429, 502, 503].

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -4,7 +4,10 @@ export interface SandboxClientOptions {
   apiKey?: string;
   /** Base URL of the sandbox service API. */
   baseUrl?: string;
-  /** Optional retry policy for transient request failures. */
+  /**
+   * Retry policy for **transient** HTTP failures (see README).
+   * Omit to use defaults; set `{ attempts: 0 }` to disable retries entirely.
+   */
   retry?: RetryOptions;
 }
 
@@ -12,7 +15,7 @@ export interface SandboxClientOptions {
 export interface RetryOptions {
   /**
    * Number of retry attempts after the initial request.
-   * Example: 3 means at most 4 total attempts.
+   * Example: 3 means at most 4 total attempts. Defaults to 3; set to 0 to turn off retries.
    */
   attempts?: number;
   /** Initial backoff delay in milliseconds. Defaults to 200. */
@@ -20,7 +23,7 @@ export interface RetryOptions {
   /** Maximum backoff delay in milliseconds. Defaults to 10000. */
   maxDelayMs?: number;
   /**
-   * HTTP statuses that should be retried. Defaults to [429, 502, 503].
+   * HTTP statuses that should be retried. Defaults to [429, 503] (transient; see API.md).
    * Network/transport errors (status 0) are always considered retryable.
    */
   retryOnStatuses?: number[];

--- a/sdk/test/client.test.ts
+++ b/sdk/test/client.test.ts
@@ -29,7 +29,20 @@ describe("SandboxClient", () => {
   });
 
   it("constructs HttpClient with options", () => {
-    expect(HttpClient).toHaveBeenCalledWith("http://localhost:8080", "test-key");
+    expect(HttpClient).toHaveBeenCalledWith("http://localhost:8080", "test-key", undefined);
+  });
+
+  it("passes retry options to HttpClient", () => {
+    new SandboxClient({
+      baseUrl: "http://localhost:8080",
+      apiKey: "test-key",
+      retry: { attempts: 3, baseDelayMs: 50, jitter: false },
+    });
+    expect(HttpClient).toHaveBeenLastCalledWith(
+      "http://localhost:8080",
+      "test-key",
+      expect.objectContaining({ attempts: 3, baseDelayMs: 50, jitter: false }),
+    );
   });
 
   it("createSandbox sends POST /sandboxes", async () => {

--- a/sdk/test/helpers.ts
+++ b/sdk/test/helpers.ts
@@ -1,0 +1,33 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+export type TestServer = {
+  server: Server;
+  baseUrl: string;
+  close: () => Promise<void>;
+};
+
+export async function startTestServer(
+  handler: (req: IncomingMessage, res: ServerResponse<IncomingMessage>) => void,
+): Promise<TestServer> {
+  const server = createServer(handler);
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.once("error", reject);
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected an ephemeral TCP port");
+  }
+
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}

--- a/sdk/test/http.test.ts
+++ b/sdk/test/http.test.ts
@@ -75,4 +75,92 @@ describe("HttpClient", () => {
       });
     }
   });
+
+  it("retries transient 503 responses and eventually succeeds", async () => {
+    let hits = 0;
+    const retryServer = createServer((req, res) => {
+      if (req.url !== "/retry-503") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      hits += 1;
+      if (hits < 3) {
+        res.writeHead(503, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "sandbox unavailable" }));
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      retryServer.listen(0, "127.0.0.1", () => resolve());
+      retryServer.once("error", reject);
+    });
+    const addr = retryServer.address();
+    if (addr === null || typeof addr === "string") {
+      throw new Error("Expected retry server TCP address");
+    }
+    const retryBaseUrl = `http://127.0.0.1:${addr.port}`;
+
+    try {
+      const client = new HttpClient(retryBaseUrl, undefined, {
+        attempts: 3,
+        baseDelayMs: 1,
+        maxDelayMs: 2,
+        jitter: false,
+      });
+      const out = await client.requestJson<{ ok: boolean }>("GET", "/retry-503");
+      expect(out).toEqual({ ok: true });
+      expect(hits).toBe(3);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        retryServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("stops after retry budget on transient failures", async () => {
+    let hits = 0;
+    const failServer = createServer((req, res) => {
+      if (req.url !== "/always-503") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      hits += 1;
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "sandbox unavailable" }));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      failServer.listen(0, "127.0.0.1", () => resolve());
+      failServer.once("error", reject);
+    });
+    const addr = failServer.address();
+    if (addr === null || typeof addr === "string") {
+      throw new Error("Expected fail server TCP address");
+    }
+    const failBaseUrl = `http://127.0.0.1:${addr.port}`;
+
+    try {
+      const client = new HttpClient(failBaseUrl, undefined, {
+        attempts: 2,
+        baseDelayMs: 1,
+        maxDelayMs: 2,
+        jitter: false,
+      });
+      await expect(client.requestJson("GET", "/always-503")).rejects.toMatchObject({
+        status: 503,
+        message: "sandbox unavailable",
+      });
+      // initial + 2 retries
+      expect(hits).toBe(3);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        failServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
 });

--- a/sdk/test/http.test.ts
+++ b/sdk/test/http.test.ts
@@ -1,14 +1,14 @@
-import { createServer, type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { SandboxServiceError } from "../src/errors.js";
 import { HttpClient } from "../src/http.js";
+import { startTestServer, type TestServer } from "./helpers.js";
 
 describe("HttpClient", () => {
-  let server: Server;
+  let server: TestServer;
   let baseUrl: string;
 
   beforeAll(async () => {
-    server = createServer((req, res) => {
+    server = await startTestServer((req, res) => {
       if (req.url === "/stream-error") {
         res.writeHead(404, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "sandbox not found", code: 4041 }));
@@ -24,24 +24,11 @@ describe("HttpClient", () => {
       res.writeHead(500, { "Content-Type": "text/plain" });
       res.end("unexpected request");
     });
-
-    await new Promise<void>((resolve, reject) => {
-      server.listen(0, "127.0.0.1", () => resolve());
-      server.once("error", reject);
-    });
-
-    const address = server.address();
-    if (address === null || typeof address === "string") {
-      throw new Error("Expected an ephemeral TCP port");
-    }
-
-    baseUrl = `http://127.0.0.1:${address.port}`;
+    baseUrl = server.baseUrl;
   });
 
   afterAll(async () => {
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
+    await server.close();
   });
 
   it("preserves JSON error payloads for stream requests", async () => {
@@ -78,7 +65,7 @@ describe("HttpClient", () => {
 
   it("retries transient 503 responses and eventually succeeds", async () => {
     let hits = 0;
-    const retryServer = createServer((req, res) => {
+    const retryServer = await startTestServer((req, res) => {
       if (req.url !== "/retry-503") {
         res.writeHead(404);
         res.end();
@@ -94,18 +81,8 @@ describe("HttpClient", () => {
       res.end(JSON.stringify({ ok: true }));
     });
 
-    await new Promise<void>((resolve, reject) => {
-      retryServer.listen(0, "127.0.0.1", () => resolve());
-      retryServer.once("error", reject);
-    });
-    const addr = retryServer.address();
-    if (addr === null || typeof addr === "string") {
-      throw new Error("Expected retry server TCP address");
-    }
-    const retryBaseUrl = `http://127.0.0.1:${addr.port}`;
-
     try {
-      const client = new HttpClient(retryBaseUrl, undefined, {
+      const client = new HttpClient(retryServer.baseUrl, undefined, {
         attempts: 3,
         baseDelayMs: 1,
         maxDelayMs: 2,
@@ -115,15 +92,13 @@ describe("HttpClient", () => {
       expect(out).toEqual({ ok: true });
       expect(hits).toBe(3);
     } finally {
-      await new Promise<void>((resolve, reject) => {
-        retryServer.close((error) => (error ? reject(error) : resolve()));
-      });
+      await retryServer.close();
     }
   });
 
   it("stops after retry budget on transient failures", async () => {
     let hits = 0;
-    const failServer = createServer((req, res) => {
+    const failServer = await startTestServer((req, res) => {
       if (req.url !== "/always-503") {
         res.writeHead(404);
         res.end();
@@ -134,18 +109,8 @@ describe("HttpClient", () => {
       res.end(JSON.stringify({ error: "sandbox unavailable" }));
     });
 
-    await new Promise<void>((resolve, reject) => {
-      failServer.listen(0, "127.0.0.1", () => resolve());
-      failServer.once("error", reject);
-    });
-    const addr = failServer.address();
-    if (addr === null || typeof addr === "string") {
-      throw new Error("Expected fail server TCP address");
-    }
-    const failBaseUrl = `http://127.0.0.1:${addr.port}`;
-
     try {
-      const client = new HttpClient(failBaseUrl, undefined, {
+      const client = new HttpClient(failServer.baseUrl, undefined, {
         attempts: 2,
         baseDelayMs: 1,
         maxDelayMs: 2,
@@ -158,15 +123,13 @@ describe("HttpClient", () => {
       // initial + 2 retries
       expect(hits).toBe(3);
     } finally {
-      await new Promise<void>((resolve, reject) => {
-        failServer.close((error) => (error ? reject(error) : resolve()));
-      });
+      await failServer.close();
     }
   });
 
   it("does not retry non-idempotent POST by default", async () => {
     let hits = 0;
-    const postServer = createServer((req, res) => {
+    const postServer = await startTestServer((req, res) => {
       if (req.url !== "/post-503") {
         res.writeHead(404);
         res.end();
@@ -177,18 +140,8 @@ describe("HttpClient", () => {
       res.end(JSON.stringify({ error: "sandbox unavailable" }));
     });
 
-    await new Promise<void>((resolve, reject) => {
-      postServer.listen(0, "127.0.0.1", () => resolve());
-      postServer.once("error", reject);
-    });
-    const addr = postServer.address();
-    if (addr === null || typeof addr === "string") {
-      throw new Error("Expected post server TCP address");
-    }
-    const postBaseUrl = `http://127.0.0.1:${addr.port}`;
-
     try {
-      const client = new HttpClient(postBaseUrl, undefined, {
+      const client = new HttpClient(postServer.baseUrl, undefined, {
         attempts: 3,
         baseDelayMs: 1,
         maxDelayMs: 2,
@@ -199,15 +152,13 @@ describe("HttpClient", () => {
       });
       expect(hits).toBe(1);
     } finally {
-      await new Promise<void>((resolve, reject) => {
-        postServer.close((error) => (error ? reject(error) : resolve()));
-      });
+      await postServer.close();
     }
   });
 
   it("retries non-idempotent POST only when explicitly opted in", async () => {
     let hits = 0;
-    const postServer = createServer((req, res) => {
+    const postServer = await startTestServer((req, res) => {
       if (req.url !== "/post-retry") {
         res.writeHead(404);
         res.end();
@@ -223,18 +174,8 @@ describe("HttpClient", () => {
       res.end(JSON.stringify({ ok: true }));
     });
 
-    await new Promise<void>((resolve, reject) => {
-      postServer.listen(0, "127.0.0.1", () => resolve());
-      postServer.once("error", reject);
-    });
-    const addr = postServer.address();
-    if (addr === null || typeof addr === "string") {
-      throw new Error("Expected post retry server TCP address");
-    }
-    const postBaseUrl = `http://127.0.0.1:${addr.port}`;
-
     try {
-      const client = new HttpClient(postBaseUrl, undefined, {
+      const client = new HttpClient(postServer.baseUrl, undefined, {
         attempts: 3,
         baseDelayMs: 1,
         maxDelayMs: 2,
@@ -242,14 +183,12 @@ describe("HttpClient", () => {
       });
       const out = await client.requestJson<{ ok: boolean }>("POST", "/post-retry", {
         data: { x: 1 },
-        retryUnsafe: true,
+        isSafeToRetry: true,
       });
       expect(out).toEqual({ ok: true });
       expect(hits).toBe(3);
     } finally {
-      await new Promise<void>((resolve, reject) => {
-        postServer.close((error) => (error ? reject(error) : resolve()));
-      });
+      await postServer.close();
     }
   });
 });

--- a/sdk/test/http.test.ts
+++ b/sdk/test/http.test.ts
@@ -163,4 +163,93 @@ describe("HttpClient", () => {
       });
     }
   });
+
+  it("does not retry non-idempotent POST by default", async () => {
+    let hits = 0;
+    const postServer = createServer((req, res) => {
+      if (req.url !== "/post-503") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      hits += 1;
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "sandbox unavailable" }));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      postServer.listen(0, "127.0.0.1", () => resolve());
+      postServer.once("error", reject);
+    });
+    const addr = postServer.address();
+    if (addr === null || typeof addr === "string") {
+      throw new Error("Expected post server TCP address");
+    }
+    const postBaseUrl = `http://127.0.0.1:${addr.port}`;
+
+    try {
+      const client = new HttpClient(postBaseUrl, undefined, {
+        attempts: 3,
+        baseDelayMs: 1,
+        maxDelayMs: 2,
+        jitter: false,
+      });
+      await expect(client.requestJson("POST", "/post-503", { data: { x: 1 } })).rejects.toMatchObject({
+        status: 503,
+      });
+      expect(hits).toBe(1);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        postServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("retries non-idempotent POST only when explicitly opted in", async () => {
+    let hits = 0;
+    const postServer = createServer((req, res) => {
+      if (req.url !== "/post-retry") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      hits += 1;
+      if (hits < 3) {
+        res.writeHead(503, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "sandbox unavailable" }));
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      postServer.listen(0, "127.0.0.1", () => resolve());
+      postServer.once("error", reject);
+    });
+    const addr = postServer.address();
+    if (addr === null || typeof addr === "string") {
+      throw new Error("Expected post retry server TCP address");
+    }
+    const postBaseUrl = `http://127.0.0.1:${addr.port}`;
+
+    try {
+      const client = new HttpClient(postBaseUrl, undefined, {
+        attempts: 3,
+        baseDelayMs: 1,
+        maxDelayMs: 2,
+        jitter: false,
+      });
+      const out = await client.requestJson<{ ok: boolean }>("POST", "/post-retry", {
+        data: { x: 1 },
+        retryUnsafe: true,
+      });
+      expect(out).toEqual({ ok: true });
+      expect(hits).toBe(3);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        postServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
 });

--- a/sdk/test/http.test.ts
+++ b/sdk/test/http.test.ts
@@ -63,6 +63,31 @@ describe("HttpClient", () => {
     }
   });
 
+  it("does not retry 502 responses with default retry options", async () => {
+    let hits = 0;
+    const failServer = await startTestServer((req, res) => {
+      if (req.url !== "/always-502") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      hits += 1;
+      res.writeHead(502, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "sandbox not running" }));
+    });
+
+    try {
+      const client = new HttpClient(failServer.baseUrl);
+      await expect(client.requestJson("GET", "/always-502")).rejects.toMatchObject({
+        status: 502,
+        message: "sandbox not running",
+      });
+      expect(hits).toBe(1);
+    } finally {
+      await failServer.close();
+    }
+  });
+
   it("retries transient 503 responses and eventually succeeds", async () => {
     let hits = 0;
     const retryServer = await startTestServer((req, res) => {
@@ -91,6 +116,38 @@ describe("HttpClient", () => {
       const out = await client.requestJson<{ ok: boolean }>("GET", "/retry-503");
       expect(out).toEqual({ ok: true });
       expect(hits).toBe(3);
+    } finally {
+      await retryServer.close();
+    }
+  });
+
+  it("retries 503 with default retry options when none passed", async () => {
+    let hits = 0;
+    const retryServer = await startTestServer((req, res) => {
+      if (req.url !== "/default-retry") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      hits += 1;
+      if (hits < 4) {
+        res.writeHead(503, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "runner unavailable" }));
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    try {
+      const client = new HttpClient(retryServer.baseUrl, undefined, {
+        baseDelayMs: 1,
+        maxDelayMs: 2,
+        jitter: false,
+      });
+      const out = await client.requestJson<{ ok: boolean }>("GET", "/default-retry");
+      expect(out).toEqual({ ok: true });
+      expect(hits).toBe(4);
     } finally {
       await retryServer.close();
     }
@@ -147,7 +204,9 @@ describe("HttpClient", () => {
         maxDelayMs: 2,
         jitter: false,
       });
-      await expect(client.requestJson("POST", "/post-503", { data: { x: 1 } })).rejects.toMatchObject({
+      await expect(
+        client.requestJson("POST", "/post-503", { data: { x: 1 } }),
+      ).rejects.toMatchObject({
         status: 503,
       });
       expect(hits).toBe(1);


### PR DESCRIPTION
## Summary

* Make Docker restart containers that died
* Add e2e tests making sure that when a container dies it comes back up
* Add e2e tests verifying responses for OOMs
* Add basic documentation about failure modes



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-restart sandboxes after exit/OOM so the same sandbox ID keeps working on the same runner. While restarting or without network we return 503 (“sandbox unavailable”); if the inner container isn’t running we return 502 (“not retryable”) so clients change strategy.

- **New Features**
  - Start sandboxes with Docker restart policy `unless-stopped`.
  - Clear 503 vs 502: 503 for transient runner/daemon/network unavailability; 502 when the sandbox exists but isn’t running. Readiness requires `/healthz` plus a tiny `/exec`.
  - Docs: failure modes in README; API.md explains 503 (retry) vs 502 (don’t retry).
  - e2e: restart keeps same ID, 503 while restarting/network-not-ready, and 502 while container is stopped (and recovery after start).
  - `sdk`: configurable retries via `SandboxClientOptions.retry`; defaults retry 429/503 with backoff/jitter; non-idempotent calls can opt in per request with `isSafeToRetry` (502 is not retried by default).

- **Bug Fixes**
  - Structured exec errors when a command is SIGKILLed or the daemon dies mid-exec; covered by new tests.
  - Network rule teardown no longer needs a container IP; delete/reconcile works even if the container isn’t running or has no network.

<sup>Written for commit 35b0760816ed8005508bcbf9a77eedbb7cd4d479. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



