### PR TITLE
chore: skip logging for healthz requests

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -46,6 +46,10 @@ func constantTimeContains(allowed map[string]struct{}, key string) bool {
 // LoggingMiddleware logs request method, path, status, and duration.
 func LoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			next.ServeHTTP(w, r)
+			return
+		}
 		start := time.Now()
 		sw := &statusWriter{ResponseWriter: w, status: 200}
 		next.ServeHTTP(sw, r)

--- a/internal/runner/middleware.go
+++ b/internal/runner/middleware.go
@@ -28,6 +28,10 @@ func AuthMiddleware(apiKeys map[string]struct{}) func(http.Handler) http.Handler
 // LoggingMiddleware logs HTTP requests.
 func LoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			next.ServeHTTP(w, r)
+			return
+		}
 		start := time.Now()
 		next.ServeHTTP(w, r)
 		slog.Info("request",


### PR DESCRIPTION
## Summary

- Skip `/healthz` requests in the `LoggingMiddleware` of both the API gateway and runner service to reduce log noise from health check probes.

## Test plan

- [ ] Verify `make vet` and `make fmt-check` pass
- [ ] Verify existing tests pass
- [ ] Confirm `/healthz` requests no longer appear in logs
- [ ] Confirm all other requests are still logged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip logging for `/healthz` requests in the API gateway and runner `LoggingMiddleware` to reduce noise from health probes. All other requests continue to be logged as before.

<sup>Written for commit 3e8a032e2a2fee1a09e3f36c5754930577d5b0db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

