### PR TITLE
chore: add manu as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @endor @mfsiega @tomi
+* @endor @mfsiega @tomi @njibhu


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `@njibhu` as a repository-wide code owner so GitHub auto-requests Manu on PRs. Previously only `@endor`, `@mfsiega`, and `@tomi` were requested; now `@njibhu` will also be requested for all paths via the wildcard rule.

<sup>Written for commit 5004f8aa3b45fe3621c98f8dee2c18d67b77973a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

