### PR TITLE
Remove incorrect fields from API docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -80,7 +80,6 @@ Resource limits (memory, CPU, process count) are configured on the runner via en
 {
   "id": "uuid",
   "status": "string",
-  "provider": "delhi",
   "created_at": 1700000000,
   "last_active_at": 1700000000
 }
@@ -110,7 +109,6 @@ Get sandbox details.
 {
   "id": "uuid",
   "status": "string",
-  "provider": "delhi",
   "created_at": 1700000000,
   "last_active_at": 1700000000
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the `provider` field from sandbox response examples in `API.md` to match the actual API and avoid confusion.

<sup>Written for commit 38f0967a62d8fd1c5414a3d7be14cca31650fee7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

