### PR TITLE
feat: Mirror published images to GHCR

### DIFF
--- a/.github/actions/docker-publish/action.yml
+++ b/.github/actions/docker-publish/action.yml
@@ -29,6 +29,17 @@ inputs:
   dockerhub-token:
     required: true
     description: Docker Hub access token
+  ghcr-image:
+    required: false
+    default: ""
+    description: >
+      GHCR image name (e.g. ghcr.io/n8n-io/n8n-sandbox-service-api) to mirror
+      all tags to. GHCR has no anonymous pull rate limits, unlike Docker Hub.
+      Requires ghcr-token.
+  ghcr-token:
+    required: false
+    default: ""
+    description: Token with packages:write, for pushing the ghcr-image mirror
 
 runs:
   using: composite
@@ -38,6 +49,14 @@ runs:
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-token }}
+
+    - name: Log in to GHCR
+      if: inputs.ghcr-image != ''
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.ghcr-token }}
 
     - name: Set up QEMU
       if: contains(inputs.platforms, 'arm64')
@@ -56,6 +75,7 @@ runs:
         VERSION: ${{ inputs.version }}
         PUSH_LATEST: ${{ inputs.push-latest }}
         EXTRA_TAGS: ${{ inputs.extra-tags }}
+        GHCR_IMAGE: ${{ inputs.ghcr-image }}
       run: |
         TAGS="${IMAGE}:${VERSION}"
         if [[ "$PUSH_LATEST" == "true" ]]; then
@@ -69,6 +89,10 @@ runs:
         ${IMAGE}:${tag}"
           fi
         done <<< "$EXTRA_TAGS"
+        if [[ -n "$GHCR_IMAGE" ]]; then
+          TAGS="${TAGS}
+        ${TAGS//${IMAGE}:/${GHCR_IMAGE}:}"
+        fi
         {
           echo "tags<<EOF"
           echo "$TAGS"

--- a/.github/workflows/release-sandbox-publish.yml
+++ b/.github/workflows/release-sandbox-publish.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   publish:
@@ -30,10 +31,12 @@ jobs:
         uses: ./.github/actions/docker-publish
         with:
           image: n8nio/n8n-sandbox-service-sandbox
+          ghcr-image: ghcr.io/n8n-io/n8n-sandbox-service-sandbox
           dockerfile: Dockerfile.sandbox
           version: ${{ steps.version.outputs.version }}
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr-token: ${{ github.token }}
 
       - name: Generate GitHub App Token
         id: generate-token

--- a/.github/workflows/release-service-publish.yml
+++ b/.github/workflows/release-service-publish.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   publish:
@@ -33,32 +34,38 @@ jobs:
         uses: ./.github/actions/docker-publish
         with:
           image: n8nio/n8n-sandbox-service-api
+          ghcr-image: ghcr.io/n8n-io/n8n-sandbox-service-api
           dockerfile: Dockerfile.api
           version: ${{ steps.version.outputs.version }}
           extra-tags: stable
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr-token: ${{ github.token }}
 
       - name: Publish runner image
         uses: ./.github/actions/docker-publish
         with:
           image: n8nio/n8n-sandbox-service-runner-dind
+          ghcr-image: ghcr.io/n8n-io/n8n-sandbox-service-runner-dind
           dockerfile: Dockerfile.runner-dind
           version: ${{ steps.version.outputs.version }}
           extra-tags: stable
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr-token: ${{ github.token }}
 
       - name: Publish Firecracker runner image
         uses: ./.github/actions/docker-publish
         with:
           image: n8nio/n8n-sandbox-service-runner-firecracker
+          ghcr-image: ghcr.io/n8n-io/n8n-sandbox-service-runner-firecracker
           dockerfile: Dockerfile.ee.runner-firecracker
           version: ${{ steps.version.outputs.version }}
           platforms: linux/amd64
           extra-tags: stable
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr-token: ${{ github.token }}
 
       - name: Generate GitHub App Token
         id: generate-token


### PR DESCRIPTION
## Summary

Mirrors every image published by the service and sandbox release workflows to `ghcr.io/n8n-io/…`, alongside the existing Docker Hub push.

**Why:** Docker Hub's anonymous pull limit (100 pulls per 6h per IP) breaks `get.n8n.io` installs (n8n-io/n8n#34711) for users behind shared/corporate NATs — reported by a Podman user whose install died mid-pull on `toomanyrequests`. `docker.n8n.io` only proxies `n8nio/n8n` (and passes Hub rate limits through), while public GHCR packages have no anonymous pull limits. Once images are on GHCR, the installer's compose file switches its sandbox image references over.

**How:** the `docker-publish` composite action gains optional `ghcr-image` / `ghcr-token` inputs — when set, it logs in to GHCR and duplicates the computed tag list for the mirror, so one buildx invocation pushes to both registries (identical digests, no extra build). Both release workflows pass them for all published images (api, runner-dind, runner-firecracker, sandbox) and gain `packages: write`.

**One-time follow-up after the first release with this change:** GHCR packages created by a first push are **private** by default — an org admin must set the four `n8n-sandbox-service-*` packages to public visibility (Org → Packages → package → settings), once. Anonymous pulls fail until then.

To backfill without waiting for the next release, anyone with `packages:write` can copy the current images:
```sh
for img in n8n-sandbox-service-api n8n-sandbox-service-runner-dind n8n-sandbox-service-sandbox; do
  docker buildx imagetools create --tag ghcr.io/n8n-io/$img:latest n8nio/$img:latest
done
```

**How to test:** tag computation is a pure string transform; verified the mirrored tag list renders correctly for a sample (version + latest + stable → same three tags under `ghcr.io/n8n-io/…`). `actionlint` clean. The real proof is the first release run.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-661
Relates to n8n-io/n8n#34711.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mirrors all release images to `ghcr.io/n8n-io/*` alongside Docker Hub to avoid anonymous pull limits that break installs on shared NATs. Addresses DEVP-661 and relates to n8n-io/n8n#34711.

- **New Features**
  - `docker-publish` accepts `ghcr-image` and `ghcr-token`; logs into GHCR and mirrors all computed tags in the same build (identical digests).
  - `release-service-publish.yml` and `release-sandbox-publish.yml` grant `packages: write` and pass GHCR inputs for `api`, `runner-dind`, `runner-firecracker`, and `sandbox`.

- **Migration**
  - After the first push, set new `n8n-sandbox-service-*` GHCR packages to public visibility to enable anonymous pulls.
  - Optional: backfill existing tags to GHCR if needed (e.g., via `docker buildx imagetools`).

<sup>Written for commit 960277adcbb139009f47258c26586e247d8b52aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

