### PR TITLE
ci: Adjust SDK release to use two-branch flow

### DIFF
--- a/.github/workflows/release-sdk-prep.yml
+++ b/.github/workflows/release-sdk-prep.yml
@@ -51,6 +51,9 @@ jobs:
         working-directory: sdk
         run: pnpm install --lockfile-only
 
+      - name: Create release branch
+        run: git push origin HEAD:refs/heads/sdk/release/${{ steps.bump.outputs.version }}
+
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
@@ -63,8 +66,8 @@ jobs:
             Automated release PR for `@n8n/sandbox-client@${{ steps.bump.outputs.version }}`.
 
             Merging this PR will trigger the SDK publish workflow.
-          branch: sdk/release/${{ steps.bump.outputs.version }}
-          base: main
+          branch: sdk/release-pr/${{ steps.bump.outputs.version }}
+          base: sdk/release/${{ steps.bump.outputs.version }}
           delete-branch: true
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/release-sdk-publish.yml
+++ b/.github/workflows/release-sdk-publish.yml
@@ -3,25 +3,28 @@ name: SDK Publish
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    branches:
+      - 'sdk/release/**'
 
 permissions:
   # Required to mint an OIDC token for npm Trusted Publishing and provenance.
   id-token: write
   contents: write
+  pull-requests: write
 
 jobs:
   publish:
     environment: npm
-    if: >-
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'sdk/release/')
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: sdk
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 100
 
       # Node 24 ships with npm >=11.5.1, which is required for npm Trusted
       # Publishing to exchange the OIDC token for a registry auth token. The
@@ -49,10 +52,14 @@ jobs:
         run: pnpm build
 
       - name: Dry-run publishing
-        run: pnpm publish --dry-run
+        env:
+          RELEASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: pnpm publish --dry-run --publish-branch "$RELEASE_BRANCH"
 
       - name: Publish to npm
-        run: pnpm publish
+        env:
+          RELEASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: pnpm publish --publish-branch "$RELEASE_BRANCH"
 
       - name: Create git tag
         working-directory: .
@@ -72,3 +79,42 @@ jobs:
           gh release create "sdk/v${VERSION}" \
             --title "@n8n/sandbox-client v${VERSION}" \
             --generate-notes
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+
+      - name: Open version-bump PR against main
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="sdk/post-release/${VERSION}"
+
+          git fetch origin main
+          git checkout -b "${BRANCH}" origin/main
+
+          cd sdk
+          npm version "${VERSION}" --no-git-tag-version --allow-same-version
+          pnpm install --lockfile-only
+          cd ..
+
+          git add sdk/package.json sdk/pnpm-lock.yaml
+          git commit -m "sdk: bump version to v${VERSION}"
+
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin "${BRANCH}"
+
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "sdk: bump version to v${VERSION}" \
+            --body "Automated post-release PR to update version on main after publishing @n8n/sandbox-client@${VERSION}." \
+            --label "release/sdk"


### PR DESCRIPTION
## Summary

Splits the SDK release into a two-branch flow: the prep workflow now creates a stable `sdk/release/<version>` branch (snapshot of main) and a `sdk/release-pr/<version>` branch that bumps the version and opens a PR targeting the release branch. When that PR is merged, the publish workflow runs npm publish from the release branch, then automatically opens a post-release PR (`sdk/post-release/<version>` → `main`) to propagate the version bump back to main.

## Changes

- **release-sdk-prep.yml**: Push `sdk/release/<version>` from HEAD before bumping, then create the version-bump PR as `sdk/release-pr/<version>` targeting the release branch instead of main.
- **release-sdk-publish.yml**: Trigger on merges into `sdk/release/**`, checkout the release branch explicitly, pass `--publish-branch` to pnpm publish, and add a post-publish step that generates an app token, sets the version on a new branch off main, and opens a PR.

## Test plan

- [ ] Trigger the prep workflow with a `patch` bump and verify both branches and the PR are created correctly
- [ ] Merge the release PR and verify npm publish, git tag, GitHub release, and the post-release PR to main all succeed
- [ ] Verify the `sdk/release/<version>` branch is preserved after publish

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the SDK release to a two-branch flow for safer, repeatable publishes and automatic sync back to `main`. We create `sdk/release/<version>`, merge a version-bump PR from `sdk/release-pr/<version>` into it, publish on merge, then open a post-release PR to `main` for `@n8n/sandbox-client`.

- **Refactors**
  - Prep: push `sdk/release/<version>` from `main` HEAD, then open `sdk/release-pr/<version>` targeting the release branch.
  - Publish: trigger on merges into `sdk/release/**`; checkout the release branch and run `pnpm publish` with `--publish-branch`.
  - Post-release: create git tag and GitHub release (`sdk/v<version>`), then open `sdk/post-release/<version>` → `main` PR using a GitHub App token.
  - Workflow tweaks: add `pull-requests: write` permission and fetch the base ref explicitly.

<sup>Written for commit e917eaf535f5f91a106478437b5ae06a3293a35c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

