### PR TITLE
Fix sdk npm publish workflow

### DIFF
--- a/.github/workflows/release-sdk-publish.yml
+++ b/.github/workflows/release-sdk-publish.yml
@@ -6,11 +6,13 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  # Required to mint an OIDC token for npm provenance attestation.
   id-token: write
+  contents: write
 
 jobs:
   publish:
+    environment: npm
     if: >-
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'sdk/release/')
@@ -30,9 +32,6 @@ jobs:
         with:
           version: 10
 
-      - name: Update npm
-        run: npm install -g npm@11
-
       - name: Read version
         id: version
         run: |
@@ -45,8 +44,11 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Dry-run publishing
+        run: pnpm publish --dry-run
+
       - name: Publish to npm
-        run: npm publish --provenance
+        run: pnpm publish
 
       - name: Create git tag
         working-directory: .


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the SDK publish workflow by switching to `pnpm` and setting the right GitHub Actions permissions, making releases reliable from `sdk/release/*` PRs. Adds a dry-run and scopes the job to the `npm` environment.

- **Bug Fixes**
  - Set `permissions.id-token: write` (OIDC) and kept `contents: write`.
  - Scoped the job to `environment: npm`.
  - Replaced `npm publish --provenance` with `pnpm publish`; removed the global `npm@11` install.
  - Added `pnpm publish --dry-run` before publishing.

<sup>Written for commit 63759aabedb70e72bda5d9b2577bc120442db9ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

