### PR TITLE
test: reduce e2e inter-suite cooldown from 15s to 2s

### DIFF
--- a/e2e/run-all.sh
+++ b/e2e/run-all.sh
@@ -37,19 +37,19 @@ echo "======== E2E 1/3: no-runner (API only) ========"
 "$SCRIPT_DIR/run-no-runner.sh" "$@"
 
 echo "Cooling down between e2e phases (host Docker / DinD)..."
-sleep 15
+sleep 2
 
 echo "======== E2E 2/3: two runners =================="
 "$SCRIPT_DIR/run-two-runners.sh" "$@"
 
 echo "Cooling down between e2e phases (host Docker / DinD)..."
-sleep 15
+sleep 2
 
 echo "======== E2E 3/4: single runner (full suite) =="
 "$SCRIPT_DIR/run.sh" "$@"
 
 echo "Cooling down between e2e phases (host Docker / DinD)..."
-sleep 15
+sleep 2
 
 echo "======== E2E 4/4: idle TTL (dedicated stack) ===="
 "$SCRIPT_DIR/run-idle-ttl.sh" "$@"


### PR DESCRIPTION
## Summary

Reduces the sleep time between e2e test phases in `e2e/run-all.sh` from 15 seconds to 2 seconds, saving ~39 seconds per full e2e run.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce inter-suite cooldown in `e2e/run-all.sh` from 15s to 2s to speed up CI, saving ~39s per full e2e run.

<sup>Written for commit 018d7fc05cb6ed7f4513321d0d78252cb4d51180. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/74?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

