### PR TITLE
fix: use constant-time compare for gRPC bearer token

### DIFF
--- a/internal/api/grpc/runner_server.go
+++ b/internal/api/grpc/runner_server.go
@@ -1,6 +1,7 @@
 package grpcapi
 
 import (
+	"crypto/subtle"
 	"io"
 	"strings"
 
@@ -31,7 +32,7 @@ func validateBearer(md metadata.MD, token string) bool {
 		const prefix = "Bearer "
 		if strings.HasPrefix(strings.ToLower(v), strings.ToLower(prefix)) {
 			got := strings.TrimSpace(v[len(prefix):])
-			return got == token
+			return subtle.ConstantTimeCompare([]byte(got), []byte(token)) == 1
 		}
 	}
 	return false


### PR DESCRIPTION
Replace plain string equality (`got == token`) with `subtle.ConstantTimeCompare` in the gRPC `validateBearer` function to prevent timing attacks. This aligns the gRPC auth path with the HTTP API-key middleware, which already uses constant-time comparison.

Closes CAT-3136

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use constant-time comparison for the gRPC bearer token to prevent timing attacks and align with the HTTP API-key middleware (CAT-3136). Replaced plain string equality in `validateBearer` with `crypto/subtle` constant-time compare.

<sup>Written for commit a72baf15baa89c8a20c42aa8e10e5dd7f09bd986. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/52?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

