### PR TITLE
feat: add config option to define log level

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -22,7 +22,9 @@ import (
 )
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	var logLevel slog.LevelVar
+	logLevel.Set(slog.LevelInfo)
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel}))
 	slog.SetDefault(logger)
 
 	cfg, err := config.LoadAPI()
@@ -30,6 +32,7 @@ func main() {
 		slog.Error("failed to load api config", "error", err)
 		os.Exit(1)
 	}
+	logLevel.Set(cfg.LogLevel)
 
 	// Ensure data directory exists
 	if info, err := os.Stat(cfg.DataDir); err != nil {

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -6,14 +6,26 @@ import (
 	"os"
 
 	"github.com/n8n-io/sandbox-service/internal/daemon"
+	"github.com/n8n-io/sandbox-service/internal/logging"
 )
 
 func main() {
 	listenAddr := flag.String("listen-addr", ":8081", "TCP address to listen on")
 	flag.Parse()
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	var logLevel slog.LevelVar
+	logLevel.Set(slog.LevelInfo)
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel}))
 	slog.SetDefault(logger)
+
+	if v := os.Getenv("SANDBOX_DAEMON_LOG_LEVEL"); v != "" {
+		lvl, err := logging.ParseLevel(v)
+		if err != nil {
+			slog.Error("SANDBOX_DAEMON_LOG_LEVEL", "error", err)
+			os.Exit(1)
+		}
+		logLevel.Set(lvl)
+	}
 
 	slog.Info("daemon starting", "listen_addr", *listenAddr)
 

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -21,7 +21,9 @@ import (
 )
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	var logLevel slog.LevelVar
+	logLevel.Set(slog.LevelInfo)
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel}))
 	slog.SetDefault(logger)
 
 	cfg, err := config.Load()
@@ -29,6 +31,7 @@ func main() {
 		slog.Error("failed to load config", "error", err)
 		os.Exit(1)
 	}
+	logLevel.Set(cfg.LogLevel)
 
 	// Create stateless container manager.
 	mgr, err := manager.New(cfg)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ All services are configured via environment variables.
 | `SANDBOX_API_KEYS` | *(required)* | Comma-separated list of valid external API keys |
 | `SANDBOX_API_RUNNER_REGISTRATION_TOKEN` | *(required)* | Shared secret; runners authenticate to the private gRPC registration service with `Authorization: Bearer …` |
 | `SANDBOX_API_RUNNER_API_KEY` | *(empty)* | Optional API key injected by the API when calling runner HTTP |
+| `SANDBOX_API_LOG_LEVEL` | `info` | Minimum log severity (`debug`, `info`, `warn`, `error`; case-insensitive) |
 | `SANDBOX_API_LISTEN_ADDR` | `:8080` | Public HTTP listen address |
 | `SANDBOX_API_GRPC_LISTEN_ADDR` | `:9090` | Private gRPC listen address for runner registration streams |
 | `SANDBOX_API_DATA_DIR` | `/var/lib/n8n-sandbox-api` | SQLite store directory; must already exist and be writable by the API user. Mount a persistent volume here to retain sandbox state across container restarts. |
@@ -39,6 +40,7 @@ All services are configured via environment variables.
 | `SANDBOX_RUNNER_API_KEYS` | *(required)* | Comma-separated list of valid internal API keys accepted from the API container |
 | `SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE` | *(required)* | Docker image used for sandbox containers |
 | `SANDBOX_RUNNER_DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker daemon endpoint used by the runner |
+| `SANDBOX_RUNNER_LOG_LEVEL` | `info` | Minimum log severity (`debug`, `info`, `warn`, `error`; case-insensitive) |
 | `SANDBOX_RUNNER_LISTEN_ADDR` | `:8080` | HTTP listen address |
 | `SANDBOX_RUNNER_API_GRPC_ADDR` | *(required)* | API `host:port` for gRPC registration |
 | `SANDBOX_RUNNER_REGISTRATION_TOKEN` | *(required)* | Must match `SANDBOX_API_RUNNER_REGISTRATION_TOKEN` on the API |
@@ -68,6 +70,7 @@ These variables are set inside each sandbox container and are typically baked in
 
 | Variable | Default | Description |
 |---|---|---|
+| `SANDBOX_DAEMON_LOG_LEVEL` | `info` | Minimum log severity (`debug`, `info`, `warn`, `error`; case-insensitive) |
 | `SANDBOX_EXEC_MAX_EVENT_BYTES` | `16777216` | Max bytes of event history retained per execution (16 MiB) |
 | `SANDBOX_EXEC_RETAIN` | `10m` | Duration to retain completed executions (Go [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) syntax, e.g. `10m`, `1h`) |
 

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -2,10 +2,13 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/n8n-io/sandbox-service/internal/logging"
 )
 
 const (
@@ -15,6 +18,7 @@ const (
 	defaultHeartbeatGrace  = 45 * time.Second
 	defaultIdleStopAfter   = time.Hour
 	defaultIdleDeleteAfter = 24 * time.Hour
+	defaultLogLevel        = slog.LevelInfo
 )
 
 // APIConfig contains configuration for the public API gateway.
@@ -63,6 +67,10 @@ type APIConfig struct {
 	// IdleSweepInterval is how often the idle stop/delete sweeper runs (default 1m).
 	IdleSweepInterval time.Duration
 
+	// LogLevel controls the minimum log severity.
+	// Parsed from SANDBOX_API_LOG_LEVEL (default info).
+	LogLevel slog.Level
+
 	// API as mTLS client dialing runner SandboxControl (required). All three must be set.
 	RunnerControlGRPCClientCAFile     string
 	RunnerControlGRPCClientCertFile   string
@@ -80,6 +88,16 @@ func LoadAPI() (*APIConfig, error) {
 		HeartbeatGrace:  defaultHeartbeatGrace,
 		IdleStopAfter:   defaultIdleStopAfter,
 		IdleDeleteAfter: defaultIdleDeleteAfter,
+		LogLevel:        defaultLogLevel,
+	}
+
+	// SANDBOX_API_LOG_LEVEL (optional)
+	if v := os.Getenv("SANDBOX_API_LOG_LEVEL"); v != "" {
+		lvl, err := logging.ParseLevel(v)
+		if err != nil {
+			return nil, fmt.Errorf("SANDBOX_API_LOG_LEVEL: %w", err)
+		}
+		cfg.LogLevel = lvl
 	}
 
 	rawKeys := os.Getenv("SANDBOX_API_KEYS")

--- a/internal/api/config/config_test.go
+++ b/internal/api/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -65,6 +66,10 @@ func TestLoadAPIParsesDefaults(t *testing.T) {
 	if cfg.IdleDeleteSafetyBuffer != time.Minute {
 		t.Errorf("expected IdleDeleteSafetyBuffer 1m, got %s", cfg.IdleDeleteSafetyBuffer)
 	}
+
+	if cfg.LogLevel != slog.LevelInfo {
+		t.Errorf("expected LogLevel info, got %v", cfg.LogLevel)
+	}
 }
 
 func TestLoadAPIHeartbeatGraceFromEnv(t *testing.T) {
@@ -90,6 +95,32 @@ func TestLoadAPIRejectsInvalidHeartbeatGrace(t *testing.T) {
 
 	if _, err := LoadAPI(); err == nil {
 		t.Fatal("expected LoadAPI to reject SANDBOX_API_RUNNER_HEARTBEAT_GRACE=0s")
+	}
+}
+
+func TestLoadAPIParsesLogLevel(t *testing.T) {
+	t.Setenv("SANDBOX_API_KEYS", "test-key")
+	t.Setenv("SANDBOX_API_RUNNER_REGISTRATION_TOKEN", "reg-token")
+	t.Setenv("SANDBOX_API_LOG_LEVEL", "debug")
+	setRequiredGRPCMTLS(t)
+
+	cfg, err := LoadAPI()
+	if err != nil {
+		t.Fatalf("LoadAPI() failed: %v", err)
+	}
+	if cfg.LogLevel != slog.LevelDebug {
+		t.Errorf("expected LogLevel debug, got %v", cfg.LogLevel)
+	}
+}
+
+func TestLoadAPIRejectsInvalidLogLevel(t *testing.T) {
+	t.Setenv("SANDBOX_API_KEYS", "test-key")
+	t.Setenv("SANDBOX_API_RUNNER_REGISTRATION_TOKEN", "reg-token")
+	t.Setenv("SANDBOX_API_LOG_LEVEL", "trace")
+	setRequiredGRPCMTLS(t)
+
+	if _, err := LoadAPI(); err == nil {
+		t.Fatal("expected LoadAPI to reject invalid SANDBOX_API_LOG_LEVEL")
 	}
 }
 

--- a/internal/logging/level.go
+++ b/internal/logging/level.go
@@ -1,0 +1,16 @@
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+// ParseLevel converts a string to slog.Level.
+// Accepts "debug", "info", "warn", "error" (case-insensitive).
+func ParseLevel(s string) (slog.Level, error) {
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(s)); err != nil {
+		return 0, fmt.Errorf("invalid log level %q: must be one of debug, info, warn, error", s)
+	}
+	return level, nil
+}

--- a/internal/logging/level_test.go
+++ b/internal/logging/level_test.go
@@ -1,0 +1,42 @@
+package logging
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestParseLevelValid(t *testing.T) {
+	tests := []struct {
+		input string
+		want  slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"DEBUG", slog.LevelDebug},
+		{"Info", slog.LevelInfo},
+		{"WARN", slog.LevelWarn},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseLevel(tt.input)
+			if err != nil {
+				t.Fatalf("ParseLevel(%q) returned error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseLevel(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseLevelInvalid(t *testing.T) {
+	for _, input := range []string{"", "trace", "fatal", "not-a-level"} {
+		t.Run(input, func(t *testing.T) {
+			if _, err := ParseLevel(input); err == nil {
+				t.Fatalf("ParseLevel(%q) should have returned an error", input)
+			}
+		})
+	}
+}

--- a/internal/runner/config/config.go
+++ b/internal/runner/config/config.go
@@ -2,11 +2,14 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"net"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/n8n-io/sandbox-service/internal/logging"
 )
 
 const (
@@ -22,6 +25,7 @@ const (
 	defaultEnableCgroups         = true
 	defaultDockerHost            = "unix:///var/run/docker.sock"
 	defaultControlGRPCListenAddr = ":9091"
+	defaultLogLevel              = slog.LevelInfo
 )
 
 // Config holds all runtime configuration parsed from environment variables.
@@ -107,6 +111,10 @@ type Config struct {
 	GRPCClientKeyFile  string
 	GRPCServerName     string
 
+	// LogLevel controls the minimum log severity.
+	// Parsed from SANDBOX_RUNNER_LOG_LEVEL (default info).
+	LogLevel slog.Level
+
 	// SandboxControl gRPC (API → runner). Always enabled; listen addr defaults to :9091.
 	ControlGRPCListenAddr     string
 	ControlGRPCAdvertiseAddr  string
@@ -179,10 +187,20 @@ func Load() (*Config, error) {
 		EnableCgroups:         defaultEnableCgroups,
 		CapacityTotal:         defaultRunnerCapacityTotal,
 		ControlGRPCListenAddr: defaultControlGRPCListenAddr,
+		LogLevel:              defaultLogLevel,
 	}
 
 	if h, err := os.Hostname(); err == nil && h != "" {
 		cfg.RunnerID = h
+	}
+
+	// SANDBOX_RUNNER_LOG_LEVEL (optional)
+	if v := os.Getenv("SANDBOX_RUNNER_LOG_LEVEL"); v != "" {
+		lvl, err := logging.ParseLevel(v)
+		if err != nil {
+			return nil, fmt.Errorf("SANDBOX_RUNNER_LOG_LEVEL: %w", err)
+		}
+		cfg.LogLevel = lvl
 	}
 
 	// SANDBOX_RUNNER_API_KEYS (required)

--- a/internal/runner/config/config_test.go
+++ b/internal/runner/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log/slog"
 	"os"
 	"testing"
 )
@@ -89,6 +90,10 @@ func TestLoadParsesDefaults(t *testing.T) {
 	}
 	if cfg.ControlGRPCListenAddr != ":9091" {
 		t.Errorf("expected ControlGRPCListenAddr :9091, got %s", cfg.ControlGRPCListenAddr)
+	}
+
+	if cfg.LogLevel != slog.LevelInfo {
+		t.Errorf("expected LogLevel info, got %v", cfg.LogLevel)
 	}
 
 	if _, exists := cfg.APIKeys["test-key"]; !exists {
@@ -262,6 +267,48 @@ func TestLoadRejectsInvalidControlGRPCAdvertiseAddr(t *testing.T) {
 
 	if _, err := Load(); err == nil {
 		t.Fatal("expected Load to reject invalid SANDBOX_RUNNER_CONTROL_GRPC_ADVERTISE_ADDR")
+	}
+}
+
+func TestLoadParsesLogLevel(t *testing.T) {
+	t.Setenv("SANDBOX_RUNNER_API_KEYS", "test-key")
+	t.Setenv("SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE", "test-image")
+	t.Setenv("SANDBOX_RUNNER_API_GRPC_ADDR", "api:9090")
+	t.Setenv("SANDBOX_RUNNER_REGISTRATION_TOKEN", "reg-token")
+	t.Setenv("SANDBOX_RUNNER_HTTP_BASE_URL", "http://runner:8080")
+	t.Setenv("SANDBOX_RUNNER_REGISTRATION_GRPC_CA_FILE", "/tmp/reg-ca.crt")
+	t.Setenv("SANDBOX_RUNNER_REGISTRATION_GRPC_CERT_FILE", "/tmp/reg.crt")
+	t.Setenv("SANDBOX_RUNNER_REGISTRATION_GRPC_KEY_FILE", "/tmp/reg.key")
+	t.Setenv("SANDBOX_RUNNER_CONTROL_GRPC_TLS_CERT_FILE", "/tmp/control.crt")
+	t.Setenv("SANDBOX_RUNNER_CONTROL_GRPC_TLS_KEY_FILE", "/tmp/control.key")
+	t.Setenv("SANDBOX_RUNNER_CONTROL_GRPC_TLS_CLIENT_CA_FILE", "/tmp/control-ca.crt")
+	t.Setenv("SANDBOX_RUNNER_LOG_LEVEL", "debug")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg.LogLevel != slog.LevelDebug {
+		t.Errorf("expected LogLevel debug, got %v", cfg.LogLevel)
+	}
+}
+
+func TestLoadRejectsInvalidLogLevel(t *testing.T) {
+	t.Setenv("SANDBOX_RUNNER_API_KEYS", "test-key")
+	t.Setenv("SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE", "test-image")
+	t.Setenv("SANDBOX_RUNNER_API_GRPC_ADDR", "api:9090")
+	t.Setenv("SANDBOX_RUNNER_REGISTRATION_TOKEN", "reg-token")
+	t.Setenv("SANDBOX_RUNNER_HTTP_BASE_URL", "http://runner:8080")
+	t.Setenv("SANDBOX_RUNNER_REGISTRATION_GRPC_CA_FILE", "/tmp/reg-ca.crt")
+	t.Setenv("SANDBOX_RUNNER_REGISTRATION_GRPC_CERT_FILE", "/tmp/reg.crt")
+	t.Setenv("SANDBOX_RUNNER_REGISTRATION_GRPC_KEY_FILE", "/tmp/reg.key")
+	t.Setenv("SANDBOX_RUNNER_CONTROL_GRPC_TLS_CERT_FILE", "/tmp/control.crt")
+	t.Setenv("SANDBOX_RUNNER_CONTROL_GRPC_TLS_KEY_FILE", "/tmp/control.key")
+	t.Setenv("SANDBOX_RUNNER_CONTROL_GRPC_TLS_CLIENT_CA_FILE", "/tmp/control-ca.crt")
+	t.Setenv("SANDBOX_RUNNER_LOG_LEVEL", "trace")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("expected Load to reject invalid SANDBOX_RUNNER_LOG_LEVEL")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds configurable log level for all three services via environment variables:
- `SANDBOX_API_LOG_LEVEL` for the API
- `SANDBOX_RUNNER_LOG_LEVEL` for the runner
- `SANDBOX_DAEMON_LOG_LEVEL` for the daemon

Accepts `debug`, `info`, `warn`, `error` (case-insensitive). Default changed from `debug` to `info` to reduce log noise. Includes a shared `internal/logging` package for level parsing, tests for valid/invalid values in all config packages, and updated configuration docs.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3207

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable log levels for the API, runner, and daemon via environment variables, with a new default of info to cut log noise. Implements CAT-3207 and centralizes level parsing in a shared `internal/logging` package.

- New Features
  - `SANDBOX_API_LOG_LEVEL`, `SANDBOX_RUNNER_LOG_LEVEL`, `SANDBOX_DAEMON_LOG_LEVEL` support `debug`, `info`, `warn`, `error` (case-insensitive).
  - Default level changed from debug to info; applied at startup using `slog.LevelVar`.
  - Added `internal/logging` ParseLevel helper, config parsing with tests, and updated configuration docs.

- Migration
  - If you need debug logs, set the respective env var to `debug` for each service.

<sup>Written for commit 5437cbd7bcb8cbf992dc2d0a0c4ae6ebbc2627b2. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/73?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

