### PR TITLE
feat: add abort execution button to playground

### DIFF
--- a/API.md
+++ b/API.md
@@ -138,7 +138,7 @@ curl -X DELETE http://localhost:8080/sandboxes/550e8400-e29b-41d4-a716-446655440
 
 ---
 
-### POST /sandboxes/{id}/exec
+### POST /sandboxes/{id}/executions
 
 Execute a command in a sandbox. The command runs in a **daemon-side execution** whose
 lifetime is independent of the HTTP stream — disconnecting does not kill the process.
@@ -200,11 +200,11 @@ The `exit` event includes:
 The command runs in a daemon-side execution whose lifetime is independent of the HTTP
 stream. Closing the HTTP connection does **not** kill the running command — it only
 stops the event stream. To cancel a running command, use
-`DELETE /sandboxes/{id}/exec/{exec_id}`. The SDK calls the delete endpoint
+`DELETE /sandboxes/{id}/executions/{exec_id}`. The SDK calls the delete endpoint
 automatically when `abortSignal` fires.
 
 The execution stores events in a bounded buffer (up to 16 MiB). Clients can reconnect
-via `GET /sandboxes/{id}/exec/{exec_id}?after=<seq>&follow=true`. Completed executions
+via `GET /sandboxes/{id}/executions/{exec_id}?after=<seq>&follow=true`. Completed executions
 are retained for 10 minutes. If the buffer is exhausted, old events are discarded and
 stale resume requests return `410 Gone`.
 
@@ -213,7 +213,7 @@ stale resume requests return `410 Gone`.
 **Example:**
 
 ```bash
-curl -X POST http://localhost:8080/sandboxes/550e8400-e29b-41d4-a716-446655440000/exec \
+curl -X POST http://localhost:8080/sandboxes/550e8400-e29b-41d4-a716-446655440000/executions \
   -H "X-Api-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"command": "echo hello", "timeout_ms": 10000}'
@@ -221,7 +221,7 @@ curl -X POST http://localhost:8080/sandboxes/550e8400-e29b-41d4-a716-44665544000
 
 ---
 
-### GET /sandboxes/{id}/exec/{exec_id}
+### GET /sandboxes/{id}/executions/{exec_id}
 
 Resume or replay an execution stream. Use this to reconnect after a transient
 stream disconnect without re-executing the command.
@@ -240,7 +240,7 @@ or the client disconnects.
 
 **Response:** `200 OK` — `Content-Type: application/x-ndjson`
 
-Same NDJSON event format as `POST /exec`.
+Same NDJSON event format as `POST /executions`.
 
 **Errors:** `400` invalid parameters, `404` execution not found, `410` requested history is no longer retained
 
@@ -248,13 +248,13 @@ Same NDJSON event format as `POST /exec`.
 
 ```bash
 # Resume from sequence 5
-curl "http://localhost:8080/sandboxes/550e8400-e29b-41d4-a716-446655440000/exec/a1b2c3d4-...?after=5&follow=true" \
+curl "http://localhost:8080/sandboxes/550e8400-e29b-41d4-a716-446655440000/executions/a1b2c3d4-...?after=5&follow=true" \
   -H "X-Api-Key: YOUR_API_KEY"
 ```
 
 ---
 
-### DELETE /sandboxes/{id}/exec/{exec_id}
+### DELETE /sandboxes/{id}/executions/{exec_id}
 
 Delete an execution. Kills the running process (if still active) and immediately
 removes the execution state from memory. After deletion, the execution can no
@@ -272,7 +272,7 @@ nonexistent execution returns `204`.
 **Example:**
 
 ```bash
-curl -X DELETE http://localhost:8080/sandboxes/550e8400-e29b-41d4-a716-446655440000/exec/a1b2c3d4-... \
+curl -X DELETE http://localhost:8080/sandboxes/550e8400-e29b-41d4-a716-446655440000/executions/a1b2c3d4-... \
   -H "X-Api-Key: YOUR_API_KEY"
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl -s -X POST http://localhost:8080/sandboxes \
 ### Run a command
 
 ```bash
-curl -s -X POST http://localhost:8080/sandboxes/<id>/exec \
+curl -s -X POST http://localhost:8080/sandboxes/<id>/executions \
   -H "X-Api-Key: test" \
   -H "Content-Type: application/json" \
   -d '{"command": "echo hello world"}'

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -61,7 +61,7 @@ export async function downloadFile(
  */
 export function startAndDisconnect(sandboxId: string, command: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const url = new URL(`${BASE_URL}/sandboxes/${sandboxId}/exec`);
+    const url = new URL(`${BASE_URL}/sandboxes/${sandboxId}/executions`);
     const reqFn = url.protocol === 'https:' ? https.request : http.request;
     const body = JSON.stringify({ command });
     let resolved = false;

--- a/e2e/tests/resilience.spec.ts
+++ b/e2e/tests/resilience.spec.ts
@@ -161,7 +161,7 @@ test.describe('Runner failure resilience', () => {
       stoppedRunner = deadRunner;
       docker(['stop', '-t', '30', stoppedRunner]);
 
-      const bad = await request.post(`/sandboxes/${id1}/exec`, {
+      const bad = await request.post(`/sandboxes/${id1}/executions`, {
         headers: { 'X-Api-Key': API_KEY, 'Content-Type': 'application/json' },
         data: { command: 'true' },
       });

--- a/e2e/tests/sandbox-api.spec.ts
+++ b/e2e/tests/sandbox-api.spec.ts
@@ -108,7 +108,7 @@ test.describe('Exec', () => {
   });
 
   test('environment variables as array returns 400', async ({ request }) => {
-    const resp = await apiRequest(request, 'POST', `/sandboxes/${sandboxId}/exec`, {
+    const resp = await apiRequest(request, 'POST', `/sandboxes/${sandboxId}/executions`, {
       data: { command: 'echo $FOO', env: ['FOO=bar'] },
     });
     expect(resp.status).toBe(400);
@@ -131,7 +131,7 @@ test.describe('Exec', () => {
   });
 
   test('missing command returns 400', async ({ request }) => {
-    const resp = await apiRequest(request, 'POST', `/sandboxes/${sandboxId}/exec`, {
+    const resp = await apiRequest(request, 'POST', `/sandboxes/${sandboxId}/executions`, {
       data: {},
     });
     expect(resp.status).toBe(400);
@@ -167,7 +167,7 @@ test.describe('Exec', () => {
   test('exec on deleted sandbox returns 404', async ({ request }) => {
     const tempId = await createSandbox();
     await deleteSandbox(tempId);
-    const resp = await apiRequest(request, 'POST', `/sandboxes/${tempId}/exec`, {
+    const resp = await apiRequest(request, 'POST', `/sandboxes/${tempId}/executions`, {
       data: { command: 'echo hi' },
     });
     expect(resp.status).toBe(404);

--- a/internal/api/gateway.go
+++ b/internal/api/gateway.go
@@ -25,9 +25,9 @@ func NewGatewayRouter(s *store.Store, cfg *config.APIConfig, reg *registry.Regis
 	mux.HandleFunc("GET /sandboxes/{id}", handleGetSandbox(s))
 	mux.HandleFunc("DELETE /sandboxes/{id}", handleDeleteSandbox(s, cfg))
 
-	mux.HandleFunc("POST /sandboxes/{id}/exec", sandboxProxy(false))
-	mux.HandleFunc("GET /sandboxes/{id}/exec/{exec_id}", sandboxProxy(false))
-	mux.HandleFunc("DELETE /sandboxes/{id}/exec/{exec_id}", sandboxProxy(false))
+	mux.HandleFunc("POST /sandboxes/{id}/executions", sandboxProxy(false))
+	mux.HandleFunc("GET /sandboxes/{id}/executions/{exec_id}", sandboxProxy(false))
+	mux.HandleFunc("DELETE /sandboxes/{id}/executions/{exec_id}", sandboxProxy(false))
 	mux.HandleFunc("POST /sandboxes/{id}/files/copy", sandboxProxy(false))
 	mux.HandleFunc("POST /sandboxes/{id}/files/move", sandboxProxy(false))
 	mux.HandleFunc("GET /sandboxes/{id}/files", sandboxProxy(false))

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -13,7 +13,7 @@ func TestRecoveryMiddlewareRethrowsAbortHandler(t *testing.T) {
 	}))
 
 	recovered := recoverPanic(func() {
-		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/exec", nil))
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/executions", nil))
 	})
 
 	if recovered != http.ErrAbortHandler {
@@ -27,7 +27,7 @@ func TestRecoveryMiddlewareWritesErrorBeforeResponseStarts(t *testing.T) {
 	}))
 
 	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/exec", nil))
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/executions", nil))
 
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, rr.Code)
@@ -47,7 +47,7 @@ func TestRecoveryMiddlewareAbortsAfterResponseStarts(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	recovered := recoverPanic(func() {
-		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/exec", nil))
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/executions", nil))
 	})
 
 	if recovered != http.ErrAbortHandler {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -113,7 +113,7 @@ func NewHandler(baseDir string) *Handler {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	})
 
-	mux.HandleFunc("POST /exec", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /executions", func(w http.ResponseWriter, r *http.Request) {
 		var req execRequest
 		if err := decodeJSONBody(r.Body, &req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
@@ -146,7 +146,7 @@ func NewHandler(baseDir string) *Handler {
 		ex.Follow(r.Context(), nil, write)
 	})
 
-	mux.HandleFunc("GET /exec/{exec_id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /executions/{exec_id}", func(w http.ResponseWriter, r *http.Request) {
 		after, err := parseAfterParam(r.URL.Query().Get("after"))
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid after parameter")
@@ -190,7 +190,7 @@ func NewHandler(baseDir string) *Handler {
 		}
 	})
 
-	mux.HandleFunc("DELETE /exec/{exec_id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("DELETE /executions/{exec_id}", func(w http.ResponseWriter, r *http.Request) {
 		execID := r.PathValue("exec_id")
 		em.Delete(execID)
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/daemon/daemon_http_test.go
+++ b/internal/daemon/daemon_http_test.go
@@ -14,7 +14,7 @@ import (
 func TestExecEndpointStreamsResponses(t *testing.T) {
 	handler := NewHandler(t.TempDir())
 
-	req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader([]byte(`{"command":"echo hello","env":{"FOO":"bar"}}`)))
+	req := httptest.NewRequest(http.MethodPost, "/executions", bytes.NewReader([]byte(`{"command":"echo hello","env":{"FOO":"bar"}}`)))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
@@ -53,7 +53,7 @@ func TestExecEndpointStreamsResponses(t *testing.T) {
 func TestExecEndpointRejectsArrayEnv(t *testing.T) {
 	handler := NewHandler(t.TempDir())
 
-	req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader([]byte(`{"command":"echo hello","env":["FOO=bar"]}`)))
+	req := httptest.NewRequest(http.MethodPost, "/executions", bytes.NewReader([]byte(`{"command":"echo hello","env":["FOO=bar"]}`)))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
@@ -75,7 +75,7 @@ func TestExecEndpointAppliesDefaultTimeout(t *testing.T) {
 	})
 
 	handler := NewHandler(t.TempDir())
-	req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader([]byte(`{"command":"sleep 1"}`)))
+	req := httptest.NewRequest(http.MethodPost, "/executions", bytes.NewReader([]byte(`{"command":"sleep 1"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 

--- a/internal/daemon/exec_manager_test.go
+++ b/internal/daemon/exec_manager_test.go
@@ -27,7 +27,7 @@ func TestExecutionFirstEventIsStarted(t *testing.T) {
 	t.Cleanup(handler.Close)
 
 	body := `{"command":"echo hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader([]byte(body)))
+	req := httptest.NewRequest(http.MethodPost, "/executions", bytes.NewReader([]byte(body)))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
@@ -58,7 +58,7 @@ func TestExecutionAllEventsHaveSeq(t *testing.T) {
 	t.Cleanup(handler.Close)
 
 	body := `{"command":"echo hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader([]byte(body)))
+	req := httptest.NewRequest(http.MethodPost, "/executions", bytes.NewReader([]byte(body)))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
@@ -140,7 +140,7 @@ func TestExecutionResumeReturnsNoDuplicates(t *testing.T) {
 	t.Cleanup(handler.Close)
 
 	body := `{"command":"echo hello","exec_id":"test-exec-id"}`
-	req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader([]byte(body)))
+	req := httptest.NewRequest(http.MethodPost, "/executions", bytes.NewReader([]byte(body)))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -169,7 +169,7 @@ func TestExecutionResumeReturnsNoDuplicates(t *testing.T) {
 	}
 
 	resumeReq := httptest.NewRequest(http.MethodGet,
-		"/exec/"+execID+"?after="+func() string {
+		"/executions/"+execID+"?after="+func() string {
 			b, _ := json.Marshal(lastSeq)
 			return string(b)
 		}(),
@@ -236,7 +236,7 @@ func TestExecutionNonexistentReturns404(t *testing.T) {
 	t.Cleanup(handler.Close)
 
 	body := `{"command":"echo hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader([]byte(body)))
+	req := httptest.NewRequest(http.MethodPost, "/executions", bytes.NewReader([]byte(body)))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -256,7 +256,7 @@ func TestExecutionNonexistentReturns404(t *testing.T) {
 		t.Fatal("missing exec_id")
 	}
 
-	resumeReq := httptest.NewRequest(http.MethodGet, "/exec/nonexistent?after=0", nil)
+	resumeReq := httptest.NewRequest(http.MethodGet, "/executions/nonexistent?after=0", nil)
 	resumeRR := httptest.NewRecorder()
 	handler.ServeHTTP(resumeRR, resumeReq)
 	if resumeRR.Code != http.StatusNotFound {
@@ -269,7 +269,7 @@ func TestDeleteExecEndpoint(t *testing.T) {
 	t.Cleanup(handler.Close)
 
 	body := `{"command":"sleep 30"}`
-	req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader([]byte(body)))
+	req := httptest.NewRequest(http.MethodPost, "/executions", bytes.NewReader([]byte(body)))
 	req.Header.Set("Content-Type", "application/json")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -293,7 +293,7 @@ func TestDeleteExecEndpoint(t *testing.T) {
 		t.Fatal("missing exec_id from started event")
 	}
 
-	delReq := httptest.NewRequest(http.MethodDelete, "/exec/"+execID, nil)
+	delReq := httptest.NewRequest(http.MethodDelete, "/executions/"+execID, nil)
 	delRR := httptest.NewRecorder()
 	handler.ServeHTTP(delRR, delReq)
 
@@ -301,14 +301,14 @@ func TestDeleteExecEndpoint(t *testing.T) {
 		t.Fatalf("expected 204, got %d", delRR.Code)
 	}
 
-	getReq := httptest.NewRequest(http.MethodGet, "/exec/"+execID, nil)
+	getReq := httptest.NewRequest(http.MethodGet, "/executions/"+execID, nil)
 	getRR := httptest.NewRecorder()
 	handler.ServeHTTP(getRR, getReq)
 	if getRR.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 on GET after DELETE, got %d", getRR.Code)
 	}
 
-	delReq2 := httptest.NewRequest(http.MethodDelete, "/exec/nonexistent", nil)
+	delReq2 := httptest.NewRequest(http.MethodDelete, "/executions/nonexistent", nil)
 	delRR2 := httptest.NewRecorder()
 	handler.ServeHTTP(delRR2, delReq2)
 	if delRR2.Code != http.StatusNoContent {

--- a/internal/runner/middleware_test.go
+++ b/internal/runner/middleware_test.go
@@ -13,7 +13,7 @@ func TestRecoveryMiddlewareRethrowsAbortHandler(t *testing.T) {
 	}))
 
 	recovered := recoverPanic(func() {
-		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/exec", nil))
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/executions", nil))
 	})
 
 	if recovered != http.ErrAbortHandler {
@@ -27,7 +27,7 @@ func TestRecoveryMiddlewareWritesErrorBeforeResponseStarts(t *testing.T) {
 	}))
 
 	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/exec", nil))
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/executions", nil))
 
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, rr.Code)
@@ -47,7 +47,7 @@ func TestRecoveryMiddlewareAbortsAfterResponseStarts(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	recovered := recoverPanic(func() {
-		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/exec", nil))
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/executions", nil))
 	})
 
 	if recovered != http.ErrAbortHandler {

--- a/internal/runner/server.go
+++ b/internal/runner/server.go
@@ -39,9 +39,9 @@ func NewRouter(mgr ContainerManager, cfg *config.Config) http.Handler {
 	proxy := ProxyHandler(mgr, cfg)
 	uploadProxy := UploadProxyHandler(mgr, cfg)
 
-	mux.HandleFunc("POST /sandboxes/{id}/exec", proxy)
-	mux.HandleFunc("GET /sandboxes/{id}/exec/{exec_id}", proxy)
-	mux.HandleFunc("DELETE /sandboxes/{id}/exec/{exec_id}", proxy)
+	mux.HandleFunc("POST /sandboxes/{id}/executions", proxy)
+	mux.HandleFunc("GET /sandboxes/{id}/executions/{exec_id}", proxy)
+	mux.HandleFunc("DELETE /sandboxes/{id}/executions/{exec_id}", proxy)
 	mux.HandleFunc("POST /sandboxes/{id}/files/copy", proxy)
 	mux.HandleFunc("POST /sandboxes/{id}/files/move", proxy)
 	mux.HandleFunc("GET /sandboxes/{id}/files", proxy)

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -15,6 +15,7 @@ let selectedSandboxId = null;
 let commandHistory = [];
 let historyIndex = -1;
 let currentAbortController = null;
+let currentExecId = null;
 let client = null;
 
 // --- SDK client ---
@@ -247,19 +248,58 @@ async function execInSandbox(sandboxId, command, timeoutMs = 300000, signal) {
   return exitCode;
 }
 
+async function abortExecution() {
+  if (!currentAbortController) return;
+
+  const execId = currentExecId;
+  const sandboxId = selectedSandboxId;
+
+  currentAbortController.abort();
+  appendOutput('^C', 'error');
+
+  if (execId && sandboxId) {
+    const baseUrl = baseUrlInput.value.trim().replace(/\/+$/, '');
+    try {
+      await fetch(`${baseUrl}/sandboxes/${sandboxId}/executions/${execId}`, {
+        method: 'DELETE',
+        headers: { 'X-Api-Key': apiKeyInput.value.trim() },
+      });
+    } catch {}
+  }
+}
+
+function setRunning(running) {
+  if (running) {
+    cmdInput.disabled = true;
+    runBtn.textContent = 'Abort';
+    runBtn.classList.add('danger');
+    runBtn.disabled = false;
+  } else {
+    cmdInput.disabled = false;
+    runBtn.textContent = 'Run';
+    runBtn.classList.remove('danger');
+    runBtn.disabled = false;
+  }
+}
+
 async function executeCommand() {
+  if (currentAbortController) {
+    abortExecution();
+    return;
+  }
+
   const cmd = cmdInput.value.trim();
   if (!cmd || !selectedSandboxId) return;
 
   commandHistory.push(cmd);
   historyIndex = commandHistory.length;
   cmdInput.value = '';
-  cmdInput.disabled = true;
-  runBtn.disabled = true;
 
   appendOutput(`$ ${cmd}`, 'cmd');
 
   currentAbortController = new AbortController();
+  currentExecId = null;
+  setRunning(true);
 
   try {
     await execInSandbox(selectedSandboxId, cmd, 300000, currentAbortController.signal);
@@ -269,14 +309,17 @@ async function executeCommand() {
     }
   } finally {
     currentAbortController = null;
-    cmdInput.disabled = false;
-    runBtn.disabled = false;
+    currentExecId = null;
+    setRunning(false);
     cmdInput.focus();
   }
 }
 
 function handleExecEvent(event) {
   switch (event.type) {
+    case 'started':
+      currentExecId = event.exec_id;
+      break;
     case 'stdout':
       if (event.data) appendOutput(event.data.replace(/\n$/, ''), 'stdout');
       break;
@@ -318,10 +361,7 @@ cmdInput.addEventListener('keydown', (e) => {
       cmdInput.value = '';
     }
   } else if (e.key === 'c' && e.ctrlKey) {
-    if (currentAbortController) {
-      currentAbortController.abort();
-      appendOutput('^C', 'error');
-    }
+    abortExecution();
   }
 });
 

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -189,7 +189,7 @@ async function deleteSandbox(id) {
 
 async function execInSandbox(sandboxId, command, timeoutMs = 300000, signal) {
   const baseUrl = baseUrlInput.value.trim().replace(/\/+$/, '');
-  const res = await fetch(`${baseUrl}/sandboxes/${sandboxId}/exec`, {
+  const res = await fetch(`${baseUrl}/sandboxes/${sandboxId}/executions`, {
     method: 'POST',
     headers: {
       'X-Api-Key': apiKeyInput.value.trim(),

--- a/scripts/smoke-local-sandbox.sh
+++ b/scripts/smoke-local-sandbox.sh
@@ -32,10 +32,10 @@ if [ -z "${sid}" ] || [ "${sid}" = "null" ]; then
 	exit 1
 fi
 
-echo "==> POST ${BASE}/sandboxes/${sid}/exec"
+echo "==> POST ${BASE}/sandboxes/${sid}/executions"
 tmp_exec_out="$(mktemp)"
 trap 'rm -f "${tmp_exec_out}"' EXIT HUP INT TERM
-curl -fsSN -X POST "${BASE}/sandboxes/${sid}/exec" \
+curl -fsSN -X POST "${BASE}/sandboxes/${sid}/executions" \
 	-H "X-Api-Key: ${KEY}" \
 	-H "Content-Type: application/json" \
 	-d '{"command":"echo hello world","timeout_ms":60000}' >"${tmp_exec_out}"

--- a/sdk/src/exec.ts
+++ b/sdk/src/exec.ts
@@ -38,7 +38,7 @@ export async function exec(
   // Phase 1: Start command via POST (idempotent via exec_id)
   while (!consumer.isDone) {
     try {
-      const { stream } = await http.requestStream("POST", `/sandboxes/${id}/exec`, {
+      const { stream } = await http.requestStream("POST", `/sandboxes/${id}/executions`, {
         data: {
           command: request.command,
           env: request.env,
@@ -66,7 +66,7 @@ export async function exec(
     try {
       const params: Record<string, string> = { follow: "true" };
       if (consumer.lastSeq >= 0) params.after = String(consumer.lastSeq);
-      const { stream } = await http.requestStream("GET", `/sandboxes/${id}/exec/${execId}`, {
+      const { stream } = await http.requestStream("GET", `/sandboxes/${id}/executions/${execId}`, {
         params,
         signal: request.abortSignal,
       });
@@ -94,7 +94,7 @@ export async function resumeExecution(
     params.after = String(afterSeq);
   }
 
-  const { stream } = await http.requestStream("GET", `/sandboxes/${sandboxId}/exec/${execId}`, {
+  const { stream } = await http.requestStream("GET", `/sandboxes/${sandboxId}/executions/${execId}`, {
     params,
   });
 
@@ -108,7 +108,7 @@ export async function deleteExecution(
   sandboxId: string,
   execId: string,
 ): Promise<void> {
-  await http.requestVoid("DELETE", `/sandboxes/${sandboxId}/exec/${execId}`);
+  await http.requestVoid("DELETE", `/sandboxes/${sandboxId}/executions/${execId}`);
 }
 
 function isTransientError(error: unknown): boolean {

--- a/sdk/test/exec.test.ts
+++ b/sdk/test/exec.test.ts
@@ -136,7 +136,7 @@ describe("exec", () => {
       timeoutMs: 5000,
     });
 
-    expect(http.requestStream).toHaveBeenCalledWith("POST", "/sandboxes/sandbox-1/exec", {
+    expect(http.requestStream).toHaveBeenCalledWith("POST", "/sandboxes/sandbox-1/executions", {
       data: {
         command: "ls",
         env: { FOO: "bar" },
@@ -228,7 +228,7 @@ describe("exec", () => {
     expect(mockHttp.requestStream).toHaveBeenCalledTimes(2);
     const resumeCall = (mockHttp.requestStream as ReturnType<typeof vi.fn>).mock.calls[1];
     expect(resumeCall[0]).toBe("GET");
-    expect(resumeCall[1]).toEqual(expect.stringMatching(/^\/sandboxes\/sandbox-1\/exec\/.+$/));
+    expect(resumeCall[1]).toEqual(expect.stringMatching(/^\/sandboxes\/sandbox-1\/executions\/.+$/));
     expect(resumeCall[2]).toEqual(
       expect.objectContaining({
         params: { after: "1", follow: "true" },
@@ -324,7 +324,7 @@ describe("exec", () => {
     // Should cancel using the client-defined exec_id, not the one from the started event
     expect(mockHttp.requestVoid).toHaveBeenCalledWith(
       "DELETE",
-      expect.stringMatching(/^\/sandboxes\/sandbox-1\/exec\/.+$/),
+      expect.stringMatching(/^\/sandboxes\/sandbox-1\/executions\/.+$/),
     );
   });
 });
@@ -340,7 +340,7 @@ describe("resumeExecution", () => {
 
     expect(result.stdout).toBe("part2");
     expect(result.exitCode).toBe(0);
-    expect(http.requestStream).toHaveBeenCalledWith("GET", "/sandboxes/sandbox-1/exec/exec-1", {
+    expect(http.requestStream).toHaveBeenCalledWith("GET", "/sandboxes/sandbox-1/executions/exec-1", {
       params: { after: "1", follow: "true" },
     });
   });


### PR DESCRIPTION
## Summary

- The "Run" button transforms into a red "Abort" button while a command is executing
- Clicking Abort or pressing Ctrl+C now calls `DELETE /sandboxes/{id}/executions/{exec_id}` to kill the server-side process, instead of only aborting the HTTP fetch stream
- Tracks the `exec_id` from the `started` event so the correct execution can be targeted for cancellation


https://github.com/user-attachments/assets/2758a5eb-33f3-4a3d-b812-e6e8fb9bc9af



## Test plan

- [ ] Run a long-running command (e.g. `sleep 60`) and verify the button changes to red "Abort"
- [ ] Click Abort and verify the process is killed server-side (exit event shows `killed: true`)
- [ ] Press Ctrl+C during execution and verify the same abort behavior
- [ ] Verify the button reverts to "Run" after execution completes or is aborted
- [ ] Verify normal command execution still works end-to-end