### PR TITLE
ci: Omit default changelog from SDK GitHub release

### DIFF
--- a/.github/workflows/release-sdk-publish.yml
+++ b/.github/workflows/release-sdk-publish.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           gh release create "sdk/v${VERSION}" \
             --title "@n8n/sandbox-client v${VERSION}" \
-            --generate-notes
+            --notes ""
 
       - name: Generate GitHub App Token
         id: generate-token


### PR DESCRIPTION
## Summary
- Replaces `--generate-notes` with `--notes ""` in the SDK publish workflow's GitHub release step, so releases are created without an auto-generated changelog.

## Test plan
- [ ] Trigger a SDK release and verify the GitHub release is created with an empty body instead of auto-generated notes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop generating default changelog notes in SDK GitHub releases by switching the `gh release create` flag from `--generate-notes` to `--notes ""`. Releases now publish with an empty body.

<sup>Written for commit 6d30ab5ddf115ea86baa03abc9c32e5ea9b9eef6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

