### PR TITLE
chore: scrape sandbox service metrics

### DIFF
--- a/charts/n8n-sandbox-service/Chart.yaml
+++ b/charts/n8n-sandbox-service/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: n8n-sandbox-service
 description: n8n Sandbox Service control plane with optional sysbox/DinD runner
 type: application
-version: 0.2.0
+version: "0.2.1"
 appVersion: "0.1.0"

--- a/charts/n8n-sandbox-service/README.md
+++ b/charts/n8n-sandbox-service/README.md
@@ -206,6 +206,20 @@ networkPolicy:
             kubernetes.io/metadata.name: ingress-nginx
 ```
 
+## Prometheus Metrics
+
+The API and sysbox runner expose Prometheus metrics on their HTTP port at `/metrics`. If your cluster uses Prometheus Operator, enable `ServiceMonitor` resources:
+
+```yaml
+monitoring:
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack
+```
+
+This renders one `ServiceMonitor` for the API Service and, when the in-chart sysbox runner is enabled, one for the runner headless Service. It also enables the matching `/metrics` handlers in the API and runner containers. Use `monitoring.serviceMonitor.api.enabled` or `monitoring.serviceMonitor.sysboxRunner.enabled` to disable either scrape target.
+
 ## Runner Identity
 
 The sysbox runner is deployed as a StatefulSet with a headless Service so each runner pod has direct, DNS-based addressability from the API:

--- a/charts/n8n-sandbox-service/templates/configmap.yaml
+++ b/charts/n8n-sandbox-service/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
   SANDBOX_API_DATA_DIR: {{ .Values.api.config.dataDir | quote }}
   SANDBOX_API_MAX_FILE_BYTES: {{ .Values.api.config.maxFileBytes | quote }}
   SANDBOX_API_ENABLE_CORS: {{ .Values.api.config.enableCors | quote }}
+  SANDBOX_API_METRICS_ENABLED: {{ and .Values.monitoring.serviceMonitor.enabled .Values.monitoring.serviceMonitor.api.enabled | quote }}
   SANDBOX_API_RUNNER_HEARTBEAT_GRACE: {{ .Values.api.config.runnerHeartbeatGrace | quote }}
   SANDBOX_API_IDLE_STOP_AFTER: {{ .Values.api.config.idleStopAfter | quote }}
   SANDBOX_API_IDLE_DELETE_AFTER: {{ .Values.api.config.idleDeleteAfter | quote }}
@@ -34,6 +35,7 @@ data:
   SANDBOX_RUNNER_IDLE_TTL_SECONDS: {{ .Values.sysboxRunner.config.idleTtlSeconds | quote }}
   SANDBOX_RUNNER_CAPACITY_TOTAL: {{ .Values.sysboxRunner.config.capacityTotal | quote }}
   SANDBOX_RUNNER_MAX_FILE_BYTES: {{ .Values.sysboxRunner.config.maxFileBytes | quote }}
+  SANDBOX_RUNNER_METRICS_ENABLED: {{ and .Values.monitoring.serviceMonitor.enabled .Values.monitoring.serviceMonitor.sysboxRunner.enabled | quote }}
   SANDBOX_RUNNER_DEFAULT_MEMORY_MB: {{ .Values.sysboxRunner.config.defaultMemoryMb | quote }}
   SANDBOX_RUNNER_DEFAULT_CPU_PERCENT: {{ .Values.sysboxRunner.config.defaultCpuPercent | quote }}
   SANDBOX_RUNNER_DEFAULT_PIDS_MAX: {{ .Values.sysboxRunner.config.defaultPidsMax | quote }}

--- a/charts/n8n-sandbox-service/templates/servicemonitor.yaml
+++ b/charts/n8n-sandbox-service/templates/servicemonitor.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.monitoring.serviceMonitor.enabled .Values.monitoring.serviceMonitor.api.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "n8n-sandbox-service.apiName" . }}
+  labels:
+    {{- include "n8n-sandbox-service.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.monitoring.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "n8n-sandbox-service.selectorLabels" (dict "Release" .Release "Chart" .Chart "Values" .Values "component" "api") | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.monitoring.serviceMonitor.path | quote }}
+      scheme: {{ .Values.monitoring.serviceMonitor.scheme | quote }}
+      interval: {{ .Values.monitoring.serviceMonitor.interval | quote }}
+      {{- if .Values.monitoring.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout | quote }}
+      {{- end }}
+{{- end }}
+{{- if and .Values.monitoring.serviceMonitor.enabled .Values.monitoring.serviceMonitor.sysboxRunner.enabled .Values.sysboxRunner.enabled (eq .Values.dataPlane.mode "sysbox") }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "n8n-sandbox-service.sysboxRunnerName" . }}
+  labels:
+    {{- include "n8n-sandbox-service.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sysbox-runner
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.monitoring.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "n8n-sandbox-service.selectorLabels" (dict "Release" .Release "Chart" .Chart "Values" .Values "component" "sysbox-runner") | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.monitoring.serviceMonitor.path | quote }}
+      scheme: {{ .Values.monitoring.serviceMonitor.scheme | quote }}
+      interval: {{ .Values.monitoring.serviceMonitor.interval | quote }}
+      {{- if .Values.monitoring.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout | quote }}
+      {{- end }}
+{{- end }}

--- a/charts/n8n-sandbox-service/values.yaml
+++ b/charts/n8n-sandbox-service/values.yaml
@@ -36,6 +36,18 @@ networkPolicy:
     # The in-chart API is allowed automatically.
     ingressFrom: []
 
+monitoring:
+  serviceMonitor:
+    # Requires the Prometheus Operator ServiceMonitor CRD.
+    enabled: false
+    interval: 30s
+    path: /metrics
+    scheme: http
+    api:
+      enabled: true
+    sysboxRunner:
+      enabled: true
+
 tls:
   # Choose how the mTLS Secrets are provided: existingSecret or certManager.
   mode: existingSecret
@@ -171,8 +183,12 @@ sysboxRunner:
 
   scheduling:
     nodeSelector:
-      sysbox-runtime: running
-    tolerations: []
+      sysbox-install: "yes"
+    tolerations:
+    - key: sysbox-runtime
+      operator: Equal
+      value: not-running
+      effect: NoSchedule
     affinity: {}
 
   config:


### PR DESCRIPTION
## Summary

Add `ServiceMonitor`s for both the API and runners, but disable them by default. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Prometheus scraping for the sandbox service by templating `ServiceMonitor`s for the API and sysbox runner, disabled by default. Enables `/metrics` handlers only when monitoring is turned on.

- **New Features**
  - Adds `ServiceMonitor` for the API and, when enabled, for the sysbox runner (only if `sysboxRunner.enabled` and `dataPlane.mode: sysbox`).
  - New values under `monitoring.serviceMonitor` (path, interval, scheme, per-target toggles, optional labels/annotations).
  - Sets `SANDBOX_API_METRICS_ENABLED` and `SANDBOX_RUNNER_METRICS_ENABLED` based on values.
  - Docs updated with example config for `kube-prometheus-stack`.
  - Helm chart version bump to 0.2.1.

- **Migration**
  - Default sysbox runner scheduling changed: `nodeSelector` now uses `sysbox-install: "yes"` and adds a toleration for `sysbox-runtime=not-running`.
  - If your cluster uses the old label (`sysbox-runtime: running`), either update node labels or override `sysboxRunner.scheduling` in your values.

<sup>Written for commit e2ef03cf66417f076cff4926931b55c423eb17b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

