### PR TITLE
feat(api): default SQLite data dir to /var/lib/n8n-sandbox-api (no-changelog)

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -17,6 +17,8 @@ COPY --from=builder /out/api /usr/local/bin/sandbox-api
 
 RUN addgroup -S sandbox-api && adduser -S -G sandbox-api sandbox-api
 
+RUN mkdir -p /var/lib/n8n-sandbox-api && chown sandbox-api:sandbox-api /var/lib/n8n-sandbox-api
+
 ENV SANDBOX_API_LISTEN_ADDR=:8080
 ENV SANDBOX_API_GRPC_LISTEN_ADDR=:9090
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -31,8 +31,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Verify the data directory exists and is a directory; we expect the
-	// image (or operator) to have pre-created it with the right ownership.
+	// Verify the data directory exists.
 	if info, err := os.Stat(cfg.DataDir); err != nil {
 		slog.Error("data dir not accessible", "path", cfg.DataDir, "error", err)
 		os.Exit(1)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -31,9 +31,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Ensure data directory exists
-	if err := os.MkdirAll(cfg.DataDir, 0o755); err != nil {
-		slog.Error("create data dir", "error", err)
+	// Verify the data directory exists and is a directory; we expect the
+	// image (or operator) to have pre-created it with the right ownership.
+	if info, err := os.Stat(cfg.DataDir); err != nil {
+		slog.Error("data dir not accessible", "path", cfg.DataDir, "error", err)
+		os.Exit(1)
+	} else if !info.IsDir() {
+		slog.Error("data dir is not a directory", "path", cfg.DataDir)
 		os.Exit(1)
 	}
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -31,7 +31,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Verify the data directory exists.
+	// Ensure data directory exists
 	if info, err := os.Stat(cfg.DataDir); err != nil {
 		slog.Error("data dir not accessible", "path", cfg.DataDir, "error", err)
 		os.Exit(1)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -31,10 +31,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Verify the data directory exists, is a directory, and is writable; we
-	// expect the image (or operator) to have pre-created it with the right
-	// ownership. The write probe surfaces "data dir not writable" instead of
-	// SQLite's cryptic "unable to open database file" later.
+	// Verify the data directory exists and is a directory; we expect the
+	// image (or operator) to have pre-created it with the right ownership.
 	if info, err := os.Stat(cfg.DataDir); err != nil {
 		slog.Error("data dir not accessible", "path", cfg.DataDir, "error", err)
 		os.Exit(1)
@@ -42,14 +40,6 @@ func main() {
 		slog.Error("data dir is not a directory", "path", cfg.DataDir)
 		os.Exit(1)
 	}
-	probePath := filepath.Join(cfg.DataDir, ".write-probe")
-	probe, err := os.OpenFile(probePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		slog.Error("data dir not writable", "path", cfg.DataDir, "error", err)
-		os.Exit(1)
-	}
-	_ = probe.Close()
-	_ = os.Remove(probePath)
 
 	// Open SQLite store for state management
 	dbPath := filepath.Join(cfg.DataDir, "api.db")

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -31,8 +31,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Verify the data directory exists and is a directory; we expect the
-	// image (or operator) to have pre-created it with the right ownership.
+	// Verify the data directory exists, is a directory, and is writable; we
+	// expect the image (or operator) to have pre-created it with the right
+	// ownership. The write probe surfaces "data dir not writable" instead of
+	// SQLite's cryptic "unable to open database file" later.
 	if info, err := os.Stat(cfg.DataDir); err != nil {
 		slog.Error("data dir not accessible", "path", cfg.DataDir, "error", err)
 		os.Exit(1)
@@ -40,6 +42,14 @@ func main() {
 		slog.Error("data dir is not a directory", "path", cfg.DataDir)
 		os.Exit(1)
 	}
+	probePath := filepath.Join(cfg.DataDir, ".write-probe")
+	probe, err := os.OpenFile(probePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		slog.Error("data dir not writable", "path", cfg.DataDir, "error", err)
+		os.Exit(1)
+	}
+	_ = probe.Close()
+	_ = os.Remove(probePath)
 
 	// Open SQLite store for state management
 	dbPath := filepath.Join(cfg.DataDir, "api.db")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ All services are configured via environment variables.
 | `SANDBOX_API_RUNNER_API_KEY` | *(empty)* | Optional API key injected by the API when calling runner HTTP |
 | `SANDBOX_API_LISTEN_ADDR` | `:8080` | Public HTTP listen address |
 | `SANDBOX_API_GRPC_LISTEN_ADDR` | `:9090` | Private gRPC listen address for runner registration streams |
-| `SANDBOX_API_DATA_DIR` | `/tmp/sandbox-api` | SQLite store directory |
+| `SANDBOX_API_DATA_DIR` | `/var/lib/n8n-sandbox-api` | SQLite store directory; must already exist and be writable by the API user. Mount a persistent volume here to retain sandbox state across container restarts. |
 | `SANDBOX_API_MAX_FILE_BYTES` | `10485760` | Maximum file upload size (10 MB) |
 | `SANDBOX_API_ENABLE_CORS` | `false` | Enable CORS headers (allow all origins); needed for the browser playground |
 | `SANDBOX_API_RUNNER_HEARTBEAT_GRACE` | `45s` | How long after the last gRPC heartbeat a runner remains eligible for placement (Go [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) syntax, e.g. `45s`, `2m`) |

--- a/docs/examples/compose.linux.yaml
+++ b/docs/examples/compose.linux.yaml
@@ -17,7 +17,7 @@ services:
       - "8080:8080"
     volumes:
       - ./.tls:/tls:ro
-      - api-data:/tmp
+      - api-data:/var/lib/n8n-sandbox-api
     env_file: .env
     environment:
       SANDBOX_API_GRPC_TLS_CERT_FILE: /tls/grpc-server.crt

--- a/docs/examples/compose.macos.yaml
+++ b/docs/examples/compose.macos.yaml
@@ -20,7 +20,7 @@ services:
       - "8080:8080"
     volumes:
       - ./.tls:/tls:ro
-      - api-data:/tmp
+      - api-data:/var/lib/n8n-sandbox-api
     env_file: .env
     environment:
       SANDBOX_API_GRPC_TLS_CERT_FILE: /tls/grpc-server.crt

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -22,17 +22,25 @@ e2e_normalize_tls_permissions() {
 	done
 }
 
-# Sets global API_DOCKER_USER: empty = use image default user, or (--user hostuid:hostgid) if chown fails.
+# Sets globals API_DOCKER_USER and API_DATA_VOLUME_ARGS.
+# When chown succeeds, the API runs as the image's default user and writes to
+# the image-baked /var/lib/n8n-sandbox-api dir (which is owned by that user).
+# When chown fails, the API runs as the host UID; we bind-mount a host-side
+# dir at /var/lib/n8n-sandbox-api so that UID can write the SQLite file there.
 e2e_setup_api_tls_for_container() {
 	local tls_dir=$1 api_image=$2
 	local uid gid
 	read -r uid gid <<< "$(docker run --rm --entrypoint sh "$api_image" -c 'echo $(id -u) $(id -g)')"
 	if chown -R "$uid:$gid" "$tls_dir" 2>/dev/null; then
 		API_DOCKER_USER=()
+		API_DATA_VOLUME_ARGS=()
 		return 0
 	fi
 	echo "chown TLS dir to API image user $uid:$gid not permitted; using host UID for API container" >&2
 	API_DOCKER_USER=(--user "$(id -u):$(id -g)")
+	local data_dir="$tls_dir/api-data"
+	mkdir -p "$data_dir"
+	API_DATA_VOLUME_ARGS=(-v "$data_dir:/var/lib/n8n-sandbox-api")
 }
 
 e2e_bootstrap_mtls_maybe() {

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -22,12 +22,12 @@ e2e_normalize_tls_permissions() {
 	done
 }
 
+# Prepares the API container's runtime user and the host-side resources that
+# user needs. Chowns the TLS dir to the image's default user when possible;
+# otherwise falls back to --user host:host plus a bind-mounted data dir at
+# /var/lib/n8n-sandbox-api so that UID can write the SQLite file.
 # Sets globals API_DOCKER_USER and API_DATA_VOLUME_ARGS.
-# When chown succeeds, the API runs as the image's default user and writes to
-# the image-baked /var/lib/n8n-sandbox-api dir (which is owned by that user).
-# When chown fails, the API runs as the host UID; we bind-mount a host-side
-# dir at /var/lib/n8n-sandbox-api so that UID can write the SQLite file there.
-e2e_setup_api_tls_for_container() {
+e2e_setup_api_container() {
 	local tls_dir=$1 api_image=$2
 	local uid gid
 	read -r uid gid <<< "$(docker run --rm --entrypoint sh "$api_image" -c 'echo $(id -u) $(id -g)')"

--- a/e2e/run-no-runner.sh
+++ b/e2e/run-no-runner.sh
@@ -40,6 +40,7 @@ fi
 e2e_bootstrap_mtls_maybe "$PROJECT_DIR" "$TLS_DIR_OWNED" "$TLS_DIR" "$API_TLS_DNS" "runner-control"
 e2e_normalize_tls_permissions "$TLS_DIR"
 API_DOCKER_USER=()
+API_DATA_VOLUME_ARGS=()
 e2e_setup_api_tls_for_container "$TLS_DIR" "$API_IMAGE"
 
 e2e_docker_network_create "$NETWORK_NAME"
@@ -48,6 +49,9 @@ echo "Starting API only on port $PORT..."
 API_DOCKER_RUN=(-d)
 if ((${#API_DOCKER_USER[@]})); then
 	API_DOCKER_RUN+=("${API_DOCKER_USER[@]}")
+fi
+if ((${#API_DATA_VOLUME_ARGS[@]})); then
+	API_DOCKER_RUN+=("${API_DATA_VOLUME_ARGS[@]}")
 fi
 API_DOCKER_RUN+=(
 	--network "$NETWORK_NAME"

--- a/e2e/run-no-runner.sh
+++ b/e2e/run-no-runner.sh
@@ -41,7 +41,7 @@ e2e_bootstrap_mtls_maybe "$PROJECT_DIR" "$TLS_DIR_OWNED" "$TLS_DIR" "$API_TLS_DN
 e2e_normalize_tls_permissions "$TLS_DIR"
 API_DOCKER_USER=()
 API_DATA_VOLUME_ARGS=()
-e2e_setup_api_tls_for_container "$TLS_DIR" "$API_IMAGE"
+e2e_setup_api_container "$TLS_DIR" "$API_IMAGE"
 
 e2e_docker_network_create "$NETWORK_NAME"
 

--- a/e2e/run-two-runners.sh
+++ b/e2e/run-two-runners.sh
@@ -66,7 +66,7 @@ e2e_bootstrap_mtls_maybe "$PROJECT_DIR" "$TLS_DIR_OWNED" "$TLS_DIR" "$API_TLS_DN
 e2e_normalize_tls_permissions "$TLS_DIR"
 API_DOCKER_USER=()
 API_DATA_VOLUME_ARGS=()
-e2e_setup_api_tls_for_container "$TLS_DIR" "$API_IMAGE"
+e2e_setup_api_container "$TLS_DIR" "$API_IMAGE"
 
 e2e_docker_network_create "$NETWORK_NAME"
 

--- a/e2e/run-two-runners.sh
+++ b/e2e/run-two-runners.sh
@@ -65,6 +65,7 @@ fi
 e2e_bootstrap_mtls_maybe "$PROJECT_DIR" "$TLS_DIR_OWNED" "$TLS_DIR" "$API_TLS_DNS" "${RUNNER1_CONTROL_ALIAS},${RUNNER2_CONTROL_ALIAS}"
 e2e_normalize_tls_permissions "$TLS_DIR"
 API_DOCKER_USER=()
+API_DATA_VOLUME_ARGS=()
 e2e_setup_api_tls_for_container "$TLS_DIR" "$API_IMAGE"
 
 e2e_docker_network_create "$NETWORK_NAME"
@@ -102,6 +103,9 @@ echo "Starting API service on port $PORT..."
 API_DOCKER_RUN=(-d)
 if ((${#API_DOCKER_USER[@]})); then
 	API_DOCKER_RUN+=("${API_DOCKER_USER[@]}")
+fi
+if ((${#API_DATA_VOLUME_ARGS[@]})); then
+	API_DOCKER_RUN+=("${API_DATA_VOLUME_ARGS[@]}")
 fi
 API_DOCKER_RUN+=(
 	--network "$NETWORK_NAME"

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -70,7 +70,7 @@ e2e_bootstrap_mtls_maybe "$PROJECT_DIR" "$TLS_DIR_OWNED" "$TLS_DIR" "$API_TLS_DN
 e2e_normalize_tls_permissions "$TLS_DIR"
 API_DOCKER_USER=()
 API_DATA_VOLUME_ARGS=()
-e2e_setup_api_tls_for_container "$TLS_DIR" "$API_IMAGE"
+e2e_setup_api_container "$TLS_DIR" "$API_IMAGE"
 
 e2e_docker_network_create "$NETWORK_NAME"
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -69,6 +69,7 @@ fi
 e2e_bootstrap_mtls_maybe "$PROJECT_DIR" "$TLS_DIR_OWNED" "$TLS_DIR" "$API_TLS_DNS" "$RUNNER_CONTROL_ALIAS"
 e2e_normalize_tls_permissions "$TLS_DIR"
 API_DOCKER_USER=()
+API_DATA_VOLUME_ARGS=()
 e2e_setup_api_tls_for_container "$TLS_DIR" "$API_IMAGE"
 
 e2e_docker_network_create "$NETWORK_NAME"
@@ -116,6 +117,9 @@ echo "Starting API service on port $PORT..."
 API_DOCKER_RUN=(-d)
 if ((${#API_DOCKER_USER[@]})); then
 	API_DOCKER_RUN+=("${API_DOCKER_USER[@]}")
+fi
+if ((${#API_DATA_VOLUME_ARGS[@]})); then
+	API_DOCKER_RUN+=("${API_DATA_VOLUME_ARGS[@]}")
 fi
 API_DOCKER_RUN+=(
 	--network "$NETWORK_NAME"

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -76,7 +76,7 @@ func LoadAPI() (*APIConfig, error) {
 		ListenAddr:      defaultListenAddr,
 		GRPCListenAddr:  defaultGRPCListenAddr,
 		MaxFileBytes:    defaultMaxFileBytes,
-		DataDir:         "/tmp/sandbox-api",
+		DataDir:         "/var/lib/n8n-sandbox-api",
 		HeartbeatGrace:  defaultHeartbeatGrace,
 		IdleStopAfter:   defaultIdleStopAfter,
 		IdleDeleteAfter: defaultIdleDeleteAfter,

--- a/internal/api/config/config_test.go
+++ b/internal/api/config/config_test.go
@@ -42,8 +42,8 @@ func TestLoadAPIParsesDefaults(t *testing.T) {
 		t.Errorf("expected RegistrationToken reg-token, got %q", cfg.RegistrationToken)
 	}
 
-	if cfg.DataDir != "/tmp/sandbox-api" {
-		t.Errorf("expected DataDir /tmp/sandbox-api, got %s", cfg.DataDir)
+	if cfg.DataDir != "/var/lib/n8n-sandbox-api" {
+		t.Errorf("expected DataDir /var/lib/n8n-sandbox-api, got %s", cfg.DataDir)
 	}
 
 	if _, exists := cfg.APIKeys["test-key"]; !exists {


### PR DESCRIPTION
## Summary

- Default `SANDBOX_API_DATA_DIR` moves from `/tmp/sandbox-api` to `/var/lib/n8n-sandbox-api`.
- `Dockerfile.api` pre-creates the dir with `sandbox-api` ownership; the binary now `stat`s it on startup and fails fast instead of `MkdirAll`-ing.
- Example compose files (`docs/examples/compose.{linux,macos}.yaml`) mount the `api-data` volume at the new path.
- Local-dev `compose.yaml` left untouched on purpose — devs typically want fresh state on each `up`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3167

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included. (Updated `config_test.go` for the new default.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaulted `SANDBOX_API_DATA_DIR` to `/var/lib/n8n-sandbox-api` so the SQLite DB persists across restarts (CAT-3167). The image pre-creates the dir; the API fails fast if it’s missing or not a directory; example Compose mounts updated; e2e runs bind-mount a host dir when using the host UID to ensure write access.

- **Migration**
  - If you mounted `api-data` at `/tmp`, change it to `/var/lib/n8n-sandbox-api`.
  - Ensure the path exists and is writable by the API user; the official image does this, custom deployments must too.

<sup>Written for commit 84223ea743112161945f3e57066d9e0982fc56c0. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/60?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

