### PR TITLE
test: add custom toHaveSucceeded() matcher for e2e exec results

### DIFF
--- a/e2e/tests/file-exec-consistency.spec.ts
+++ b/e2e/tests/file-exec-consistency.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import './matchers';
 import {
   createSandbox,
   deleteSandbox,
@@ -34,7 +35,7 @@ test.describe('File API and Exec API path consistency', () => {
     await uploadFile(sandboxId, path, content);
 
     const result = await exec(sandboxId, `cat ${path}`);
-    expect(result.exitCode).toBe(0);
+    expect(result).toHaveSucceeded();
     expect(result.stdout.trim()).toBe(content);
   });
 
@@ -43,7 +44,7 @@ test.describe('File API and Exec API path consistency', () => {
     const content = 'hello from exec';
 
     const writeResult = await exec(sandboxId, `echo -n '${content}' > ${path}`);
-    expect(writeResult.exitCode).toBe(0);
+    expect(writeResult).toHaveSucceeded();
 
     const downloaded = await downloadFile(sandboxId, path);
     expect(downloaded).toBe(content);
@@ -53,7 +54,7 @@ test.describe('File API and Exec API path consistency', () => {
     const dir = '/tmp/exec-created-dir';
 
     const mkdirResult = await exec(sandboxId, `mkdir -p ${dir}/sub && touch ${dir}/sub/a.txt ${dir}/sub/b.txt`);
-    expect(mkdirResult.exitCode).toBe(0);
+    expect(mkdirResult).toHaveSucceeded();
 
     // Download one of the files via file API to confirm visibility
     const content = await downloadFile(sandboxId, `${dir}/sub/a.txt`);
@@ -72,7 +73,7 @@ test.describe('File API and Exec API path consistency', () => {
       timeoutMs: 10_000,
       retryWindowMs: 12_000,
     });
-    expect(result.exitCode).toBe(0);
+    expect(result).toHaveSucceeded();
     expect(result.stdout.trim()).toBe('hello world');
   });
 
@@ -97,7 +98,7 @@ test.describe('File API and Exec API path consistency', () => {
     expect(content).toBe('to be deleted');
 
     const rmResult = await exec(sandboxId, `rm -f ${path}`);
-    expect(rmResult.exitCode).toBe(0);
+    expect(rmResult).toHaveSucceeded();
 
     // After unlink, some setups (busy CI / overlay) can briefly still serve the file;
     // poll until the file API observes the delete.
@@ -133,7 +134,7 @@ test.describe('File API and Exec API path consistency', () => {
       timeoutMs: 10_000,
       retryWindowMs: 12_000,
     });
-    expect(result.exitCode).toBe(0);
+    expect(result).toHaveSucceeded();
     expect(result.stdout.trim()).toBe('2');
 
     // Confirm full content via exec

--- a/e2e/tests/matchers.ts
+++ b/e2e/tests/matchers.ts
@@ -1,9 +1,11 @@
 import { expect } from '@playwright/test';
 import type { ExecResult } from './helpers';
 
-declare module '@playwright/test' {
-  interface Matchers<R, T = unknown> {
-    toHaveSucceeded(): R;
+declare global {
+  namespace PlaywrightTest {
+    interface Matchers<R, T = unknown> {
+      toHaveSucceeded(): R;
+    }
   }
 }
 
@@ -28,10 +30,10 @@ function formatExecResult(result: ExecResult): string {
 
 expect.extend({
   toHaveSucceeded(received: ExecResult) {
-    const pass = received.exitCode === 0;
+    const pass = received.exitCode === 0 && received.success === true;
     const message = pass
       ? () => `Expected command to have failed, but it succeeded.\n\n${formatExecResult(received)}`
-      : () => `Expected command to have succeeded (exitCode === 0), but it failed.\n\n${formatExecResult(received)}`;
+      : () => `Expected command to have succeeded (exitCode === 0 and success === true), but it failed.\n\n${formatExecResult(received)}`;
     return { pass, message };
   },
 });

--- a/e2e/tests/matchers.ts
+++ b/e2e/tests/matchers.ts
@@ -1,0 +1,37 @@
+import { expect } from '@playwright/test';
+import type { ExecResult } from './helpers';
+
+declare module '@playwright/test' {
+  interface Matchers<R, T = unknown> {
+    toHaveSucceeded(): R;
+  }
+}
+
+function formatExecResult(result: ExecResult): string {
+  const lines = [
+    `  exitCode:  ${result.exitCode}`,
+    `  success:   ${result.success}`,
+    `  timedOut:  ${result.timedOut}`,
+    `  killed:    ${result.killed}`,
+    `  execTime:  ${result.executionTimeMs}ms`,
+  ];
+
+  if (result.stdout) {
+    lines.push(`\n  --- stdout ---\n${result.stdout}`);
+  }
+  if (result.stderr) {
+    lines.push(`\n  --- stderr ---\n${result.stderr}`);
+  }
+
+  return lines.join('\n');
+}
+
+expect.extend({
+  toHaveSucceeded(received: ExecResult) {
+    const pass = received.exitCode === 0;
+    const message = pass
+      ? () => `Expected command to have failed, but it succeeded.\n\n${formatExecResult(received)}`
+      : () => `Expected command to have succeeded (exitCode === 0), but it failed.\n\n${formatExecResult(received)}`;
+    return { pass, message };
+  },
+});

--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import './matchers';
 import { createSandbox, deleteSandbox, exec, execWithTransientRetry } from './helpers';
 
 // Helper: use python3 for HTTP requests since curl is not in the sandbox rootfs
@@ -21,7 +22,7 @@ test.describe('Network isolation', () => {
       const result = await exec(id, pyGet('http://httpbin.org/ip', 15), {
         timeoutMs: 30_000,
       });
-      expect(result.exitCode).toBe(0);
+      expect(result).toHaveSucceeded();
       expect(result.stdout.trim()).toBe('200');
     } finally {
       await deleteSandbox(id);
@@ -53,7 +54,7 @@ test.describe('Network isolation', () => {
     try {
       // Get sandbox 2's IP
       const ipResult = await execWithTransientRetry(id2, 'hostname -I', { timeoutMs: 5_000 });
-      expect(ipResult.exitCode).toBe(0);
+      expect(ipResult).toHaveSucceeded();
       const sandbox2IP = ipResult.stdout.trim();
       expect(sandbox2IP).toBeTruthy();
 
@@ -99,7 +100,7 @@ import time; time.sleep(30)
     const id = await createSandbox();
     try {
       const result = await execWithTransientRetry(id, pyResolve('example.com'), { timeoutMs: 10_000 });
-      expect(result.exitCode).toBe(0);
+      expect(result).toHaveSucceeded();
       // Should resolve to an IP address
       expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+\.\d+$/);
     } finally {

--- a/e2e/tests/resumable-exec.spec.ts
+++ b/e2e/tests/resumable-exec.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import './matchers';
 import { SandboxServiceError } from '@n8n/sandbox-client';
 import { client, createSandbox, deleteSandbox, startAndDisconnect } from './helpers';
 
@@ -32,7 +33,7 @@ test.describe('Resumable Exec', () => {
 
     expect(result.stdout).toContain('before');
     expect(result.stdout).toContain('after');
-    expect(result.exitCode).toBe(0);
+    expect(result).toHaveSucceeded();
     expect(result.killed).toBe(false);
   });
 

--- a/e2e/tests/sandbox-api.spec.ts
+++ b/e2e/tests/sandbox-api.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import './matchers';
 import {
   client,
   createSandbox,
@@ -38,8 +39,7 @@ test.describe('Sandbox lifecycle', () => {
 
     const result = await exec(id, 'echo hello world');
     expect(result.stdout).toBe('hello world\n');
-    expect(result.success).toBe(true);
-    expect(result.exitCode).toBe(0);
+    expect(result).toHaveSucceeded();
 
     await deleteSandbox(id);
 
@@ -82,18 +82,18 @@ test.describe('Exec', () => {
   test('simple echo', async () => {
     const result = await exec(sandboxId, 'echo hello');
     expect(result.stdout).toBe('hello\n');
-    expect(result.success).toBe(true);
+    expect(result).toHaveSucceeded();
   });
 
   test('command with args', async () => {
     const result = await exec(sandboxId, 'ls /tmp');
-    expect(result.success).toBe(true);
+    expect(result).toHaveSucceeded();
   });
 
   test('stderr output', async () => {
     const result = await exec(sandboxId, 'echo error >&2');
     expect(result.stderr).toContain('error');
-    expect(result.success).toBe(true);
+    expect(result).toHaveSucceeded();
   });
 
   test('non-zero exit code', async () => {
@@ -166,7 +166,7 @@ test.describe('Exec', () => {
       retryWindowMs: 12_000,
     });
     expect(result.stdout.trim()).toBe('/home/user/');
-    expect(result.success).toBe(true);
+    expect(result).toHaveSucceeded();
   });
 
   test('missing command returns 400', async ({ request }) => {
@@ -195,7 +195,7 @@ test.describe('Exec', () => {
   test('exitCode is present even when 0', async () => {
     const result = await exec(sandboxId, 'true');
     expect(result).toHaveProperty('exitCode');
-    expect(result.exitCode).toBe(0);
+    expect(result).toHaveSucceeded();
   });
 
   test('sandbox runs as non-root user', async () => {
@@ -675,7 +675,7 @@ test.describe('File operations', () => {
       retryWindowMs: 12_000,
     });
     expect(result.stdout).toBe('from api\n');
-    expect(result.success).toBe(true);
+    expect(result).toHaveSucceeded();
   });
 
   test('file created by exec is downloadable via API', async () => {
@@ -696,7 +696,7 @@ test.describe('File operations', () => {
       retryWindowMs: 12_000,
     });
     expect(result.stdout).toBe('spaced content\n');
-    expect(result.success).toBe(true);
+    expect(result).toHaveSucceeded();
   });
 });
 

--- a/e2e/tests/sandbox-idle-ttl.spec.ts
+++ b/e2e/tests/sandbox-idle-ttl.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import './matchers';
 import { apiRequest, createSandbox, execWithTransientRetry } from './helpers';
 
 test.describe.configure({ timeout: 75_000 });
@@ -16,7 +17,7 @@ test.describe('idle stop / wake / delete', () => {
     expect(j1.status).toBe('stopped');
 
     const execRes = await execWithTransientRetry(id, 'echo wake');
-    expect(execRes.success).toBe(true);
+    expect(execRes).toHaveSucceeded();
 
     // delete_after=10s, buffer=2s, sweep=1s from last activity (wake)
     await new Promise((r) => setTimeout(r, 16_000));

--- a/e2e/tests/sandbox-recovery.spec.ts
+++ b/e2e/tests/sandbox-recovery.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import './matchers';
 import { createSandbox, deleteSandbox, docker, dockerOutput, exec, innerContainerName } from './helpers';
 
 async function waitExecOK(sandboxID: string, command: string, deadlineMs: number): Promise<void> {
@@ -145,7 +146,7 @@ test.describe('Sandbox recovery on runner', () => {
       docker(['exec', runnerContainer, 'docker', 'stop', '--time', '0', innerName]);
       await waitExecOK(id, 'echo first', 45_000);
       const out = await exec(id, 'echo second');
-      expect(out.exitCode).toBe(0);
+      expect(out).toHaveSucceeded();
       expect(out.stdout.trim()).toBe('second');
     } finally {
       await deleteSandbox(id);


### PR DESCRIPTION
## Summary

Add a custom Playwright matcher `toHaveSucceeded()` that checks `exitCode === 0` on exec results. When the assertion fails, it prints all relevant debug info (exitCode, success, timedOut, killed, executionTimeMs, stdout, stderr) instead of just "expected 0, got 127". All existing `expect(result.exitCode).toBe(0)` and `expect(result.success).toBe(true)` assertions across 6 spec files are migrated to use the new matcher.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a custom Playwright matcher `toHaveSucceeded()` for exec results that asserts both `exitCode === 0` and `success === true`, with clear diagnostics on failure. Replaces scattered `exitCode`/`success` checks across six e2e specs to improve readability and debugging.

- **New Features**
  - Added `e2e/tests/matchers.ts` extending `@playwright/test` with `toHaveSucceeded()`; on failure, prints exitCode, success, timedOut, killed, executionTimeMs, stdout, and stderr.

- **Refactors**
  - Imported `./matchers` and replaced `expect(result.exitCode).toBe(0)`/`expect(result.success).toBe(true)` with `expect(result).toHaveSucceeded()` in updated specs.

<sup>Written for commit 26c599758656a59e298d669b868a4f4c3019a373. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/75?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

