### PR TITLE
ci: extract e2e job into reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,25 +66,7 @@ jobs:
         run: make docker-amd64
 
   e2e:
-    runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version: "1.25.0"
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: "22"
-
-      - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6
-        with:
-          version: 10
-
-      - name: Run e2e tests
-        # TODO: set E2E_VERIFY_DISK_QUOTA=true when the runner supports it.
-        run: PRIVILEGED=1 e2e/run.sh
+    uses: ./.github/workflows/e2e.yml
 
   # This job is required by GitHub branch protection rules.
   # PRs cannot be merged unless this job passes.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,26 @@
+name: E2E
+
+on:
+  workflow_call:
+
+jobs:
+  e2e:
+    runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.25.0"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+
+      - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6
+        with:
+          version: 10
+
+      - name: Run e2e tests
+        # TODO: set E2E_VERIFY_DISK_QUOTA=true when the runner supports it.
+        run: PRIVILEGED=1 e2e/run.sh

--- a/.github/workflows/release-sandbox-publish.yml
+++ b/.github/workflows/release-sandbox-publish.yml
@@ -26,9 +26,6 @@ jobs:
           VERSION=$(cat SANDBOX_VERSION)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Run tests
-        uses: ./.github/actions/sandbox-service-test
-
       - name: Publish sandbox image
         uses: ./.github/actions/docker-publish
         with:

--- a/.github/workflows/release-sandbox-validate.yml
+++ b/.github/workflows/release-sandbox-validate.yml
@@ -23,8 +23,6 @@ jobs:
           fi
           echo "Version: $VERSION"
 
-      - name: Run tests
-        uses: ./.github/actions/sandbox-service-test
+      - name: Run e2e tests
+        uses: ./.github/workflows/e2e.yml
 
-      - name: Build sandbox image (amd64, no push)
-        run: make docker-sandbox-amd64

--- a/.github/workflows/release-sandbox-validate.yml
+++ b/.github/workflows/release-sandbox-validate.yml
@@ -23,6 +23,6 @@ jobs:
           fi
           echo "Version: $VERSION"
 
-      - name: Run e2e tests
-        uses: ./.github/workflows/e2e.yml
+  e2e:
+    uses: ./.github/workflows/e2e.yml
 


### PR DESCRIPTION
## Summary
- Extract the e2e job from `ci.yml` into a reusable workflow at `.github/workflows/e2e.yml` (called via `workflow_call`).
- Reuse it from `release-sandbox-validate.yml` so the sandbox release pipeline also runs e2e tests.

## Test plan
- [ ] CI passes on this PR (`e2e` job in `ci.yml` invokes the reusable workflow)
- [ ] Verify the sandbox release validate pipeline runs e2e tests on a `sandbox/release/**` PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted E2E tests into a reusable GitHub Actions workflow and wired it into CI and sandbox release validation. This removes duplication and ensures the sandbox pipeline runs the same E2E suite as CI.

- **Refactors**
  - Moved the `e2e` job from `.github/workflows/ci.yml` to `.github/workflows/e2e.yml` via `workflow_call`.
  - `ci.yml` now invokes the reusable workflow as a job.
  - `release-sandbox-validate.yml` runs the reusable E2E workflow as a separate job; removed the `sandbox-service-test` step and the no-push sandbox image build.
  - Removed `sandbox-service-test` from `release-sandbox-publish.yml`.

<sup>Written for commit 1415602ff6c2babff0415090a2f7c312411d01bd. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/65?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

