### PR TITLE
chore: add k8s quickstart documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ See [docs/](docs/README.md) for the full documentation, including:
 
 - [Linux quickstart](docs/quickstart-linux.md) — production deployment with sysbox-runc
 - [macOS quickstart](docs/quickstart-macos.md) — local development with privileged containers
+- [k8s quickstart](docs/quickstart-k8s.md) - production k8s deployment with sysbox-runc
 - [Configuration reference](docs/configuration.md) — all environment variables
 - [Development guide](docs/development.md) — building, testing, SDK, playground
 - [REST API reference](docs/API.md) — endpoint reference

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ The n8n Sandbox Service provides isolated execution environments via a REST API.
 |----------|----------|-------|
 | **Linux** | Production (sysbox-runc isolation) | [quickstart-linux.md](quickstart-linux.md) |
 | **macOS** | Local development (privileged containers) | [quickstart-macos.md](quickstart-macos.md) |
-| **Kubernetes** | Production cluster deployment | [quickstart-k8s.md] |
+| **Kubernetes** | Production cluster deployment | [quickstart-k8s.md](quickstart-k8s.md) |
 
 > Both platform guides share common [prerequisites](prerequisites.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ The n8n Sandbox Service provides isolated execution environments via a REST API.
 |----------|----------|-------|
 | **Linux** | Production (sysbox-runc isolation) | [quickstart-linux.md](quickstart-linux.md) |
 | **macOS** | Local development (privileged containers) | [quickstart-macos.md](quickstart-macos.md) |
-| **Kubernetes** | Production cluster deployment | _Coming soon_ |
+| **Kubernetes** | Production cluster deployment | [quickstart-k8s.md] |
 
 > Both platform guides share common [prerequisites](prerequisites.md).
 

--- a/docs/quickstart-k8s.md
+++ b/docs/quickstart-k8s.md
@@ -13,6 +13,8 @@ This guide covers running the n8n Sandbox Service on kubernetes.
 * Create a new nodepool and label it, so you can identify the nodes that are supposed to run the sysbox sandbox workloads.
 * Build a helm chart based on sysbox' [own manifests](https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/sysbox-install.yaml). Update the node selectors to match the labels you gave to your nodepool.
 
+Sysbox also has their own [instructions](https://github.com/nestybox/sysbox/blob/master/docs/user-guide/install-k8s.md) on how to install it on k8s.
+
 ## Use the sandbox service chart
 
 Write a wrapper helm chart that includes the n8n-sandbox-service helm chart as a dependency. Then add additional resources you might need, depending on your setup, like: an external secret for the Docker credentials/API keys, an ingressroute or a CA certificate. For more configuration options, refer to the chart's [README](../charts/n8n-sandbox-service/README.md).

--- a/docs/quickstart-k8s.md
+++ b/docs/quickstart-k8s.md
@@ -15,7 +15,7 @@ This guide covers running the n8n Sandbox Service on kubernetes.
 
 ## Use the sandbox service chart
 
-Write a wrapper helm chart that includes the n8n-sandbox-service helm chart as a dependency. Then add additional resources you might need, depending on your setup, like: an external secret for the Docker credentials/API keys, an ingressroute or a CA certificate. For more configuration options, refer to the chart's [README](file://../charts/n8n-sandbox-service/README.md).
+Write a wrapper helm chart that includes the n8n-sandbox-service helm chart as a dependency. Then add additional resources you might need, depending on your setup, like: an external secret for the Docker credentials/API keys, an ingressroute or a CA certificate. For more configuration options, refer to the chart's [README](../charts/n8n-sandbox-service/README.md).
 
 ## Verify
 

--- a/docs/quickstart-k8s.md
+++ b/docs/quickstart-k8s.md
@@ -1,0 +1,29 @@
+# Quickstart: kubernetes
+
+This guide covers running the n8n Sandbox Service on kubernetes.
+
+## Contents
+
+- [Install sysbox](#install-sysbox)
+- [Use the sandbox service chart](#use-the-sandbox-service-chart)
+- [Verify](#verify)
+
+## Install sysbox
+
+* Create a new nodepool and label it, so you can identify the nodes that are supposed to run the sysbox sandbox workloads.
+* Build a helm chart based on sysbox' [own manifests](https://raw.githubusercontent.com/nestybox/sysbox/master/sysbox-k8s-manifests/sysbox-install.yaml). Update the node selectors to match the labels you gave to your nodepool.
+
+## Use the sandbox service chart
+
+Write a wrapper helm chart that includes the n8n-sandbox-service helm chart as a dependency. Then add additional resources you might need, depending on your setup, like: an external secret for the Docker credentials/API keys, an ingressroute or a CA certificate. For more configuration options, refer to the chart's [README](file://../charts/n8n-sandbox-service/README.md).
+
+## Verify
+
+Check the API health endpoint:
+
+```bash
+kubectl port-forward deploy/sandbox-n8n-sandbox-service-api 8080:8080
+curl http://localhost:8080/healthz
+```
+
+If you used an ingress you can also use that to check the API health.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Kubernetes quickstart for the Sandbox Service with steps to install sysbox, deploy via a wrapper Helm chart that depends on `n8n-sandbox-service`, and verify API health via port-forward or ingress. Links the guide from the root README and docs index; fulfills Linear CAT-3060 (how to deploy to k8s).

<sup>Written for commit bc2cb834d4424280153deee3ec91cf881d0d0503. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/79?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

