### PR TITLE
chore: prepare licensing for firecracker runner

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,9 +3,9 @@
 Portions of this software are licensed as follows:
 
 - Content of branches other than the main branch (i.e. "main") are not licensed.
-- Source code files that contain ".ee." in their filename or ".ee" in their dirname are NOT licensed under
+- Source code files that are part of the firecracker runner are NOT licensed under
   the Sustainable Use License.
-  To use source code files that contain ".ee." in their filename or ".ee" in their dirname you must hold a
+  To use source code files that are part of the firecracker runner you must hold a
 	valid n8n Enterprise License specifically allowing you access to such source code files and as defined
 	in "LICENSE_EE.md".
 - All third party components incorporated into the n8n Software are licensed under the original license

--- a/LICENSE_EE.md
+++ b/LICENSE_EE.md
@@ -1,6 +1,6 @@
 # The n8n Enterprise License (the “Enterprise License”)
 
-Copyright (c) 2022-present n8n GmbH.
+Copyright (c) 2026-present n8n GmbH.
 
 With regard to the n8n Software:
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies licensing for the firecracker runner by excluding it from the Sustainable Use License and requiring an n8n Enterprise License. Also updates the copyright year in `LICENSE_EE.md`.

<sup>Written for commit cdd27d0bf6d2be2d1cbe4ad13d25e7d7f8861c4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

