### PR TITLE
fix: pull sandbox image asynchronously to prevent startup timeout

### DIFF
--- a/charts/n8n-sandbox-service/templates/sysbox-runner-statefulset.yaml
+++ b/charts/n8n-sandbox-service/templates/sysbox-runner-statefulset.yaml
@@ -96,17 +96,23 @@ spec:
             {{- with .Values.sysboxRunner.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          startupProbe:
+            httpGet:
+              path: /livez
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 24
           livenessProbe:
             httpGet:
               path: /livez
               port: http
-            initialDelaySeconds: 20
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /readyz
               port: http
-            initialDelaySeconds: 10
+            initialDelaySeconds: 5
             periodSeconds: 5
           volumeMounts:
             - name: runner-registration-tls

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -89,6 +89,8 @@ func main() {
 		}
 	}()
 
+	go mgr.EnsureSandboxImage(ctx)
+
 	select {
 	case <-ctx.Done():
 		slog.Info("received signal, shutting down")

--- a/internal/runner/grpc_control.go
+++ b/internal/runner/grpc_control.go
@@ -59,6 +59,9 @@ func (s *SandboxControlGRPC) CreateSandbox(ctx context.Context, req *pb.CreateSa
 	if err := s.checkAPIKey(ctx); err != nil {
 		return nil, err
 	}
+	if !s.Mgr.ImageReady() {
+		return nil, status.Error(codes.Unavailable, "sandbox image not yet available")
+	}
 	sandboxID := strings.TrimSpace(req.GetSandboxId())
 	if !isValidID(sandboxID) {
 		return nil, status.Error(codes.InvalidArgument, "invalid sandbox id")

--- a/internal/runner/manager/manager.go
+++ b/internal/runner/manager/manager.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/n8n-io/sandbox-service/internal/runner/config"
@@ -42,10 +43,11 @@ type ContainerInfo struct {
 
 // Manager orchestrates container lifecycle without persistent state.
 type Manager struct {
-	config    *config.Config
-	gatewayIP string
-	wakeGroup singleflight.Group
-	docker    *dockerClient
+	config     *config.Config
+	gatewayIP  string
+	wakeGroup  singleflight.Group
+	docker     *dockerClient
+	imageReady atomic.Bool
 }
 
 // New creates a new Manager. It reconciles any previous containers and ensures
@@ -69,15 +71,49 @@ func New(cfg *config.Config) (*Manager, error) {
 	}
 	m.gatewayIP = gatewayIP
 
-	if err := m.docker.pullImage(ctx, m.config.DockerSandboxImage); err != nil {
-		return nil, fmt.Errorf("pull sandbox image: %w", err)
-	}
-
 	return m, nil
+}
+
+// EnsureSandboxImage pulls the sandbox image with retries. It is intended to
+// run in a goroutine after the HTTP server is listening.
+func (m *Manager) EnsureSandboxImage(ctx context.Context) {
+	image := m.config.DockerSandboxImage
+
+	for attempt := 1; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			slog.Error("image pull canceled", "image", image, "error", err)
+			return
+		}
+
+		if err := m.docker.pullImage(ctx, image); err != nil {
+			backoff := min(time.Duration(attempt)*5*time.Second, 60*time.Second)
+			slog.Warn("sandbox image pull failed, retrying",
+				"image", image, "attempt", attempt, "retry_in", backoff, "error", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+				continue
+			}
+		}
+
+		m.imageReady.Store(true)
+		slog.Info("sandbox image ready", "image", image)
+		return
+	}
+}
+
+// ImageReady reports whether the sandbox image has been pulled successfully.
+func (m *Manager) ImageReady() bool {
+	return m.imageReady.Load()
 }
 
 // CreateContainer creates and starts a new container.
 func (m *Manager) CreateContainer(ctx context.Context, sandboxID string, opts *CreateOptions) (*ContainerInfo, error) {
+	if !m.imageReady.Load() {
+		return nil, fmt.Errorf("sandbox image not yet available")
+	}
+
 	if opts == nil {
 		opts = &CreateOptions{}
 	}

--- a/internal/runner/manager/manager.go
+++ b/internal/runner/manager/manager.go
@@ -43,19 +43,21 @@ type ContainerInfo struct {
 
 // Manager orchestrates container lifecycle without persistent state.
 type Manager struct {
-	config     *config.Config
-	gatewayIP  string
-	wakeGroup  singleflight.Group
-	docker     *dockerClient
-	imageReady atomic.Bool
+	config       *config.Config
+	gatewayIP    string
+	wakeGroup    singleflight.Group
+	docker       *dockerClient
+	imageReady   atomic.Bool
+	imageReadyCh chan struct{}
 }
 
 // New creates a new Manager. It reconciles any previous containers and ensures
 // the runner bridge exists.
 func New(cfg *config.Config) (*Manager, error) {
 	m := &Manager{
-		config: cfg,
-		docker: &dockerClient{host: cfg.DockerHost},
+		config:       cfg,
+		docker:       &dockerClient{host: cfg.DockerHost},
+		imageReadyCh: make(chan struct{}),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -98,6 +100,7 @@ func (m *Manager) EnsureSandboxImage(ctx context.Context) {
 		}
 
 		m.imageReady.Store(true)
+		close(m.imageReadyCh)
 		slog.Info("sandbox image ready", "image", image)
 		return
 	}
@@ -106,6 +109,11 @@ func (m *Manager) EnsureSandboxImage(ctx context.Context) {
 // ImageReady reports whether the sandbox image has been pulled successfully.
 func (m *Manager) ImageReady() bool {
 	return m.imageReady.Load()
+}
+
+// ImageReadyCh returns a channel that is closed when the sandbox image becomes available.
+func (m *Manager) ImageReadyCh() <-chan struct{} {
+	return m.imageReadyCh
 }
 
 // CreateContainer creates and starts a new container.

--- a/internal/runner/register/register.go
+++ b/internal/runner/register/register.go
@@ -115,7 +115,7 @@ func connectOnce(ctx context.Context, cfg *config.Config, mgr *manager.Manager) 
 		hb := &pb.RunnerHeartbeat{
 			RunnerId:        cfg.RunnerID,
 			HttpBaseUrl:     cfg.RunnerHTTPBaseURL,
-			Healthy:         true,
+			Healthy:         mgr.ImageReady(),
 			CapacityTotal:   cfg.CapacityTotal,
 			CapacityUsed:    int32(n),
 			ControlGrpcAddr: cfg.ResolvedControlGRPCAdvertiseAddr(),

--- a/internal/runner/register/register.go
+++ b/internal/runner/register/register.go
@@ -137,12 +137,19 @@ func connectOnce(ctx context.Context, cfg *config.Config, mgr *manager.Manager) 
 	tick := time.NewTicker(10 * time.Second)
 	defer tick.Stop()
 
+	imageReadyCh := mgr.ImageReadyCh()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case err := <-errCh:
 			return err
+		case <-imageReadyCh:
+			imageReadyCh = nil
+			if err := send(); err != nil {
+				return err
+			}
 		case <-tick.C:
 			if err := send(); err != nil {
 				return err

--- a/internal/runner/server.go
+++ b/internal/runner/server.go
@@ -19,6 +19,7 @@ type ContainerManager interface {
 	DaemonURL(ctx context.Context, containerID string) (string, error)
 	FindContainerIDByLabel(ctx context.Context, sandboxID string) (string, error)
 	DockerHealthy(ctx context.Context) error
+	ImageReady() bool
 }
 
 // NewRouter creates the HTTP handler for container operations.
@@ -34,6 +35,11 @@ func NewRouter(mgr ContainerManager, cfg *config.Config) http.Handler {
 	mux.HandleFunc("GET /healthz", livenessHandler)
 	mux.HandleFunc("GET /livez", livenessHandler)
 	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, r *http.Request) {
+		if !mgr.ImageReady() {
+			writeError(w, http.StatusServiceUnavailable, "sandbox image not ready")
+			return
+		}
+
 		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 		defer cancel()
 

--- a/internal/runner/server_test.go
+++ b/internal/runner/server_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 type fakeContainerManager struct {
-	dockerErr error
+	dockerErr  error
+	imageReady bool
 }
 
 func (f *fakeContainerManager) CreateContainer(context.Context, string, *manager.CreateOptions) (*manager.ContainerInfo, error) {
@@ -43,6 +44,10 @@ func (f *fakeContainerManager) DockerHealthy(context.Context) error {
 	return f.dockerErr
 }
 
+func (f *fakeContainerManager) ImageReady() bool {
+	return f.imageReady
+}
+
 func TestRunnerLivenessEndpointsDoNotCheckDocker(t *testing.T) {
 	router := NewRouter(&fakeContainerManager{dockerErr: errors.New("docker down")}, &config.Config{})
 
@@ -61,7 +66,7 @@ func TestRunnerLivenessEndpointsDoNotCheckDocker(t *testing.T) {
 }
 
 func TestRunnerReadyzChecksDocker(t *testing.T) {
-	router := NewRouter(&fakeContainerManager{}, &config.Config{})
+	router := NewRouter(&fakeContainerManager{imageReady: true}, &config.Config{})
 	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 	rec := httptest.NewRecorder()
 
@@ -73,7 +78,7 @@ func TestRunnerReadyzChecksDocker(t *testing.T) {
 }
 
 func TestRunnerReadyzFailsWhenDockerUnavailable(t *testing.T) {
-	router := NewRouter(&fakeContainerManager{dockerErr: errors.New("docker down")}, &config.Config{})
+	router := NewRouter(&fakeContainerManager{dockerErr: errors.New("docker down"), imageReady: true}, &config.Config{})
 	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 	rec := httptest.NewRecorder()
 
@@ -81,5 +86,17 @@ func TestRunnerReadyzFailsWhenDockerUnavailable(t *testing.T) {
 
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected readyz to return 503, got %d", rec.Code)
+	}
+}
+
+func TestRunnerReadyzFailsWhenImageNotReady(t *testing.T) {
+	router := NewRouter(&fakeContainerManager{imageReady: false}, &config.Config{})
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected readyz to return 503 when image not ready, got %d", rec.Code)
 	}
 }

--- a/scripts/start-runner.sh
+++ b/scripts/start-runner.sh
@@ -141,12 +141,6 @@ if ! docker network inspect runner-bridge >/dev/null 2>&1; then
     runner-bridge >/dev/null
 fi
 
-# After `docker stop`/`docker start`, the inner graph usually still has this image; skipping pull
-# lets sandbox-runner become ready without waiting on the registry.
-if ! docker image inspect "${SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE}" >/dev/null 2>&1; then
-  docker pull "${SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE}"
-fi
-
 /usr/local/bin/sandbox-runner &
 RUNNER_PID=$!
 wait "$RUNNER_PID"


### PR DESCRIPTION
## Summary

Runner pods crash-loop on k8s when the sandbox image pull takes too long on a cold cache. The startup sequence blocked on `docker pull` before the HTTP server started listening, so the liveness probe killed the pod before it could become ready.

This PR moves the image pull out of the blocking startup path into a background goroutine with retry and capped backoff. The HTTP server starts immediately so k8s probes pass. Readiness probe, registration heartbeat, and `CreateSandbox` gRPC all gate on image availability via an `ImageReady()` flag. A `startupProbe` is added to the Helm chart to give the Docker daemon time to boot without the liveness probe interfering.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3221

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pull the sandbox image asynchronously so the runner starts HTTP immediately and avoids k8s startup timeouts on cold pulls. Send an immediate heartbeat when the image becomes ready; addresses CAT-3221 with readiness/API ops gated on image availability and a `startupProbe` replacing probe delays.

- **Bug Fixes**
  - Pull image in a background goroutine with retry/backoff; expose `ImageReady()` and `ImageReadyCh()`.
  - Gate `/readyz`, registration heartbeat, and `CreateSandbox`/`CreateContainer` on image availability; keep liveness endpoints unchanged.
  - Helm: resolve probe config with main by adding a `startupProbe` on `/livez`, removing liveness initial delay, and setting readiness `initialDelaySeconds: 5`.
  - Remove image pre-pull from `scripts/start-runner.sh`.

- **Refactors**
  - Integrate with the upstream `newManager` factory and `dockerBackend` interface.

<sup>Written for commit 294477bec99ffaf5d7f2f465fd5e031cca504b7c. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/78?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

