### PR TITLE
fix(netrules): serialize iptables calls and add lock-wait flags

### DIFF
--- a/internal/runner/netrules/netrules.go
+++ b/internal/runner/netrules/netrules.go
@@ -162,7 +162,7 @@ func run(name string, args ...string) error {
 
 func output(name string, args ...string) (string, error) {
 	if name == "iptables" {
-		args = append([]string{"-w", "5", "-W", "100000"}, args...)
+		args = append([]string{"-w", "5", "-W", "10000"}, args...)
 	}
 	cmd := exec.Command(name, args...)
 	var stdout bytes.Buffer

--- a/internal/runner/netrules/netrules.go
+++ b/internal/runner/netrules/netrules.go
@@ -46,6 +46,8 @@ func ApplyPolicy(containerID, sourceIP, gatewayIP string, daemonPort int) error 
 		return fmt.Errorf("source ip is required")
 	}
 
+	// Serialize all iptables mutations so concurrent sandbox lifecycles
+	// cannot observe the shared DOCKER-USER chain in an intermediate state.
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -161,6 +163,8 @@ func run(name string, args ...string) error {
 }
 
 func output(name string, args ...string) (string, error) {
+	// -w 5: wait up to 5s for the kernel xtables lock instead of failing immediately.
+	// -W 10000: poll the lock every 10ms (legacy iptables only; ignored by iptables-nft).
 	if name == "iptables" {
 		args = append([]string{"-w", "5", "-W", "10000"}, args...)
 	}

--- a/internal/runner/netrules/netrules.go
+++ b/internal/runner/netrules/netrules.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 )
 
 const chainPrefix = "N8N-SB-"
+
+var mu sync.Mutex
 
 var privateRangesV4 = []string{
 	"10.0.0.0/8",
@@ -43,10 +46,13 @@ func ApplyPolicy(containerID, sourceIP, gatewayIP string, daemonPort int) error 
 		return fmt.Errorf("source ip is required")
 	}
 
+	mu.Lock()
+	defer mu.Unlock()
+
 	if err := ensureDockerUserChain(); err != nil {
 		return err
 	}
-	if err := Teardown(containerID); err != nil {
+	if err := teardownLocked(containerID); err != nil {
 		return err
 	}
 
@@ -91,6 +97,12 @@ func ApplyPolicy(containerID, sourceIP, gatewayIP string, daemonPort int) error 
 
 // Teardown removes per-sandbox iptables rules and chains.
 func Teardown(containerID string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	return teardownLocked(containerID)
+}
+
+func teardownLocked(containerID string) error {
 	if containerID == "" {
 		return nil
 	}
@@ -149,6 +161,9 @@ func run(name string, args ...string) error {
 }
 
 func output(name string, args ...string) (string, error) {
+	if name == "iptables" {
+		args = append([]string{"-w", "5", "-W", "100000"}, args...)
+	}
 	cmd := exec.Command(name, args...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
## Summary

Concurrent `ApplyPolicy`/`Teardown` calls from parallel sandbox lifecycles race on the shared `DOCKER-USER` iptables chain, causing truncated exec responses under load. This PR adds two fixes:

1. **`-w 5 -W 100000` on every `iptables` invocation** — injected in the `output` helper so calls wait for the kernel xtables lock instead of failing immediately.
2. **Package-level `sync.Mutex`** serializing `ApplyPolicy` and `Teardown` — prevents interleaved writes to `DOCKER-USER`. A `teardownLocked` helper is extracted so `ApplyPolicy` can call it without self-deadlocking.

## Related Linear tickets, Github issues, and Community forum posts

Closes [CAT-3269](https://linear.app/n8n/issue/CAT-3269/harden-netrulesapplypolicy-teardown-against-concurrent-calls)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes `iptables` rule updates and adds lock-wait flags to prevent races on the shared `DOCKER-USER` chain during concurrent sandbox lifecycles. Fixes the truncated exec responses seen under load (Linear: CAT-3269).

- **Bug Fixes**
  - Added a package-level `sync.Mutex` to serialize `ApplyPolicy` and `Teardown`.
  - Extracted `teardownLocked` to avoid self-deadlock when `ApplyPolicy` triggers teardown.
  - Injected `-w 5 -W 10000` into every `iptables` call via the `output` helper to wait for the xtables lock and poll every 10ms, with inline comments clarifying both behaviors.

<sup>Written for commit 424538c642c137f2bc10423a55143d594a8d82ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/89?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

