### PR TITLE
chore(e2e): remove pyConnect code from network isolation tests

### DIFF
--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -2,14 +2,14 @@ import { test, expect } from '@playwright/test';
 import './matchers';
 import { createSandbox, deleteSandbox, exec, execWithTransientRetry } from './helpers';
 
-const pyConnect = (ip: string, port: number = 80, timeout: number = 3) =>
-  `python3 -c "import socket; s=socket.socket(); s.settimeout(${timeout}); s.connect(('${ip}', ${port})); s.close(); print('connected')"`;
+const tcpConnect = (ip: string, port: number = 80, timeout: number = 3) =>
+  `curl --connect-timeout ${timeout} -s -o /dev/null http://${ip}:${port}/`;
 
-const pyConnectV6 = (ip: string, port: number = 443, timeout: number = 3) =>
-  `python3 -c "import socket; s=socket.socket(socket.AF_INET6); s.settimeout(${timeout}); s.connect(('${ip}', ${port})); s.close(); print('connected')"`;
+const tcpConnectV6 = (ip: string, port: number = 443, timeout: number = 3) =>
+  `curl --connect-timeout ${timeout} -s -o /dev/null -6 "http://[${ip}]:${port}/"`;
 
-const pyResolve = (host: string) =>
-  `python3 -c "import socket; print(socket.gethostbyname('${host}'))"`;
+const resolve = (host: string) =>
+  `getent ahostsv4 ${host} | head -1 | awk '{print $1}'`;
 
 test.describe('Network isolation', () => {
   test('sandbox can reach public internet', async () => {
@@ -36,7 +36,7 @@ test.describe('Network isolation', () => {
       ];
 
       for (const ip of privateIPs) {
-        const result = await execWithTransientRetry(id, pyConnect(ip, 80, 3), { timeoutMs: 10_000 });
+        const result = await execWithTransientRetry(id, tcpConnect(ip, 80, 3), { timeoutMs: 10_000 });
         expect(result.exitCode, `expected private IP ${ip} to be unreachable`).not.toBe(0);
       }
     } finally {
@@ -54,18 +54,11 @@ test.describe('Network isolation', () => {
       const sandbox2IP = ipResult.stdout.trim();
       expect(sandbox2IP).toBeTruthy();
 
-      // Start a TCP listener in sandbox 2 on port 9999
-      await exec(id2, `python3 -c "
-import socket, threading
-s = socket.socket()
-s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-s.bind(('0.0.0.0', 9999))
-s.listen(1)
-import time; time.sleep(30)
-" &`, { timeoutMs: 5_000 });
+      // Start an HTTP listener in sandbox 2 on port 9999
+      await exec(id2, `node -e "require('http').createServer((q,r)=>r.end('ok')).listen(9999,'0.0.0.0');setTimeout(()=>{},30000)" &`, { timeoutMs: 5_000 });
 
       // Sandbox 1 should not be able to reach sandbox 2
-      const result = await execWithTransientRetry(id1, pyConnect(sandbox2IP, 9999, 3), { timeoutMs: 10_000 });
+      const result = await execWithTransientRetry(id1, tcpConnect(sandbox2IP, 9999, 3), { timeoutMs: 10_000 });
       expect(result.exitCode, `expected sandbox 1 to not reach sandbox 2 at ${sandbox2IP}`).not.toBe(0);
     } finally {
       await deleteSandbox(id1);
@@ -84,7 +77,7 @@ import time; time.sleep(30)
       ];
 
       for (const ip of v6Targets) {
-        const result = await execWithTransientRetry(id, pyConnectV6(ip, 443, 3), { timeoutMs: 10_000 });
+        const result = await execWithTransientRetry(id, tcpConnectV6(ip, 443, 3), { timeoutMs: 10_000 });
         expect(result.exitCode, `expected IPv6 ${ip} to be unreachable`).not.toBe(0);
       }
     } finally {
@@ -95,7 +88,7 @@ import time; time.sleep(30)
   test('DNS resolution works', async () => {
     const id = await createSandbox();
     try {
-      const result = await execWithTransientRetry(id, pyResolve('example.com'), { timeoutMs: 10_000 });
+      const result = await execWithTransientRetry(id, resolve('example.com'), { timeoutMs: 10_000 });
       expect(result).toHaveSucceeded();
       // Should resolve to an IP address
       expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+\.\d+$/);

--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -6,7 +6,7 @@ const tcpConnect = (ip: string, port: number = 80, timeout: number = 3) =>
   `curl --connect-timeout ${timeout} -s -o /dev/null http://${ip}:${port}/`;
 
 const tcpConnectV6 = (ip: string, port: number = 443, timeout: number = 3) =>
-  `curl --connect-timeout ${timeout} -s -o /dev/null -6 "http://[${ip}]:${port}/"`;
+  `curl --connect-timeout ${timeout} -sk -o /dev/null -6 "https://[${ip}]:${port}/"`;
 
 const resolve = (host: string) =>
   `getent ahostsv4 ${host} | head -1 | awk '{print $1}'`;


### PR DESCRIPTION
## Summary

Replace Python socket helpers (`pyConnect`, `pyConnectV6`, `pyResolve`) in network isolation e2e tests with `curl`, `getent`, and a lightweight `node` HTTP listener. This removes the Python dependency from the test file while keeping the same test coverage. Follow-up from [PR #91 review](https://github.com/n8n-io/n8n-sandbox-service/pull/91#pullrequestreview-4418904656).

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/CAT-3327/remove-pyconnect-code

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove Python helpers from network isolation e2e tests to drop the Python dependency while keeping the same coverage. Also fix the IPv6 reachability check to avoid false passes. Addresses Linear CAT-3327.

- **Refactors**
  - Replaced `pyConnect`, `pyConnectV6`, `pyResolve` with `curl` (IPv4/IPv6) and `getent` for DNS.
  - Added a lightweight HTTP listener using `node` for sandbox-to-sandbox checks so `curl` can validate connections.
  - Kept test behavior and assertions the same.

- **Bug Fixes**
  - Use HTTPS with `-k` for IPv6 checks to avoid protocol-mismatch false passes on port 443.

<sup>Written for commit 4f66b2704295b035a2d595504777ad1420cdd1e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

