### PR TITLE
feat: Support Agent Knowledge sandboxes

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     ca-certificates \
     curl \
+    ripgrep \
     wget \
     sudo \
     && npm install -g typescript \

--- a/docs/API.md
+++ b/docs/API.md
@@ -116,7 +116,7 @@ Resource limits (memory, CPU, process count) are configured on the runner via en
 }
 ```
 
-**Errors:** `400` invalid supplied id, `502` stale sandbox cleanup failed, `503` no sandbox runners are registered or available
+**Errors:** `400` invalid request body or supplied id, `502` stale sandbox cleanup failed, `503` no sandbox runners are registered or available
 
 **Examples:**
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,11 +93,19 @@ curl http://localhost:8080/sandboxes \
 
 ### POST /sandboxes
 
-Create a new sandbox. No request body is required.
+Create a sandbox. With no request body, the service generates a UUID. Callers may instead supply a lowercase UUID to create or reconnect to a deterministic sandbox:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+If that ID is still available within its idle-delete window, the existing sandbox is returned. If it has passed the window, the stale sandbox is deleted before the ID is reused.
 
 Resource limits (memory, CPU, process count) are configured on the runner via environment variables. Network policy blocks all private IP ranges and allows public internet access.
 
-**Response:** `201 Created`
+**Response:** `201 Created` for a new sandbox, or `200 OK` when returning an existing caller-supplied sandbox
 
 ```json
 {
@@ -108,13 +116,20 @@ Resource limits (memory, CPU, process count) are configured on the runner via en
 }
 ```
 
-**Errors:** `503` when no sandbox runners are registered or available
+**Errors:** `400` invalid supplied id, `502` stale sandbox cleanup failed, `503` no sandbox runners are registered or available
 
-**Example:**
+**Examples:**
 
 ```bash
+# Server-generated ID
 curl -X POST http://localhost:8080/sandboxes \
   -H "X-Api-Key: YOUR_API_KEY"
+
+# Caller-supplied deterministic ID
+curl -X POST http://localhost:8080/sandboxes \
+  -H "X-Api-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"id":"550e8400-e29b-41d4-a716-446655440000"}'
 ```
 
 ---

--- a/e2e/tests/sandbox-api.spec.ts
+++ b/e2e/tests/sandbox-api.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
 import './matchers';
 import {
   client,
@@ -32,6 +33,37 @@ test.describe('Auth', () => {
 });
 
 test.describe('Sandbox lifecycle', () => {
+  test('creates and reuses a client-supplied sandbox ID', async ({ request }) => {
+    const id = randomUUID();
+    try {
+      const created = await request.post('/sandboxes', {
+        headers: { 'X-Api-Key': API_KEY, 'Content-Type': 'application/json' },
+        data: { id },
+      });
+      expect(created.status()).toBe(201);
+      expect((await created.json()).id).toBe(id);
+
+      const reused = await request.post('/sandboxes', {
+        headers: { 'X-Api-Key': API_KEY, 'Content-Type': 'application/json' },
+        data: { id },
+      });
+      expect(reused.status()).toBe(200);
+      expect((await reused.json()).id).toBe(id);
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+
+  test('rejects invalid client-supplied sandbox IDs', async ({ request }) => {
+    for (const id of ['', 'not-a-uuid', randomUUID().toUpperCase()]) {
+      const response = await request.post('/sandboxes', {
+        headers: { 'X-Api-Key': API_KEY, 'Content-Type': 'application/json' },
+        data: { id },
+      });
+      expect(response.status()).toBe(400);
+    }
+  });
+
   test('create, exec, delete', async ({ request }) => {
     const id = await createSandbox();
     expect(id).toBeTruthy();

--- a/e2e/tests/sandbox-api.spec.ts
+++ b/e2e/tests/sandbox-api.spec.ts
@@ -36,12 +36,18 @@ test.describe('Sandbox lifecycle', () => {
   test('creates and reuses a client-supplied sandbox ID', async ({ request }) => {
     const id = randomUUID();
     try {
-      const created = await request.post('/sandboxes', {
-        headers: { 'X-Api-Key': API_KEY, 'Content-Type': 'application/json' },
-        data: { id },
-      });
-      expect(created.status()).toBe(201);
-      expect((await created.json()).id).toBe(id);
+      const initialResponses = await Promise.all(
+        Array.from({ length: 2 }, () =>
+          request.post('/sandboxes', {
+            headers: { 'X-Api-Key': API_KEY, 'Content-Type': 'application/json' },
+            data: { id },
+          }),
+        ),
+      );
+      expect(initialResponses.map((response) => response.status()).sort()).toEqual([200, 201]);
+      for (const response of initialResponses) {
+        expect((await response.json()).id).toBe(id);
+      }
 
       const reused = await request.post('/sandboxes', {
         headers: { 'X-Api-Key': API_KEY, 'Content-Type': 'application/json' },
@@ -62,6 +68,18 @@ test.describe('Sandbox lifecycle', () => {
       });
       expect(response.status()).toBe(400);
     }
+  });
+
+  test('rejects trailing data in a create request', async ({ request }) => {
+    const id = randomUUID();
+    const response = await request.post('/sandboxes', {
+      headers: { 'X-Api-Key': API_KEY, 'Content-Type': 'application/json' },
+      data: `{"id":"${id}"} {}`,
+    });
+    expect(response.status()).toBe(400);
+
+    const sandbox = await apiRequest(request, 'GET', `/sandboxes/${id}`);
+    expect(sandbox.status).toBe(404);
   });
 
   test('create, exec, delete', async ({ request }) => {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
@@ -91,6 +93,19 @@ type SandboxResponse struct {
 	LastActiveAt int64  `json:"last_active_at"`
 }
 
+type createSandboxRequest struct {
+	ID *string `json:"id"`
+}
+
+func sandboxResponse(rec *store.SandboxRecord) *SandboxResponse {
+	return &SandboxResponse{
+		ID:           rec.ID,
+		Status:       rec.Status,
+		CreatedAt:    rec.CreatedAt,
+		LastActiveAt: rec.LastActiveAt,
+	}
+}
+
 func handleListSandboxes(s store.SandboxStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		records, err := s.List()
@@ -165,6 +180,37 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 		success := false
 		defer func() { rec.ObserveSandboxOp(metrics.OpCreate, success) }()
 
+		var req createSandboxRequest
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1024)).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+
+		sandboxID := generateUUID()
+		if req.ID != nil {
+			if !isValidUUID(*req.ID) {
+				writeError(w, http.StatusBadRequest, "invalid sandbox id")
+				return
+			}
+			sandboxID = *req.ID
+
+			existing, err := s.Get(sandboxID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if existing != nil {
+				if !isPastIdleDeleteWindow(existing, cfg, time.Now().Unix()) {
+					writeJSON(w, http.StatusOK, sandboxResponse(existing))
+					success = true
+					return
+				}
+				if !deleteSandboxRecord(w, r, s, cfg, existing) {
+					return
+				}
+			}
+		}
+
 		run, err := reg.PickLowestUsed()
 		if err != nil {
 			if errors.Is(err, registry.ErrNoRunners) {
@@ -180,7 +226,6 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 		controlAddr := run.ControlGRPCAddr
 		tlsCfg := runnerControlTLS(cfg)
 
-		sandboxID := generateUUID()
 		now := time.Now().Unix()
 		slog.Info(
 			"create sandbox: runner selected",
@@ -220,6 +265,11 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 		}
 		if err := s.Create(record); err != nil {
 			_ = runnerctl.DeleteSandbox(r.Context(), controlAddr, cfg.RunnerAPIKey, tlsCfg, sandboxID)
+			if existing, getErr := s.Get(sandboxID); getErr == nil && existing != nil {
+				writeJSON(w, http.StatusOK, sandboxResponse(existing))
+				success = true
+				return
+			}
 			slog.Error(
 				"create sandbox failed: store record",
 				"sandbox_id", sandboxID,
@@ -237,15 +287,21 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 			"container_ip", containerIP,
 		)
 
-		resp := &SandboxResponse{
-			ID:           sandboxID,
-			Status:       "running",
-			CreatedAt:    now,
-			LastActiveAt: now,
-		}
-		writeJSON(w, http.StatusCreated, resp)
+		writeJSON(w, http.StatusCreated, sandboxResponse(record))
 		success = true
 	}
+}
+
+func deleteSandboxRecord(w http.ResponseWriter, r *http.Request, s store.SandboxStore, cfg *config.APIConfig, rec *store.SandboxRecord) bool {
+	if err := runnerctl.DeleteSandbox(r.Context(), rec.RunnerControlGRPCAddr, cfg.RunnerAPIKey, runnerControlTLS(cfg), rec.ID); err != nil {
+		writeError(w, http.StatusBadGateway, "failed to delete container: "+err.Error())
+		return false
+	}
+	if err := s.Delete(rec.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return false
+	}
+	return true
 }
 
 func handleDeleteSandbox(s store.SandboxStore, cfg *config.APIConfig, mrec *metrics.APIRecorder) http.HandlerFunc {
@@ -270,15 +326,7 @@ func handleDeleteSandbox(s store.SandboxStore, cfg *config.APIConfig, mrec *metr
 			return
 		}
 
-		controlAddr := rec.RunnerControlGRPCAddr
-		tlsCfg := runnerControlTLS(cfg)
-		if err := runnerctl.DeleteSandbox(r.Context(), controlAddr, cfg.RunnerAPIKey, tlsCfg, id); err != nil {
-			writeError(w, http.StatusBadGateway, "failed to delete container: "+err.Error())
-			return
-		}
-
-		if err := s.Delete(id); err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+		if !deleteSandboxRecord(w, r, s, cfg, rec) {
 			return
 		}
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -327,6 +327,13 @@ func handleDeleteSandbox(s store.SandboxStore, cfg *config.APIConfig, mrec *metr
 			return
 		}
 
+		unlock, err := s.LockSandbox(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		defer unlock()
+
 		rec, err := s.Get(id)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -181,7 +181,12 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 		defer func() { rec.ObserveSandboxOp(metrics.OpCreate, success) }()
 
 		var req createSandboxRequest
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1024)).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1024))
+		if err := decoder.Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 			writeError(w, http.StatusBadRequest, "invalid request body")
 			return
 		}
@@ -193,6 +198,13 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 				return
 			}
 			sandboxID = *req.ID
+
+			unlock, err := s.LockSandbox(r.Context(), sandboxID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			defer unlock()
 
 			existing, err := s.Get(sandboxID)
 			if err != nil {

--- a/internal/api/store/postgres.go
+++ b/internal/api/store/postgres.go
@@ -14,7 +14,8 @@ import (
 
 // PostgresStore wraps a *sql.DB backed by Postgres.
 type PostgresStore struct {
-	db *sql.DB
+	db     *sql.DB
+	lockDB *sql.DB
 }
 
 // NewPostgres opens Postgres using cfg, runs schema migrations, and returns a ready store.
@@ -42,8 +43,22 @@ func NewPostgres(cfg config.PostgresConfig) (*PostgresStore, error) {
 		return nil, fmt.Errorf("store: run runners schema: %w", err)
 	}
 
+	lockDB, err := sql.Open("pgx", cfg.DSN())
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("store: open postgres lock pool: %w", err)
+	}
+	lockDB.SetMaxOpenConns(5)
+	lockDB.SetMaxIdleConns(1)
+	lockDB.SetConnMaxLifetime(30 * time.Minute)
+	if err := lockDB.Ping(); err != nil {
+		_ = lockDB.Close()
+		_ = db.Close()
+		return nil, fmt.Errorf("store: ping postgres lock pool: %w", err)
+	}
+
 	slog.Debug("store: opened postgres database", "host", cfg.Host, "db", cfg.Database)
-	return &PostgresStore{db: db}, nil
+	return &PostgresStore{db: db, lockDB: lockDB}, nil
 }
 
 // DB returns the underlying database handle (for registry and sweeper lock).
@@ -51,7 +66,7 @@ func (s *PostgresStore) DB() *sql.DB { return s.db }
 
 func (s *PostgresStore) Backend() Backend { return BackendPostgres }
 
-func (s *PostgresStore) Close() error { return s.db.Close() }
+func (s *PostgresStore) Close() error { return errors.Join(s.db.Close(), s.lockDB.Close()) }
 
 func (s *PostgresStore) Create(record *SandboxRecord) error {
 	const q = `
@@ -122,19 +137,25 @@ func (s *PostgresStore) Delete(id string) error {
 }
 
 func (s *PostgresStore) LockSandbox(ctx context.Context, id string) (func(), error) {
-	conn, err := s.db.Conn(ctx)
+	conn, err := s.lockDB.Conn(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("store: acquire conn for sandbox lock: %w", err)
 	}
-	lockID := "sandbox:" + id
-	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock(hashtextextended($1, 0))`, lockID); err != nil {
+	tx, err := conn.BeginTx(context.Background(), nil)
+	if err != nil {
 		_ = conn.Close()
+		return nil, fmt.Errorf("store: begin sandbox lock transaction: %w", err)
+	}
+	unlock := func() {
+		_ = tx.Rollback()
+		_ = conn.Close()
+	}
+	lockID := "sandbox:" + id
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, lockID); err != nil {
+		unlock()
 		return nil, fmt.Errorf("store: lock sandbox %s: %w", id, err)
 	}
-	return func() {
-		_, _ = conn.ExecContext(context.Background(), `SELECT pg_advisory_unlock(hashtextextended($1, 0))`, lockID)
-		_ = conn.Close()
-	}, nil
+	return unlock, nil
 }
 
 func (s *PostgresStore) ListForIdleReapDelete(cutoff int64) ([]*SandboxRecord, error) {

--- a/internal/api/store/postgres.go
+++ b/internal/api/store/postgres.go
@@ -121,6 +121,22 @@ func (s *PostgresStore) Delete(id string) error {
 	return nil
 }
 
+func (s *PostgresStore) LockSandbox(ctx context.Context, id string) (func(), error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("store: acquire conn for sandbox lock: %w", err)
+	}
+	lockID := "sandbox:" + id
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock(hashtextextended($1, 0))`, lockID); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("store: lock sandbox %s: %w", id, err)
+	}
+	return func() {
+		_, _ = conn.ExecContext(context.Background(), `SELECT pg_advisory_unlock(hashtextextended($1, 0))`, lockID)
+		_ = conn.Close()
+	}, nil
+}
+
 func (s *PostgresStore) ListForIdleReapDelete(cutoff int64) ([]*SandboxRecord, error) {
 	const q = `
 		SELECT id, status, created_at, last_active_at, rootfs_path, socket_path, container_ip, daemon_port, runner_id, runner_http_base_url, runner_control_grpc_addr

--- a/internal/api/store/postgres_integration_test.go
+++ b/internal/api/store/postgres_integration_test.go
@@ -4,6 +4,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strconv"
 	"sync"
@@ -101,6 +102,50 @@ func TestPostgresStoreCRUD(t *testing.T) {
 	if len(rows) == 0 {
 		t.Fatal("expected stop candidate")
 	}
+}
+
+func TestPostgresSandboxLockKeepsStoreUsableAndReleasesAfterCancellation(t *testing.T) {
+	s := openTestPostgresStore(t)
+	s.db.SetMaxOpenConns(1)
+
+	unlock, err := s.LockSandbox(context.Background(), "shared-sandbox")
+	if err != nil {
+		t.Fatalf("lock sandbox: %v", err)
+	}
+	var unlockOnce sync.Once
+	release := func() { unlockOnce.Do(unlock) }
+	defer release()
+
+	countDone := make(chan error, 1)
+	go func() {
+		_, err := s.Count()
+		countDone <- err
+	}()
+	select {
+	case err := <-countDone:
+		if err != nil {
+			t.Fatalf("count while sandbox locked: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("store query blocked by sandbox lock")
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	waitUnlock, err := s.LockSandbox(waitCtx, "shared-sandbox")
+	if waitUnlock != nil {
+		waitUnlock()
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("contended lock error = %v, want context deadline exceeded", err)
+	}
+
+	release()
+	unlock, err = s.LockSandbox(context.Background(), "shared-sandbox")
+	if err != nil {
+		t.Fatalf("reacquire sandbox lock: %v", err)
+	}
+	unlock()
 }
 
 func TestTryRunExcludesConcurrentHolder(t *testing.T) {

--- a/internal/api/store/sqlite.go
+++ b/internal/api/store/sqlite.go
@@ -1,9 +1,11 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"strings"
 	"time"
@@ -13,7 +15,8 @@ import (
 
 // SQLiteStore wraps a *sql.DB and exposes CRUD operations for SandboxRecord rows.
 type SQLiteStore struct {
-	db *sql.DB
+	db           *sql.DB
+	sandboxLocks [64]chan struct{}
 }
 
 // NewSQLite opens (or creates) the SQLite database at dbPath, runs schema migrations,
@@ -59,7 +62,11 @@ func NewSQLite(dbPath string) (*SQLiteStore, error) {
 	}
 
 	slog.Debug("store: opened sqlite database", "path", dbPath)
-	return &SQLiteStore{db: db}, nil
+	store := &SQLiteStore{db: db}
+	for i := range store.sandboxLocks {
+		store.sandboxLocks[i] = make(chan struct{}, 1)
+	}
+	return store, nil
 }
 
 // New opens SQLite at dbPath. It is an alias for NewSQLite for backward compatibility.
@@ -137,6 +144,18 @@ func (s *SQLiteStore) Delete(id string) error {
 		return fmt.Errorf("store: delete sandbox %s: %w", id, err)
 	}
 	return nil
+}
+
+func (s *SQLiteStore) LockSandbox(ctx context.Context, id string) (func(), error) {
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(id))
+	lock := s.sandboxLocks[hash.Sum32()%uint32(len(s.sandboxLocks))]
+	select {
+	case lock <- struct{}{}:
+		return func() { <-lock }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func (s *SQLiteStore) ListForIdleReapDelete(cutoff int64) ([]*SandboxRecord, error) {

--- a/internal/api/store/store.go
+++ b/internal/api/store/store.go
@@ -1,7 +1,10 @@
 // Package store provides persistent storage for sandbox records (SQLite or Postgres).
 package store
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 // Backend identifies the sandbox store implementation.
 type Backend string
@@ -34,6 +37,7 @@ type SandboxStore interface {
 	UpdateStatus(id, status string) error
 	UpdateLastActive(id string) error
 	Delete(id string) error
+	LockSandbox(ctx context.Context, id string) (unlock func(), err error)
 	ListForIdleReapDelete(cutoff int64) ([]*SandboxRecord, error)
 	ListForIdleReapStop(cutoff int64) ([]*SandboxRecord, error)
 	Count() (int64, error)

--- a/internal/api/ttl.go
+++ b/internal/api/ttl.go
@@ -134,6 +134,23 @@ func reapOrphanSandbox(s store.SandboxStore, rec *store.SandboxRecord, runnerID 
 	logSandboxDeleted(rec.ID, runnerID, "orphan")
 }
 
+func withLockedSandbox(ctx context.Context, s store.SandboxStore, id string, fn func(*store.SandboxRecord)) error {
+	unlock, err := s.LockSandbox(ctx, id)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	rec, err := s.Get(id)
+	if err != nil {
+		return err
+	}
+	if rec != nil {
+		fn(rec)
+	}
+	return nil
+}
+
 func sweepIdleDeleteSandboxes(ctx context.Context, s store.SandboxStore, reg registry.RunnerRegistry, cfg *config.APIConfig, tlsCfg *runnerctl.TLS, now time.Time) {
 	deleteSec := int64(cfg.IdleDeleteAfter.Seconds())
 	bufferSec := int64(cfg.IdleDeleteSafetyBuffer.Seconds())
@@ -149,23 +166,34 @@ func sweepIdleDeleteSandboxes(ctx context.Context, s store.SandboxStore, reg reg
 		if rec == nil {
 			continue
 		}
-		if orphanReapDue(reg, rec.RunnerID, cfg, now) {
-			reapOrphanSandbox(s, rec, rec.RunnerID)
-			continue
-		}
-		controlAddr := resolveControlAddr(rec, reg)
-		if err := runnerctl.DeleteSandbox(ctx, controlAddr, cfg.RunnerAPIKey, tlsCfg, rec.ID); err != nil {
-			if ctx.Err() != nil {
+		id := rec.ID
+		err := withLockedSandbox(ctx, s, id, func(rec *store.SandboxRecord) {
+			if rec.Status != "stopped" || rec.LastActiveAt > deleteCutoff {
 				return
 			}
-			slog.Error("idle delete failed", "sandbox_id", rec.ID, "err", err)
-			continue
+			if orphanReapDue(reg, rec.RunnerID, cfg, now) {
+				reapOrphanSandbox(s, rec, rec.RunnerID)
+				return
+			}
+			controlAddr := resolveControlAddr(rec, reg)
+			if err := runnerctl.DeleteSandbox(ctx, controlAddr, cfg.RunnerAPIKey, tlsCfg, rec.ID); err != nil {
+				if ctx.Err() == nil {
+					slog.Error("idle delete failed", "sandbox_id", rec.ID, "err", err)
+				}
+				return
+			}
+			if err := s.Delete(rec.ID); err != nil {
+				slog.Error("idle delete store failed", "sandbox_id", rec.ID, "err", err)
+				return
+			}
+			logSandboxDeleted(rec.ID, rec.RunnerID, "idle")
+		})
+		if err != nil && ctx.Err() == nil {
+			slog.Error("idle delete lock or refresh failed", "sandbox_id", id, "err", err)
 		}
-		if err := s.Delete(rec.ID); err != nil {
-			slog.Error("idle delete store failed", "sandbox_id", rec.ID, "err", err)
-			continue
+		if ctx.Err() != nil {
+			return
 		}
-		logSandboxDeleted(rec.ID, rec.RunnerID, "idle")
 	}
 }
 
@@ -183,22 +211,33 @@ func sweepIdleStopSandboxes(ctx context.Context, s store.SandboxStore, reg regis
 		if rec == nil {
 			continue
 		}
-		if orphanReapDue(reg, rec.RunnerID, cfg, now) {
-			reapOrphanSandbox(s, rec, rec.RunnerID)
-			continue
-		}
-		controlAddr := resolveControlAddr(rec, reg)
-		if err := runnerctl.StopSandbox(ctx, controlAddr, cfg.RunnerAPIKey, tlsCfg, rec.ID); err != nil {
-			if ctx.Err() != nil {
+		id := rec.ID
+		err := withLockedSandbox(ctx, s, id, func(rec *store.SandboxRecord) {
+			if rec.Status != "running" || rec.LastActiveAt > stopCutoff {
 				return
 			}
-			slog.Error("idle stop failed", "sandbox_id", rec.ID, "err", err)
-			continue
+			if orphanReapDue(reg, rec.RunnerID, cfg, now) {
+				reapOrphanSandbox(s, rec, rec.RunnerID)
+				return
+			}
+			controlAddr := resolveControlAddr(rec, reg)
+			if err := runnerctl.StopSandbox(ctx, controlAddr, cfg.RunnerAPIKey, tlsCfg, rec.ID); err != nil {
+				if ctx.Err() == nil {
+					slog.Error("idle stop failed", "sandbox_id", rec.ID, "err", err)
+				}
+				return
+			}
+			if err := s.UpdateStatus(rec.ID, "stopped"); err != nil {
+				slog.Error("idle stop status update failed", "sandbox_id", rec.ID, "err", err)
+				return
+			}
+			logSandboxStopped(rec.ID, rec.RunnerID, "idle")
+		})
+		if err != nil && ctx.Err() == nil {
+			slog.Error("idle stop lock or refresh failed", "sandbox_id", id, "err", err)
 		}
-		if err := s.UpdateStatus(rec.ID, "stopped"); err != nil {
-			slog.Error("idle stop status update failed", "sandbox_id", rec.ID, "err", err)
-			continue
+		if ctx.Err() != nil {
+			return
 		}
-		logSandboxStopped(rec.ID, rec.RunnerID, "idle")
 	}
 }

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -38,6 +38,11 @@ By default the client retries transient failures: 3 extra attempts (four tries t
 const sandbox = await client.createSandbox();
 console.log(sandbox.id); // UUID
 
+// Create or reconnect to a deterministic sandbox
+const stableSandbox = await client.createSandbox({
+  id: '550e8400-e29b-41d4-a716-446655440000',
+});
+
 // Get sandbox info
 const info = await client.getSandbox(sandbox.id);
 

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -14,6 +14,7 @@ import { HttpClient } from "./http";
 import { createSandbox, getSandbox, deleteSandbox } from "./sandboxes";
 import type {
   CopyFileRequest,
+  CreateSandboxOptions,
   DeleteFileOptions,
   ExecRequest,
   ExecResult,
@@ -44,8 +45,8 @@ export class SandboxClient {
   /**
    * Creates a new sandbox.
    */
-  async createSandbox(): Promise<SandboxRecord> {
-    return createSandbox(this.http);
+  async createSandbox(options?: CreateSandboxOptions): Promise<SandboxRecord> {
+    return createSandbox(this.http, options);
   }
 
   /**

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -2,6 +2,7 @@ export { SandboxClient } from "./client";
 export { SandboxServiceError } from "./errors";
 export type {
   SandboxClientOptions,
+  CreateSandboxOptions,
   RetryOptions,
   SandboxRecord,
   FileEntry,

--- a/sdk/src/sandboxes.ts
+++ b/sdk/src/sandboxes.ts
@@ -1,8 +1,17 @@
 import type { HttpClient } from "./http";
-import type { SandboxRecord, SandboxWireResponse } from "./types";
+import type { CreateSandboxOptions, SandboxRecord, SandboxWireResponse } from "./types";
 
-export async function createSandbox(http: HttpClient): Promise<SandboxRecord> {
-  const response = await http.requestJson<SandboxWireResponse>("POST", "/sandboxes");
+export async function createSandbox(
+  http: HttpClient,
+  options?: CreateSandboxOptions,
+): Promise<SandboxRecord> {
+  const response =
+    options?.id !== undefined
+      ? await http.requestJson<SandboxWireResponse>("POST", "/sandboxes", {
+          data: { id: options.id },
+          isSafeToRetry: true,
+        })
+      : await http.requestJson<SandboxWireResponse>("POST", "/sandboxes");
   return mapSandboxRecord(response);
 }
 

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -11,6 +11,12 @@ export interface SandboxClientOptions {
   retry?: RetryOptions;
 }
 
+/** Options for creating a sandbox. */
+export interface CreateSandboxOptions {
+  /** UUID to create or reuse. The service generates one when omitted. */
+  id?: string;
+}
+
 /** Retry policy for transient HTTP failures. */
 export interface RetryOptions {
   /**

--- a/sdk/test/client.test.ts
+++ b/sdk/test/client.test.ts
@@ -65,6 +65,24 @@ describe("SandboxClient", () => {
     });
   });
 
+  it("creates or reuses a caller-supplied sandbox ID", async () => {
+    const mock = getMockHttp(client);
+    mock.requestJson.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      status: "running",
+      created_at: 1000,
+      last_active_at: 1000,
+    });
+
+    const result = await client.createSandbox({ id: "11111111-1111-4111-8111-111111111111" });
+
+    expect(mock.requestJson).toHaveBeenCalledWith("POST", "/sandboxes", {
+      data: { id: "11111111-1111-4111-8111-111111111111" },
+      isSafeToRetry: true,
+    });
+    expect(result.id).toBe("11111111-1111-4111-8111-111111111111");
+  });
+
   it("getSandbox sends GET /sandboxes/{id}", async () => {
     const mock = getMockHttp(client);
     mock.requestJson.mockResolvedValue({


### PR DESCRIPTION
## Summary

- Preinstall ripgrep in the sandbox guest image so Agent Knowledge can search files without runtime setup.
- Allow callers to supply a sandbox UUID when creating a sandbox, returning the existing sandbox for repeated requests while preserving random IDs for existing clients.
- Document the deterministic sandbox creation contract in the API and SDK.

## How to test

```sh
# Go API checks
make fmt-check
make vet

# Focused SDK coverage
cd sdk
pnpm exec vitest run test/client.test.ts -t "creates or reuses a caller-supplied sandbox ID"

# Focused live API/runner coverage
cd ../e2e
pnpm exec playwright test tests/sandbox-api.spec.ts -g "client-supplied sandbox ID"
```

After merge, use the existing SDK Release Prep workflow to publish the patch release consumed by the separate n8n application follow-up.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-507

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.