### PR TITLE
Add dry-run flag to sysbox install script

### DIFF
--- a/scripts/setup-sysbox.sh
+++ b/scripts/setup-sysbox.sh
@@ -8,6 +8,7 @@ MANUAL_INSTALL_URL="https://github.com/nestybox/sysbox/blob/master/docs/user-gui
 SHA256_AMD64="eeff273671467b8fa351ab3d40709759462dc03d9f7b50a1b207b37982ce40a9"
 SHA256_ARM64="eae9c0e91ddd39bd1826d6a7a313a73d42a8449ef5113e9d6d118b559cb809ba"
 
+DRY_RUN="${DRY_RUN:-}"
 DL_DIR=""
 
 cleanup() {
@@ -89,8 +90,12 @@ check_sudo() {
 
 check_sysbox_installed() {
 	if command -v sysbox-runc >/dev/null 2>&1 && systemctl is-active --quiet sysbox 2>/dev/null; then
-		echo "==> Sysbox is already installed and running. Nothing to do."
-		exit 0
+		if [[ "$DRY_RUN" == "1" ]]; then
+			echo "==> Sysbox is already installed and running."
+		else
+			echo "==> Sysbox is already installed and running. Nothing to do."
+			exit 0
+		fi
 	fi
 }
 
@@ -189,6 +194,17 @@ verify_sysbox() {
 }
 
 main() {
+	for arg in "$@"; do
+		case "$arg" in
+			--dry-run) DRY_RUN=1 ;;
+			*) err "Unknown argument: $arg" ;;
+		esac
+	done
+
+	if [[ "$DRY_RUN" == "1" ]]; then
+		echo "==> [DRY RUN] Checking prerequisites only — no changes will be made"
+	fi
+
 	echo "==> Setting up sysbox v${SYSBOX_VERSION}"
 
 	check_sysbox_installed
@@ -201,20 +217,50 @@ main() {
 	check_docker
 	check_sudo
 
-	echo "==> Installing dependencies..."
-	install_jq
-	ensure_br_netfilter
+	if [[ "$DRY_RUN" == "1" ]]; then
+		echo "==> [DRY RUN] Would install dependencies (jq, br_netfilter kernel module)"
+		if command -v jq >/dev/null 2>&1; then
+			echo "    jq: already installed"
+		else
+			echo "    jq: not installed — would install via apt-get"
+		fi
+		if lsmod | grep -q br_netfilter; then
+			echo "    br_netfilter: already loaded"
+		else
+			echo "    br_netfilter: not loaded — would modprobe and persist"
+		fi
 
-	echo "==> Downloading sysbox..."
-	download_sysbox "$arch"
+		local filename="sysbox-ce_${SYSBOX_VERSION}-0.linux_${arch}.deb"
+		echo "==> [DRY RUN] Would download ${filename} from ${SYSBOX_BASE_URL}/${filename}"
+		echo "==> [DRY RUN] Would stop/remove running Docker containers (if any)"
 
-	stop_docker_containers
-	install_sysbox
+		local running
+		running=$(docker ps -q) || true
+		if [[ -z "$running" ]]; then
+			echo "    No running containers"
+		else
+			echo "    $(echo "$running" | wc -l | tr -d ' ') running container(s) would be stopped and removed"
+		fi
 
-	echo "==> Verifying sysbox installation..."
-	verify_sysbox
+		echo "==> [DRY RUN] Would install sysbox via apt-get"
+		echo "==> [DRY RUN] Would verify sysbox installation (skipped — sysbox not installed)"
+		echo "==> [DRY RUN] Prerequisite checks passed. Machine appears ready for sysbox installation."
+	else
+		echo "==> Installing dependencies..."
+		install_jq
+		ensure_br_netfilter
 
-	echo "==> Sysbox v${SYSBOX_VERSION} installed successfully!"
+		echo "==> Downloading sysbox..."
+		download_sysbox "$arch"
+
+		stop_docker_containers
+		install_sysbox
+
+		echo "==> Verifying sysbox installation..."
+		verify_sysbox
+
+		echo "==> Sysbox v${SYSBOX_VERSION} installed successfully!"
+	fi
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Adds `--dry-run` flag (and `DRY_RUN=1` env var) to `scripts/setup-sysbox.sh`
- In dry-run mode, all read-only prerequisite checks (arch, distro, kernel, Docker, sudo) run normally
- All mutating steps (installing jq, loading kernel modules, downloading/installing sysbox, stopping containers) are skipped with informational output about what would happen
- If sysbox is already installed, dry-run reports this but continues showing the full prerequisite report instead of exiting early

```
$ sudo ./setup.sh --dry-run
==> [DRY RUN] Checking prerequisites only — no changes will be made
==> Setting up sysbox v0.7.0
==> Sysbox is already installed and running.
==> Checking prerequisites...
==> Distribution: ubuntu 24.04
==> Kernel: 6.17.0-1012-aws
==> Docker: installed
==> [DRY RUN] Would install dependencies (jq, br_netfilter kernel module)
    jq: already installed
    br_netfilter: already loaded
==> [DRY RUN] Would download sysbox-ce_0.7.0-0.linux_amd64.deb from https://downloads.nestybox.com/sysbox/releases/v0.7.0/sysbox-ce_0.7.0-0.linux_amd64.deb
==> [DRY RUN] Would stop/remove running Docker containers (if any)
    No running containers
==> [DRY RUN] Would install sysbox via apt-get
==> [DRY RUN] Would verify sysbox installation (skipped — sysbox not installed)
==> [DRY RUN] Prerequisite checks passed. Machine appears ready for sysbox installation.
```

## Test plan

- [ ] Run `bash scripts/setup-sysbox.sh --dry-run` on a Linux machine — verify checks run and no mutations occur
- [ ] Run `DRY_RUN=1 bash scripts/setup-sysbox.sh` — same behavior via env var
- [ ] Run `bash scripts/setup-sysbox.sh --bogus` — should error with "Unknown argument"
- [ ] Run without flags — verify normal installation flow is unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--dry-run` mode to the Sysbox install script so users can verify prerequisites without making changes and see what would happen. Implements Linear CAT-3119 for safer environment validation.

- **New Features**
  - New `--dry-run` flag and `DRY_RUN=1` env var; runs arch/distro/kernel/Docker/sudo checks only.
  - Skips installing `jq`, loading `br_netfilter`, downloading/installing Sysbox, and stopping containers; prints intended actions (download URL, container count).
  - If Sysbox is already installed, dry-run reports it and continues checks; normal mode unchanged; unknown args now error.

<sup>Written for commit a15945eadc43adbef502f45a32ee99c9294e13e3. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/47?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

