### PR TITLE
fix(e2e): Wait for local registry before pushing sandbox image

### DIFF
--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -65,6 +65,19 @@ e2e_docker_network_create() {
 	return 1
 }
 
+e2e_wait_for_registry() {
+	local port=$1
+	local i
+	for i in $(seq 1 30); do
+		if curl -sf "http://localhost:${port}/v2/" >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 0.5
+	done
+	echo "Registry on port $port failed to start within 15s" >&2
+	return 1
+}
+
 e2e_wait_for_api_http() {
 	local port=$1 container=$2
 	local i

--- a/e2e/run-two-runners.sh
+++ b/e2e/run-two-runners.sh
@@ -83,6 +83,10 @@ else
 	docker network connect "$NETWORK_NAME" "$REGISTRY_NAME" >/dev/null 2>&1 || true
 fi
 
+if [[ "${STARTED_REGISTRY:-}" == "true" ]]; then
+	e2e_wait_for_registry "$REGISTRY_PORT"
+fi
+
 echo "Pushing sandbox image to local registry..."
 docker tag "$SANDBOX_IMAGE" "$PUSH_SANDBOX_IMAGE"
 docker push "$PUSH_SANDBOX_IMAGE"

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -87,6 +87,10 @@ else
 	docker network connect "$NETWORK_NAME" "$REGISTRY_NAME" >/dev/null 2>&1 || true
 fi
 
+if [[ "${STARTED_REGISTRY:-}" == "true" ]]; then
+	e2e_wait_for_registry "$REGISTRY_PORT"
+fi
+
 echo "Pushing sandbox image to local registry..."
 docker tag "$SANDBOX_IMAGE" "$PUSH_SANDBOX_IMAGE"
 docker push "$PUSH_SANDBOX_IMAGE"


### PR DESCRIPTION
## Summary

Fix a race condition in the e2e tests that started occurring after we switched over to blacksmith runners:

- E2e tests start a local Docker registry and immediately push to it without waiting for readiness, causing a race condition (`connection reset by peer`) on fast Blacksmith CI runners.
- Adds an `e2e_wait_for_registry` helper that polls the registry's `/v2/` endpoint for up to 15s before pushing.
- Applied to both `run.sh` and `run-two-runners.sh`.

## Test plan

- [ ] Verify e2e tests pass on Blacksmith runners in CI