### PR TITLE
chore: pin FC version to 1.14.1 everywhere

### DIFF
--- a/Dockerfile.ee.runner-firecracker
+++ b/Dockerfile.ee.runner-firecracker
@@ -16,9 +16,12 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /out/runner ./cmd/runner-firecracker.ee
 FROM debian:bookworm-slim AS firecracker-binaries
 
 ARG TARGETARCH
-ARG FIRECRACKER_VERSION=v1.13.1
+# Must match the version installed by scripts/firecracker.ee/install-runner-host.sh:
+# the host creates the golden snapshot, this image restores it, and Firecracker
+# cannot restore a snapshot taken by a newer version.
+ARG FIRECRACKER_VERSION=v1.14.1
 # From https://github.com/firecracker-microvm/firecracker/releases/download/${FIRECRACKER_VERSION}/firecracker-${FIRECRACKER_VERSION}-x86_64.tgz.sha256.txt
-ARG FIRECRACKER_X86_64_SHA256=59450b9171ff2ebdf2f9a25be3a248a7ba79fb6371aec51a9d6d8eefca7b4faf
+ARG FIRECRACKER_X86_64_SHA256=ea66dc1fbdb2473bbb95a1e822ae7884cd575a891a8f801258723258d36b7c7c
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/scripts/firecracker.ee/install-runner-host.sh
+++ b/scripts/firecracker.ee/install-runner-host.sh
@@ -62,9 +62,6 @@ resolve_firecracker_tarball_sha256() {
 		return 0
 	fi
 	case "$FIRECRACKER_VERSION" in
-	v1.13.1)
-		FIRECRACKER_TARBALL_SHA256="59450b9171ff2ebdf2f9a25be3a248a7ba79fb6371aec51a9d6d8eefca7b4faf"
-		;;
 	v1.14.1)
 		FIRECRACKER_TARBALL_SHA256="ea66dc1fbdb2473bbb95a1e822ae7884cd575a891a8f801258723258d36b7c7c"
 		;;


### PR DESCRIPTION
## Summary

Firecracker pinned everywhere to 1.14.1 instead of two different versions across the codebase.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Firecracker to v1.14.1 across the host and runner image to remove version skew that breaks snapshot restore. Before: the image used v1.13.1 while the host installed v1.14.1; now both use v1.14.1.

- Set `FIRECRACKER_VERSION=v1.14.1` and updated `FIRECRACKER_X86_64_SHA256` in `Dockerfile.ee.runner-firecracker`; removed the `v1.13.1` checksum branch from `scripts/firecracker.ee/install-runner-host.sh`.
- Action: Rebuild the runner-firecracker image and re-run the host install script so both sides run 1.14.1; remove any cached 1.13.1 binaries.

<sup>Written for commit 0e2e731dbed1378bc2b1beeda5dd1e490099649b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

