### PR TITLE
Add k6 benchmark for sandbox lifecycle throughput

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,49 @@
+# Benchmarks
+
+Load tests for the n8n Sandbox Service using [k6](https://grafana.com/docs/k6/).
+
+## Setup
+
+1. Install k6: https://grafana.com/docs/k6/latest/set-up/install-k6/
+2. Start the sandbox service (e.g. `make up` from the repo root).
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `k6-sandbox-lifecycle.js` | Full sandbox lifecycle: create, execute `echo 'hello'`, delete. Ramps to 50 VUs. |
+
+## Running
+
+Smoke test (single iteration):
+
+```sh
+k6 run --vus 1 --iterations 1 benchmarks/k6-sandbox-lifecycle.js
+```
+
+Full run (default stages: ramp to 50 VUs over 30s, hold 1m, ramp down):
+
+```sh
+k6 run benchmarks/k6-sandbox-lifecycle.js
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BASE_URL` | `http://127.0.0.1:8080` | Sandbox service API base URL |
+| `API_KEY` | `test` | API key for `X-Api-Key` header |
+
+Example:
+
+```sh
+k6 run -e BASE_URL=http://10.0.0.5:8080 -e API_KEY=my-key benchmarks/k6-sandbox-lifecycle.js
+```
+
+## Custom metrics
+
+Each script reports per-step latency trends in addition to k6's built-in HTTP metrics:
+
+- `sandbox_create_duration` — time to create a sandbox
+- `sandbox_exec_duration` — time to execute a command and receive the full response
+- `sandbox_delete_duration` — time to delete a sandbox

--- a/benchmarks/k6-sandbox-lifecycle.js
+++ b/benchmarks/k6-sandbox-lifecycle.js
@@ -11,8 +11,8 @@ const deleteDuration = new Trend("sandbox_delete_duration", true);
 
 export const options = {
   stages: [
-    { duration: "30s", target: 10 },
-    { duration: "1m", target: 10 },
+    { duration: "30s", target: 50 },
+    { duration: "1m", target: 50 },
     { duration: "10s", target: 0 },
   ],
   thresholds: {

--- a/benchmarks/k6-sandbox-lifecycle.js
+++ b/benchmarks/k6-sandbox-lifecycle.js
@@ -1,0 +1,75 @@
+import http from "k6/http";
+import { check, fail } from "k6";
+import { Trend } from "k6/metrics";
+
+const BASE_URL = __ENV.BASE_URL || "http://127.0.0.1:8080";
+const API_KEY = __ENV.API_KEY || "test";
+
+const createDuration = new Trend("sandbox_create_duration", true);
+const execDuration = new Trend("sandbox_exec_duration", true);
+const deleteDuration = new Trend("sandbox_delete_duration", true);
+
+export const options = {
+  stages: [
+    { duration: "30s", target: 10 },
+    { duration: "1m", target: 10 },
+    { duration: "10s", target: 0 },
+  ],
+  thresholds: {
+    http_req_failed: ["rate<0.05"],
+    iteration_duration: ["p(95)<30000"],
+  },
+};
+
+const headers = {
+  "Content-Type": "application/json",
+  "X-Api-Key": API_KEY,
+};
+
+export default function () {
+  // 1. Create sandbox
+  const createRes = http.post(`${BASE_URL}/sandboxes`, null, { headers });
+  createDuration.add(createRes.timings.duration);
+
+  if (
+    !check(createRes, {
+      "create status is 201": (r) => r.status === 201,
+    })
+  ) {
+    fail(`create failed: ${createRes.status} ${createRes.body}`);
+  }
+
+  const sandboxId = createRes.json().id;
+
+  // 2. Execute echo 'hello'
+  const execPayload = JSON.stringify({ command: "echo 'hello'" });
+  const execRes = http.post(
+    `${BASE_URL}/sandboxes/${sandboxId}/executions`,
+    execPayload,
+    { headers },
+  );
+  execDuration.add(execRes.timings.duration);
+
+  if (
+    !check(execRes, {
+      "exec status is 200": (r) => r.status === 200,
+      "exec completed successfully": (r) => {
+        const lines = r.body.trim().split("\n");
+        const last = JSON.parse(lines[lines.length - 1]);
+        return last.type === "exit" && last.exit_code === 0;
+      },
+    })
+  ) {
+    fail(`exec failed: ${execRes.status} ${execRes.body}`);
+  }
+
+  // 3. Delete sandbox
+  const deleteRes = http.del(`${BASE_URL}/sandboxes/${sandboxId}`, null, {
+    headers,
+  });
+  deleteDuration.add(deleteRes.timings.duration);
+
+  check(deleteRes, {
+    "delete status is 204": (r) => r.status === 204,
+  });
+}


### PR DESCRIPTION
## Summary

Adds a k6 load test script that benchmarks the full sandbox lifecycle: create a sandbox, execute `echo 'hello'`, and delete it. Ramps to 50 concurrent VUs and reports per-step latency trends (create, exec, delete) alongside k6's built-in HTTP metrics. Includes a README with setup, usage, environment variables, and custom metrics documentation.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `k6` load test that benchmarks the sandbox lifecycle (create, exec, delete) to measure throughput and latency. Includes a README with setup, env vars, and how to run it locally.

- **New Features**
  - Adds `benchmarks/k6-sandbox-lifecycle.js` with stages: 30s → 50 VUs, hold 1m, ramp down; thresholds: <5% HTTP failures, p95 iteration <30s.
  - Reports custom trends: `sandbox_create_duration`, `sandbox_exec_duration`, `sandbox_delete_duration`.
  - Supports `BASE_URL` and `API_KEY` env vars (defaults: `http://127.0.0.1:8080`, `test`).

<sup>Written for commit 45780e04bdd5f412540c71b057880f95ad5f9731. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/83?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

