### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @endor @mfsiega @tomi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `.github/CODEOWNERS` to set `@endor`, `@mfsiega`, and `@tomi` as default owners for all files. New PRs will auto-request reviews from them.

<sup>Written for commit cacf62bdef9c573b62467100e042f69e926976e8. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/86?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

