### PR TITLE
ci: Use Blacksmith runner for e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: sdk
 
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: make docker-amd64
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
Use a Blacksmith 4-vCPU runner for e2e tests instead of the default GitHub-hosted runner, for faster execution. Falls back to `ubuntu-latest` when `RUNNER_PROVIDER` is set to `github`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Docker build and e2e jobs on the Blacksmith 4‑vCPU runner to speed up CI. Falls back to `ubuntu-latest` when `vars.RUNNER_PROVIDER` is `github`.

<sup>Written for commit 1e958a750daf849c2e64024bbd3bb4eb69e47563. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

