### PR TITLE
fix: use pvc for docker

### DIFF
--- a/charts/n8n-sandbox-service/README.md
+++ b/charts/n8n-sandbox-service/README.md
@@ -39,6 +39,22 @@ sysboxRunner:
 
 If inner Docker cannot use `overlay2` in that environment, set `sysboxRunner.config.dockerStorageDriver` to another dockerd storage driver such as `vfs`. This is slower than `overlay2`, but avoids nested overlayfs mounts.
 
+For `overlay2`, prefer mounting a dedicated per-runner volume at the inner Docker data root so dockerd does not place its graph on the runner container filesystem:
+
+```yaml
+sysboxRunner:
+  config:
+    dockerStorageDriver: overlay2
+  dockerDataRoot:
+    persistence:
+      enabled: true
+      size: 64Gi
+      accessModes:
+        - ReadWriteOnce
+```
+
+The chart renders this as a StatefulSet `volumeClaimTemplates` entry mounted at `/var/lib/docker`, so each runner replica gets its own Docker data root. Do not share one `/var/lib/docker` volume across runner pods; the inner Docker daemon requires exclusive access to its graph.
+
 If your cluster uses a dedicated node pool with custom labels and taints, override them through values:
 
 ```yaml

--- a/charts/n8n-sandbox-service/templates/sysbox-runner-statefulset.yaml
+++ b/charts/n8n-sandbox-service/templates/sysbox-runner-statefulset.yaml
@@ -100,13 +100,13 @@ spec:
             httpGet:
               path: /livez
               port: http
-            initialDelaySeconds: 20
+            initialDelaySeconds: 50
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /readyz
               port: http
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 5
           volumeMounts:
             - name: runner-registration-tls
@@ -120,6 +120,10 @@ spec:
               mountPath: {{ printf "%s/config.json" .Values.sysboxRunner.dockerConfig.mountPath | quote }}
               subPath: config.json
               readOnly: true
+            {{- end }}
+            {{- if .Values.sysboxRunner.dockerDataRoot.persistence.enabled }}
+            - name: docker-data
+              mountPath: /var/lib/docker
             {{- end }}
             {{- with .Values.sysboxRunner.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -179,4 +183,18 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if .Values.sysboxRunner.dockerDataRoot.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: docker-data
+      spec:
+        accessModes:
+          {{- toYaml .Values.sysboxRunner.dockerDataRoot.persistence.accessModes | nindent 10 }}
+        {{- if .Values.sysboxRunner.dockerDataRoot.persistence.storageClass }}
+        storageClassName: {{ .Values.sysboxRunner.dockerDataRoot.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.sysboxRunner.dockerDataRoot.persistence.size | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/n8n-sandbox-service/values.yaml
+++ b/charts/n8n-sandbox-service/values.yaml
@@ -152,6 +152,14 @@ sysboxRunner:
     configKey: .dockerconfigjson
     mountPath: /root/.docker
 
+  dockerDataRoot:
+    persistence:
+      enabled: false
+      size: 64Gi
+      storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+
   service:
     annotations: {}
     httpPort: 8080


### PR DESCRIPTION
## Summary

Use `overlay2` instead of `vfs` by mounting a PVC for `/var/lib/docker`, thereby speeding up container creation from ~3.6s to ~200ms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mount a per-runner PVC at `/var/lib/docker` to enable `overlay2` in the inner Docker, cutting container creation from ~3.6s to ~200ms. Adds `sysboxRunner.dockerDataRoot.persistence` values and increases probe initial delays so dockerd can start with the volume.

- New Features
  - Optional PVC for Docker data root via `sysboxRunner.dockerDataRoot.persistence` (enabled, size, storageClass, accessModes).
  - Adds StatefulSet `volumeClaimTemplates` per replica; mounted at `/var/lib/docker`.
  - README updated with `overlay2` guidance and a warning not to share the volume across pods.

- Migration
  - To use `overlay2`: set `sysboxRunner.config.dockerStorageDriver` to `overlay2` and enable `sysboxRunner.dockerDataRoot.persistence`.
  - Each runner replica needs its own RWO PVC; do not reuse a single `/var/lib/docker` volume.

<sup>Written for commit 1223fcf83772e2ce8cb632f9c6153c1b43ae9f7f. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/82?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

