### PR TITLE
fix(runner): disable IPv6 inside sandbox containers

### DIFF
--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -73,6 +73,21 @@ import time; time.sleep(30)
     }
   });
 
+  test('sandbox has IPv6 disabled', async () => {
+    const id = await createSandbox();
+    try {
+      const result = await exec(
+        id,
+        'cat /proc/sys/net/ipv6/conf/all/disable_ipv6',
+        { timeoutMs: 5_000 },
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('1');
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+
   test('DNS resolution works', async () => {
     const id = await createSandbox();
     try {

--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -8,6 +8,9 @@ const pyGet = (url: string, timeout: number = 5) =>
 const pyConnect = (ip: string, port: number = 80, timeout: number = 3) =>
   `python3 -c "import socket; s=socket.socket(); s.settimeout(${timeout}); s.connect(('${ip}', ${port})); s.close(); print('connected')"`;
 
+const pyConnectV6 = (ip: string, port: number = 443, timeout: number = 3) =>
+  `python3 -c "import socket; s=socket.socket(socket.AF_INET6); s.settimeout(${timeout}); s.connect(('${ip}', ${port})); s.close(); print('connected')"`;
+
 const pyResolve = (host: string) =>
   `python3 -c "import socket; print(socket.gethostbyname('${host}'))"`;
 
@@ -73,16 +76,20 @@ import time; time.sleep(30)
     }
   });
 
-  test('sandbox has IPv6 disabled', async () => {
+  test('sandbox cannot reach IPv6 destinations', async () => {
     const id = await createSandbox();
     try {
-      const result = await exec(
-        id,
-        'cat /proc/sys/net/ipv6/conf/all/disable_ipv6',
-        { timeoutMs: 5_000 },
-      );
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout.trim()).toBe('1');
+      // Cloudflare and Google public DNS, IPv6 addresses. With IPv6 disabled
+      // in the container netns, the AF_INET6 connect must fail.
+      const v6Targets = [
+        '2606:4700:4700::1111',
+        '2001:4860:4860::8888',
+      ];
+
+      for (const ip of v6Targets) {
+        const result = await execWithTransientRetry(id, pyConnectV6(ip, 443, 3), { timeoutMs: 10_000 });
+        expect(result.exitCode, `expected IPv6 ${ip} to be unreachable`).not.toBe(0);
+      }
     } finally {
       await deleteSandbox(id);
     }

--- a/internal/runner/manager/docker_client.go
+++ b/internal/runner/manager/docker_client.go
@@ -89,6 +89,11 @@ func (dc *dockerClient) createContainer(ctx context.Context, sandboxID, containe
 		"--user", "1000:1000",
 		"--env", "HOME=/home/user",
 		"--env", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		// netrules only filter IPv4; disable v6 in the container so sandboxes
+		// can't bypass the policy via link-local/ULA or v6 metadata addresses.
+		"--sysctl", "net.ipv6.conf.all.disable_ipv6=1",
+		"--sysctl", "net.ipv6.conf.default.disable_ipv6=1",
+		"--sysctl", "net.ipv6.conf.lo.disable_ipv6=1",
 	}
 	if enableCgroups {
 		args = append(args, dockerLimitArgs(limits)...)


### PR DESCRIPTION
## Summary
- `netrules` only filters IPv4 via `iptables`; if the runner host has IPv6 enabled a sandbox could reach link-local (`fe80::/10`), ULA (`fc00::/7`), sibling sandboxes, or the v6 metadata IP — bypassing our v4-only egress policy.
- Disable the v6 stack inside each sandbox container by passing `--sysctl net.ipv6.conf.{all,default,lo}.disable_ipv6=1` on create. No v6 packet can leave the netns regardless of host/bridge configuration.
- Adds an e2e check in `network-isolation.spec.ts` that `/proc/sys/net/ipv6/conf/all/disable_ipv6` reads `1` inside a fresh sandbox.

Refs [CAT-3137](https://linear.app/n8n/issue/CAT-3137/block-ipv6-egress-on-sandbox-network).

## Test plan
- [x] `make fmt-check`
- [x] `make vet`
- [x] `go test ./internal/runner/manager/... ./internal/runner/netrules/...`
- [ ] e2e `network-isolation.spec.ts` (sysbox runner required — runs in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable IPv6 inside sandbox containers so sandboxes can’t bypass the IPv4-only `netrules` egress policy via link-local, ULA, or IPv6 metadata addresses. Pass `--sysctl net.ipv6.conf.{all,default,lo}.disable_ipv6=1` on create and add a behavioral e2e test that attempts AF_INET6 connects to public IPv6 DNS and asserts they fail; addresses CAT-3137.

<sup>Written for commit 4c38ea982b58a83b858bc011b7a623e3015edcf4. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/55?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

