### PR TITLE
Remove dead HTTP sandbox create/delete/list routes from runner

### DIFF
--- a/internal/runner/handlers.go
+++ b/internal/runner/handlers.go
@@ -1,9 +1,7 @@
 package runner
 
 import (
-	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"regexp"
 
@@ -12,9 +10,6 @@ import (
 
 var uuidRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
-// CreateSandboxRequest is the optional JSON body for POST /sandboxes.
-type CreateSandboxRequest struct{}
-
 // ContainerResponse is the JSON response for container operations.
 type ContainerResponse struct {
 	ID           string `json:"id"`
@@ -22,65 +17,6 @@ type ContainerResponse struct {
 	CreatedAt    int64  `json:"created_at"`
 	LastActiveAt int64  `json:"last_active_at"`
 	IP           string `json:"ip,omitempty"`
-}
-
-// ListSandboxes handles GET /sandboxes - returns empty for stateless runner
-func ListSandboxes(mgr ContainerManager) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Stateless runner has no list of sandboxes
-		writeJSON(w, http.StatusOK, []ContainerResponse{})
-	}
-}
-
-// CreateSandbox handles POST /sandboxes
-func CreateSandbox(mgr ContainerManager) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		var req CreateSandboxRequest
-
-		// Parse optional JSON body
-		if r.Body != nil {
-			r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB limit
-			body, err := io.ReadAll(r.Body)
-			if err != nil {
-				writeError(w, http.StatusBadRequest, "failed to read request body")
-				return
-			}
-			if len(body) > 0 {
-				if err := json.Unmarshal(body, &req); err != nil {
-					writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
-					return
-				}
-			}
-		}
-
-		// Get sandbox ID from header (set by API gateway)
-		sandboxID := r.Header.Get("X-Sandbox-Id")
-		if sandboxID == "" {
-			writeError(w, http.StatusBadRequest, "missing X-Sandbox-Id header")
-			return
-		}
-		if !isValidID(sandboxID) {
-			writeError(w, http.StatusBadRequest, "invalid sandbox id")
-			return
-		}
-
-		opts := &manager.CreateOptions{}
-
-		info, err := mgr.CreateContainer(r.Context(), sandboxID, opts)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		resp := &ContainerResponse{
-			ID:     sandboxID,
-			Status: "running",
-		}
-		if info != nil {
-			resp.IP = info.IP
-		}
-		writeJSON(w, http.StatusCreated, resp)
-	}
 }
 
 // GetSandbox handles GET /sandboxes/{id}
@@ -106,35 +42,6 @@ func GetSandbox(mgr ContainerManager) http.HandlerFunc {
 			Status: "running",
 		}
 		writeJSON(w, http.StatusOK, resp)
-	}
-}
-
-// DeleteSandbox handles DELETE /sandboxes/{id}
-func DeleteSandbox(mgr ContainerManager) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		sandboxID := r.PathValue("id")
-		if !isValidID(sandboxID) {
-			writeError(w, http.StatusBadRequest, "invalid sandbox id")
-			return
-		}
-
-		// Find container ID by sandbox ID using labels
-		containerID, err := mgr.FindContainerIDByLabel(r.Context(), sandboxID)
-		if err != nil {
-			if errors.Is(err, manager.ErrSandboxNotFound) {
-				writeError(w, http.StatusNotFound, err.Error())
-			} else {
-				writeError(w, http.StatusInternalServerError, err.Error())
-			}
-			return
-		}
-
-		if err := mgr.DeleteContainer(r.Context(), containerID); err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/internal/runner/server.go
+++ b/internal/runner/server.go
@@ -29,11 +29,7 @@ func NewRouter(mgr ContainerManager, cfg *config.Config) http.Handler {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	// Sandbox CRUD (stateless - no database persistence)
-	mux.HandleFunc("GET /sandboxes", ListSandboxes(mgr))
-	mux.HandleFunc("POST /sandboxes", CreateSandbox(mgr))
 	mux.HandleFunc("GET /sandboxes/{id}", GetSandbox(mgr))
-	mux.HandleFunc("DELETE /sandboxes/{id}", DeleteSandbox(mgr))
 
 	// Proxy exec, files, mkdir, stat to daemon
 	proxy := ProxyHandler(mgr, cfg)


### PR DESCRIPTION
These endpoints were never called after the control plane moved to
gRPC (SandboxControl.CreateSandbox / DeleteSandbox). The HTTP routes
are an unnecessary attack surface now that the API uses runnerctl
for all sandbox lifecycle operations.

https://claude.ai/code/session_01UAZsgr3RXEXpZn3Pu1CLni

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused HTTP sandbox create/delete/list routes from the runner. Sandbox lifecycle now flows only through gRPC (`SandboxControl`) and `runnerctl`, reducing attack surface.

- **Refactors**
  - Removed handlers and routes for GET /sandboxes, POST /sandboxes, DELETE /sandboxes/{id}.
  - Kept GET /sandboxes/{id} for status checks; no change to active paths.

<sup>Written for commit d544b8ab60934feec57851f2da4e50893d030da6. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/48?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

