### PR TITLE
chore: reduce Docker registry log spam

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,8 @@ services:
     ports:
       - "5050:5000"
     restart: unless-stopped
+    environment:
+      REGISTRY_LOG_LEVEL: warn
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:5000/v2/"]
       interval: 2s


### PR DESCRIPTION
## Summary

- Sets `REGISTRY_LOG_LEVEL` to `warn` on the local Docker registry container to suppress per-request access logs from healthchecks and image pulls.

## Test plan

- [ ] Run `docker compose up` and verify the registry container no longer floods logs with access entries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce log spam in the local Docker registry by setting `REGISTRY_LOG_LEVEL=warn` in `compose.yaml`. This suppresses per-request access logs from healthchecks and image pulls, keeping `docker compose` output readable.

<sup>Written for commit a0aabe9cdd40b85e0ed8fdde2aa8a10f91768b97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

