### PR TITLE
sdk: add publish pipeline

### DIFF
--- a/.github/workflows/release-sdk-prep.yml
+++ b/.github/workflows/release-sdk-prep.yml
@@ -1,0 +1,65 @@
+name: SDK Release Prep
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prep-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+
+      - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6
+        with:
+          version: 10
+
+      - name: Bump version
+        id: bump
+        working-directory: sdk
+        run: |
+          npm version ${{ inputs.bump }} --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Sync lockfile
+        working-directory: sdk
+        run: pnpm install --lockfile-only
+
+      - name: Create release branch and PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          BRANCH="sdk/release/${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add sdk/package.json sdk/pnpm-lock.yaml
+          git commit -m "sdk: bump version to v${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "sdk: release v${VERSION}" \
+            --body "Automated release PR for \`@n8n/sandbox-client@${VERSION}\`.
+
+          Merging this PR will trigger the SDK publish workflow."

--- a/.github/workflows/release-sdk-publish.yml
+++ b/.github/workflows/release-sdk-publish.yml
@@ -1,0 +1,63 @@
+name: SDK Publish
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'sdk/release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6
+        with:
+          version: 10
+
+      - name: Read version
+        id: version
+        working-directory: sdk
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        working-directory: sdk
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        working-directory: sdk
+        run: pnpm build
+
+      - name: Publish to npm
+        working-directory: sdk
+        run: pnpm publish --provenance --access public --no-git-checks
+
+      - name: Create git tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git tag "sdk/v${VERSION}"
+          git push origin "sdk/v${VERSION}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "sdk/v${VERSION}" \
+            --title "@n8n/sandbox-client v${VERSION}" \
+            --generate-notes

--- a/.github/workflows/release-sdk-publish.yml
+++ b/.github/workflows/release-sdk-publish.yml
@@ -15,6 +15,9 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'sdk/release/')
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -32,35 +35,41 @@ jobs:
 
       - name: Read version
         id: version
-        working-directory: sdk
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
-        working-directory: sdk
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        working-directory: sdk
         run: pnpm build
 
       - name: Publish to npm
-        working-directory: sdk
-        run: npm publish --provenance --access public
+        run: npm publish --provenance
 
       - name: Create git tag
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          git tag "sdk/v${VERSION}"
-          git push origin "sdk/v${VERSION}"
+          TAG="sdk/v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists; skipping"
+          else
+            git tag "${TAG}"
+            git push origin "${TAG}"
+          fi
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          gh release create "sdk/v${VERSION}" \
-            --title "@n8n/sandbox-client v${VERSION}" \
-            --generate-notes
+          TAG="sdk/v${VERSION}"
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists; skipping"
+          else
+            gh release create "${TAG}" \
+              --title "@n8n/sandbox-client v${VERSION}" \
+              --generate-notes
+          fi

--- a/.github/workflows/release-sdk-publish.yml
+++ b/.github/workflows/release-sdk-publish.yml
@@ -49,27 +49,20 @@ jobs:
         run: npm publish --provenance
 
       - name: Create git tag
+        working-directory: .
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           TAG="sdk/v${VERSION}"
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists; skipping"
-          else
-            git tag "${TAG}"
-            git push origin "${TAG}"
-          fi
+          git tag --force "${TAG}"
+          git push --force origin "${TAG}"
 
       - name: Create GitHub Release
+        working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          TAG="sdk/v${VERSION}"
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            echo "Release ${TAG} already exists; skipping"
-          else
-            gh release create "${TAG}" \
-              --title "@n8n/sandbox-client v${VERSION}" \
-              --generate-notes
-          fi
+          gh release create "sdk/v${VERSION}" \
+            --title "@n8n/sandbox-client v${VERSION}" \
+            --generate-notes

--- a/.github/workflows/release-sdk-publish.yml
+++ b/.github/workflows/release-sdk-publish.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           version: 10
 
+      - name: Update npm
+        run: npm install -g npm@11
+
       - name: Read version
         id: version
         working-directory: sdk
@@ -44,7 +47,7 @@ jobs:
 
       - name: Publish to npm
         working-directory: sdk
-        run: pnpm publish --provenance --access public --no-git-checks
+        run: npm publish --provenance --access public
 
       - name: Create git tag
         env:

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -15,6 +15,15 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/n8n-io/n8n-sandbox-service.git",
+    "directory": "sdk"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Adds a manual SDK release prep workflow that bumps @n8n/sandbox-client, syncs the lockfile, and opens a release PR.

Adds a publish workflow that runs when sdk/release/* PRs are merged, builds the SDK, publishes to npm with provenance, tags the release, and creates a GitHub release.

Updates sdk/package.json with repository metadata and public provenance publish config.

Checks: node package.json parse; git diff --check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual release prep workflow and an automated publish pipeline for the SDK to bump versions, publish `@n8n/sandbox-client` to npm with provenance, and create tags/releases.

- **New Features**
  - Manual "SDK Release Prep" workflow: choose bump type, update `sdk/package.json`, sync lockfile, and open `sdk/release/<version>` PR.
  - "SDK Publish" workflow: on merge of `sdk/release/*` PRs into `main`, use `npm@11`, build, publish to npm (`--provenance`), force-update `sdk/v<version>` tag, and create a GitHub Release.
  - `sdk/package.json`: added `repository` (with `directory: "sdk"`) and `publishConfig` with public access and provenance.

<sup>Written for commit 43ca9e537af5454f06a43b19290c295397a0e84b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

