### PR TITLE
Use n8n assistant to create release PR

### DIFF
--- a/.github/workflows/release-sdk-prep.yml
+++ b/.github/workflows/release-sdk-prep.yml
@@ -58,7 +58,7 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           commit-message: 'sdk: release v${{ steps.bump.outputs.version }}'
           labels: 'release/sdk'
-          title: 'chore: Update node popularity data'
+          title: 'sdk: release v${{ steps.bump.outputs.version }}'
           body: |
             Automated release PR for `@n8n/sandbox-client@${{ steps.bump.outputs.version }}`.
 

--- a/.github/workflows/release-sdk-prep.yml
+++ b/.github/workflows/release-sdk-prep.yml
@@ -32,6 +32,13 @@ jobs:
         with:
           version: 10
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+
       - name: Bump version
         id: bump
         working-directory: sdk
@@ -44,22 +51,20 @@ jobs:
         working-directory: sdk
         run: pnpm install --lockfile-only
 
-      - name: Create release branch and PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.bump.outputs.version }}
-        run: |
-          BRANCH="sdk/release/${VERSION}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
-          git add sdk/package.json sdk/pnpm-lock.yaml
-          git commit -m "sdk: bump version to v${VERSION}"
-          git push origin "$BRANCH"
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "sdk: release v${VERSION}" \
-            --body "Automated release PR for \`@n8n/sandbox-client@${VERSION}\`.
+      - name: Create Pull Request
+        id: create-pr
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: 'sdk: release v${{ steps.bump.outputs.version }}'
+          labels: 'release/sdk'
+          title: 'chore: Update node popularity data'
+          body: |
+            Automated release PR for `@n8n/sandbox-client@${{ steps.bump.outputs.version }}`.
 
-          Merging this PR will trigger the SDK publish workflow."
+            Merging this PR will trigger the SDK publish workflow.
+          branch: sdk/release/${{ steps.bump.outputs.version }}
+          base: main
+          delete-branch: true
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
To overcome issues CI not running if using GH token to create PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches SDK release PR creation to use the n8n assistant GitHub App so CI runs on the PR. Replaces manual git/GH CLI with `peter-evans/create-pull-request` and sets clear PR title/body and labels.

- **Refactors**
  - Generate a GitHub App token via `actions/create-github-app-token` using `N8N_ASSISTANT_APP_ID` and `N8N_ASSISTANT_PRIVATE_KEY`.
  - Create the PR with `peter-evans/create-pull-request`: branch `sdk/release/${version}`, base `main`, label `release/sdk`, author/committer `github-actions[bot]`, auto-delete branch; title/body note the `@n8n/sandbox-client` version and that merging triggers the publish workflow.
  - Remove the `gh pr create` flow using `GITHUB_TOKEN` that prevented CI.

<sup>Written for commit ca7eb3757643218a6ca254af47d174d767eabb97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

