### PR TITLE
fix: update stale /exec endpoint in daemon health check

### DIFF
--- a/internal/runner/manager/manager.go
+++ b/internal/runner/manager/manager.go
@@ -284,7 +284,7 @@ func waitForDaemon(ctx context.Context, baseURL string) error {
 			execReq, err := http.NewRequestWithContext(
 				ctx,
 				http.MethodPost,
-				baseURL+"/exec",
+				baseURL+"/executions",
 				bytes.NewBufferString(`{"command":"true","timeout_ms":2000}`),
 			)
 			if err != nil {
@@ -300,7 +300,7 @@ func waitForDaemon(ctx context.Context, baseURL string) error {
 			if execResp.StatusCode != http.StatusOK {
 				continue
 			}
-			// Daemon /exec streams NDJSON events; require a successful exit event.
+			// Daemon /executions streams NDJSON events; require a successful exit event.
 			if isSuccessfulExit(body) {
 				return nil
 			}


### PR DESCRIPTION
The daemon endpoint was renamed from `/exec` to `/executions` in #22, but the health-check probe in `waitForDaemon()` was not updated. This caused the probe to get 404s and time out after 30 seconds, breaking all sandbox creation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the daemon health check to call /executions instead of /exec, matching the renamed endpoint. This fixes 404s and 30s timeouts during startup that blocked sandbox creation.

<sup>Written for commit a8c932e2ef29762ab3c74813c3865980f38b18f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

