### PR TITLE
chore: shellcheck and shfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,27 @@ jobs:
       - name: Vet
         run: make vet
 
+      # Both tools are pinned so CI and local runs agree. The runner image does
+      # preinstall shellcheck, but at a version that lags brew's and still reports
+      # findings v0.11.0 dropped (SC2015 on `A && B || true`).
+      - name: Install shfmt
+        run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.13.1
+
+      - name: Install shellcheck
+        env:
+          SHELLCHECK_VERSION: v0.11.0
+        run: |
+          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJ
+          sudo install -m 0755 "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+          rm -rf "shellcheck-${SHELLCHECK_VERSION}"
+          shellcheck --version
+
+      - name: Check shell formatting
+        run: make shell-fmt-check
+
+      - name: Lint shell scripts
+        run: make shell-lint
+
       - name: Build
         run: make all
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,18 @@ make fmt-check
 make vet
 ```
 
+After modifying shell scripts, run:
+
+```sh
+make shell-fmt-check
+make shell-lint
+```
+
+`make shell-fmt` applies the formatting. These need `shfmt` and `shellcheck`
+(`brew install shfmt shellcheck`). Both are enforced in CI, which pins shfmt
+v3.13.1 and shellcheck v0.11.0 — older shellcheck releases report findings that
+v0.11.0 has since dropped, so match the pinned version locally.
+
 Fix any issues before committing.
 
 ## When making changes to the API

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,14 +12,14 @@ make vet
 After modifying shell scripts, run:
 
 ```sh
-make shell-fmt-check
+make shell-fmt
 make shell-lint
 ```
 
-`make shell-fmt` applies the formatting. These need `shfmt` and `shellcheck`
-(`brew install shfmt shellcheck`). Both are enforced in CI, which pins shfmt
-v3.13.1 and shellcheck v0.11.0 — older shellcheck releases report findings that
-v0.11.0 has since dropped, so match the pinned version locally.
+These need `shfmt` and `shellcheck` (`brew install shfmt shellcheck`). Both are
+enforced in CI, which pins shfmt v3.13.1 and shellcheck v0.11.0 — older
+shellcheck releases report findings that v0.11.0 has since dropped, so match the
+pinned version locally.
 
 Fix any issues before committing.
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ SHELL := /bin/bash
 MODULE  := github.com/n8n-io/sandbox-service
 BINDIR  := bin
 
-.PHONY: all daemon runner runner-docker runner-firecracker api test clean docker docker-local docker-arm64 docker-amd64 docker-api-arm64 docker-api-amd64 docker-runner-arm64 docker-runner-amd64 docker-firecracker-runner-amd64 docker-sandbox-arm64 docker-sandbox-amd64 fmt fmt-check vet playground up down smoke sdk sdk-install sdk-build sdk-typecheck sdk-test sdk-fmt sdk-fmt-check sdk-lint
+SHELL_FILES := $(shell git ls-files '*.sh')
+
+.PHONY: all daemon runner runner-docker runner-firecracker api test clean docker docker-local docker-arm64 docker-amd64 docker-api-arm64 docker-api-amd64 docker-runner-arm64 docker-runner-amd64 docker-firecracker-runner-amd64 docker-sandbox-arm64 docker-sandbox-amd64 fmt fmt-check vet shell-fmt shell-fmt-check shell-lint check-shell-files playground up down smoke sdk sdk-install sdk-build sdk-typecheck sdk-test sdk-fmt sdk-fmt-check sdk-lint
 
 all: daemon runner api
 
@@ -26,6 +28,22 @@ fmt-check:
 ## vet: Run go vet on all packages.
 vet:
 	go vet ./...
+
+## shell-fmt: Format all shell scripts with shfmt.
+shell-fmt: check-shell-files
+	shfmt -w $(SHELL_FILES)
+
+## shell-fmt-check: Check that all shell scripts are shfmt-formatted.
+shell-fmt-check: check-shell-files
+	shfmt -d $(SHELL_FILES)
+
+## shell-lint: Run shellcheck on all shell scripts.
+shell-lint: check-shell-files
+	shellcheck -x $(SHELL_FILES)
+
+# shfmt reads stdin when given no paths, so fail loudly instead of hanging.
+check-shell-files:
+	@test -n "$(SHELL_FILES)" || { echo "No shell files found; run from a git checkout."; exit 1; }
 
 ## daemon: Build the sandbox daemon (static, Linux).
 daemon:

--- a/docs/development.md
+++ b/docs/development.md
@@ -152,3 +152,20 @@ To auto-format:
 ```bash
 make fmt
 ```
+
+After modifying shell scripts, always run:
+
+```bash
+make shell-fmt-check    # Check that all shell scripts are shfmt-formatted
+make shell-lint         # Run shellcheck on all shell scripts
+```
+
+To auto-format:
+
+```bash
+make shell-fmt
+```
+
+These need `shfmt` and `shellcheck` (`brew install shfmt shellcheck`). CI pins
+shfmt v3.13.1 and shellcheck v0.11.0; older shellcheck releases report findings
+that v0.11.0 has since dropped, so match the pinned version locally.

--- a/e2e/infra/scripts/collect-e2e-vm-logs.sh
+++ b/e2e/infra/scripts/collect-e2e-vm-logs.sh
@@ -8,12 +8,12 @@ set -euo pipefail
 : "${SSH_KEY_PATH:?SSH_KEY_PATH is required}"
 
 VM_ADMIN="azureuser"
-SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=10"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o ConnectTimeout=10)
 ARTIFACT_DIR="/tmp/e2e-artifacts"
 
 echo "==> Collecting logs from ${VM_IP}..."
 
-ssh $SSH_OPTS -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" bash -s << 'EOF'
+ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" bash -s <<'EOF'
 set -x
 cd ~/project
 tar czf /tmp/e2e-results.tar.gz e2e/test-results/ 2>/dev/null || true
@@ -24,7 +24,7 @@ EOF
 
 mkdir -p "$ARTIFACT_DIR"
 for f in e2e-results.tar.gz docker-info.txt sysbox-status.txt sysbox-journal.txt; do
-	scp $SSH_OPTS -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}:/tmp/${f}" "${ARTIFACT_DIR}/" 2>/dev/null || true
+	scp "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}:/tmp/${f}" "${ARTIFACT_DIR}/" 2>/dev/null || true
 done
 
 echo "==> Logs collected to ${ARTIFACT_DIR}"

--- a/e2e/infra/scripts/collect-firecracker-e2e-vm-logs.sh
+++ b/e2e/infra/scripts/collect-firecracker-e2e-vm-logs.sh
@@ -8,12 +8,12 @@ set -euo pipefail
 : "${SSH_KEY_PATH:?SSH_KEY_PATH is required}"
 
 VM_ADMIN="azureuser"
-SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=10"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o ConnectTimeout=10)
 ARTIFACT_DIR="/tmp/e2e-firecracker-artifacts"
 
 echo "==> Collecting Firecracker logs from ${VM_IP}..."
 
-ssh $SSH_OPTS -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" bash -s << 'EOF'
+ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" bash -s <<'EOF'
 set -x
 rm -rf /tmp/e2e-firecracker-artifacts
 mkdir -p /tmp/e2e-firecracker-artifacts
@@ -65,7 +65,7 @@ sudo chown -R "$(id -u):$(id -g)" /tmp/e2e-firecracker-artifacts
 EOF
 
 mkdir -p "$ARTIFACT_DIR"
-scp $SSH_OPTS -i "$SSH_KEY_PATH" \
+scp "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" \
 	"${VM_ADMIN}@${VM_IP}:/tmp/e2e-firecracker-artifacts/*" \
 	"${ARTIFACT_DIR}/" 2>/dev/null || true
 

--- a/e2e/infra/scripts/provision-e2e-vm.sh
+++ b/e2e/infra/scripts/provision-e2e-vm.sh
@@ -13,12 +13,12 @@ TF_DIR="e2e/infra"
 VM_NAME="e2e-sysbox-${GITHUB_RUN_ID:-$(date +%s)}"
 SSH_KEY_PATH="$HOME/.ssh/e2e-vm-key"
 VM_ADMIN="azureuser"
-SSH_OPTS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=6"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=6)
 
 output() {
 	echo "$1=$2"
 	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-		echo "$1=$2" >> "$GITHUB_OUTPUT"
+		echo "$1=$2" >>"$GITHUB_OUTPUT"
 	fi
 }
 
@@ -30,7 +30,7 @@ else
 	echo "==> Using existing SSH keypair at ${SSH_KEY_PATH}"
 fi
 
-cat > "${TF_DIR}/e2e-vm.auto.tfvars.json" <<EOF
+cat >"${TF_DIR}/e2e-vm.auto.tfvars.json" <<EOF
 {
   "resource_group_name": "$RESOURCE_GROUP",
   "vm_name": "$VM_NAME",
@@ -72,13 +72,13 @@ COPYFILE_DISABLE=1 "$GNUTAR" czf /tmp/repo.tar.gz \
 	--exclude='e2e/infra/.terraform' \
 	--exclude='e2e/infra/*.tfstate*' \
 	-C "$(pwd)" .
-scp $SSH_OPTS -i "$SSH_KEY_PATH" /tmp/repo.tar.gz "${VM_ADMIN}@${VM_IP}:/tmp/repo.tar.gz"
-ssh $SSH_OPTS -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" \
+scp "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" /tmp/repo.tar.gz "${VM_ADMIN}@${VM_IP}:/tmp/repo.tar.gz"
+ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" \
 	"mkdir -p ~/project && tar xzf /tmp/repo.tar.gz -C ~/project && rm /tmp/repo.tar.gz"
 rm -f /tmp/repo.tar.gz
 
 echo "==> Setting up VM (Docker, sysbox, Go, Node, pnpm)..."
-ssh $SSH_OPTS -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" "bash ~/project/e2e/infra/scripts/setup-e2e-vm.sh"
+ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" "bash ~/project/e2e/infra/scripts/setup-e2e-vm.sh"
 
 output "vm_name" "$VM_NAME"
 output "vm_ip" "$VM_IP"

--- a/e2e/infra/scripts/provision-firecracker-e2e-vm.sh
+++ b/e2e/infra/scripts/provision-firecracker-e2e-vm.sh
@@ -22,7 +22,7 @@ VM_ADMIN="azureuser"
 output() {
 	echo "$1=$2"
 	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-		echo "$1=$2" >> "$GITHUB_OUTPUT"
+		echo "$1=$2" >>"$GITHUB_OUTPUT"
 	fi
 }
 
@@ -39,7 +39,7 @@ case "${E2E_PEER_VM_ENABLED:-false}" in
 1 | true | yes) peer_vm_tf=true ;;
 esac
 
-cat > "${TF_DIR}/e2e-vm.auto.tfvars.json" <<EOF
+cat >"${TF_DIR}/e2e-vm.auto.tfvars.json" <<EOF
 {
   "resource_group_name": "$RESOURCE_GROUP",
   "vm_name": "$VM_NAME",

--- a/e2e/infra/scripts/setup-e2e-vm.sh
+++ b/e2e/infra/scripts/setup-e2e-vm.sh
@@ -16,9 +16,10 @@ sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
 	-o /etc/apt/keyrings/docker.asc
 sudo chmod a+r /etc/apt/keyrings/docker.asc
 
+# shellcheck source=/dev/null  # /etc/os-release only exists on the target VM
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
-	https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-	sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+	https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" |
+	sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
 
 sudo apt-get update -qq
 sudo apt-get install -y -qq \
@@ -41,7 +42,9 @@ echo "==> Installing Go 1.25.0..."
 curl -fsSL "https://go.dev/dl/go1.25.0.linux-amd64.tar.gz" -o /tmp/go.tar.gz
 sudo tar -C /usr/local -xzf /tmp/go.tar.gz
 rm /tmp/go.tar.gz
-echo 'export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH' >> ~/.bashrc
+# Single quotes on purpose: $HOME must stay literal in .bashrc.
+# shellcheck disable=SC2016
+echo 'export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH' >>~/.bashrc
 export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH
 go version
 

--- a/e2e/infra/scripts/sweep-e2e-vms.sh
+++ b/e2e/infra/scripts/sweep-e2e-vms.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 : "${RESOURCE_GROUP:?RESOURCE_GROUP is required}"
 
 TAG="purpose=sandbox-service-e2e"
-CUTOFF_EPOCH=$(python3 - <<'PY'
+CUTOFF_EPOCH=$(
+	python3 - <<'PY'
 import time
 
 print(int(time.time()) - 3600)

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -12,10 +12,11 @@ e2e_docker_arch() {
 # otherwise falls back to --user host:host plus a bind-mounted data dir at
 # /var/lib/n8n-sandbox-api so that UID can write the SQLite file.
 # Sets globals API_DOCKER_USER and API_DATA_VOLUME_ARGS.
+# shellcheck disable=SC2034  # both globals are read by the run-*.sh callers
 e2e_setup_api_container() {
 	local tls_dir=$1 api_image=$2
 	local uid gid
-	read -r uid gid <<< "$(docker run --rm --entrypoint sh "$api_image" -c 'echo $(id -u) $(id -g)')"
+	read -r uid gid <<<"$(docker run --rm --entrypoint sh "$api_image" -c 'echo $(id -u) $(id -g)')"
 	if chown -R "$uid:$gid" "$tls_dir" 2>/dev/null; then
 		API_DOCKER_USER=()
 		API_DATA_VOLUME_ARGS=()
@@ -101,7 +102,7 @@ e2e_build_sdk_unless_skip() {
 
 e2e_install_playwright_deps_if_needed() {
 	local script_dir=$1
-	cd "$script_dir"
+	cd "$script_dir" || return 1
 	if [[ ! -d node_modules ]] || [[ ! -f node_modules/@n8n/sandbox-client/dist/index.js ]]; then
 		echo "Installing dependencies..."
 		pnpm install --frozen-lockfile
@@ -176,6 +177,8 @@ e2e_ssh_firecracker_host() {
 	if [[ -n "$jump_host" ]]; then
 		opts+=(-o "ProxyCommand=$(e2e_ssh_proxy_command "$ssh_key" "$admin" "$jump_host")")
 	fi
+	# Callers pass a remote command; expanding it locally is the intent.
+	# shellcheck disable=SC2029
 	ssh "${opts[@]}" "${admin}@${host}" "$@"
 }
 
@@ -322,6 +325,7 @@ e2e_configure_api_store() {
 
 	e2e_wait_for_postgres "$E2E_POSTGRES_CONTAINER"
 
+	# shellcheck disable=SC2034  # read by the run-*.sh callers
 	API_DATA_VOLUME_ARGS=()
 	API_STORE_ENV=(
 		-e "SANDBOX_API_STORE=postgres"

--- a/e2e/lib/restart-firecracker-runner.sh
+++ b/e2e/lib/restart-firecracker-runner.sh
@@ -20,6 +20,9 @@ sudo rm -rf /srv/jailer/firecracker/sandbox-* >/dev/null 2>&1 || true
 for i in $(seq 0 63); do sudo ip link delete "fc-veth-${i}" >/dev/null 2>&1 || true; done
 sudo ip netns list | awk '{print $1}' | grep '^fc-sb-' | xargs -r -n1 sudo ip netns delete || true
 
+# The redirect runs as the calling user on purpose, so the harness can read the
+# log without sudo.
+# shellcheck disable=SC2024
 sudo env "${RUNNER_ENV[@]}" "${RUNNER_BIN}" >"$RUNNER_LOG" 2>&1 &
 E2E_RUNNER_PID=$!
 export E2E_RUNNER_PID

--- a/e2e/run-firecracker-azure.sh
+++ b/e2e/run-firecracker-azure.sh
@@ -51,6 +51,9 @@ E2E_PEER_VM_ENABLED=true GITHUB_OUTPUT="$OUTPUT_FILE" \
 	bash e2e/infra/scripts/provision-firecracker-e2e-vm.sh
 
 while IFS='=' read -r key value; do
+	# PEER_VM_PUBLIC_IP is parsed for symmetry with the provisioner's outputs; only
+	# the peer private IP is used from here.
+	# shellcheck disable=SC2034
 	case "$key" in
 	vm_ip) VM_IP="$value" ;;
 	vm_private_ip) VM_PRIVATE_IP="$value" ;;
@@ -66,9 +69,9 @@ if [[ -z "$VM_IP" || -z "$VM_PRIVATE_IP" || -z "$PEER_VM_PRIVATE_IP" || -z "$SSH
 fi
 
 echo "==> Running Firecracker e2e tests on control VM ${VM_IP}..."
-SSH_OPTS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=6"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=6)
 TESTS_STARTED=1
-ssh $SSH_OPTS -i "$SSH_KEY_PATH" "azureuser@${VM_IP}" bash -s -- "$@" <<'EOF'
+ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" "azureuser@${VM_IP}" bash -s -- "$@" <<'EOF'
 set -euxo pipefail
 export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH
 

--- a/e2e/run-firecracker-runner-peer.sh
+++ b/e2e/run-firecracker-runner-peer.sh
@@ -105,6 +105,9 @@ runner_env=(
 } >"$RUNNER_ENV_FILE"
 
 echo "Starting peer Firecracker runner..."
+# The redirect runs as the calling user on purpose, so the harness can read the
+# log without sudo.
+# shellcheck disable=SC2024
 sudo env "${runner_env[@]}" "$PROJECT_DIR/bin/runner-firecracker" >"$RUNNER_LOG" 2>&1 &
 RUNNER_PID=$!
 echo "export E2E_RUNNER_PID=${RUNNER_PID}" >>"$RUNNER_ENV_FILE"

--- a/e2e/run-firecracker-two-runners-azure.sh
+++ b/e2e/run-firecracker-two-runners-azure.sh
@@ -14,7 +14,7 @@ source "$SCRIPT_DIR/lib/common.sh"
 : "${SSH_KEY_PATH:?SSH_KEY_PATH is required}"
 
 VM_ADMIN="${VM_ADMIN:-azureuser}"
-SSH_OPTS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=6"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=6)
 TLS_DIR="$(mktemp -d)"
 REMOTE_TLS_DIR="/tmp/n8n-sandbox-e2e-tls-$$"
 RUNNER2_PID=""
@@ -31,16 +31,16 @@ bash "$PROJECT_DIR/scripts/bootstrap-mtls.sh" \
 	--control-sans "runner-control-a,runner-control-b,localhost"
 
 echo "Copying TLS material to VMs..."
-ssh $SSH_OPTS -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" "rm -rf '$REMOTE_TLS_DIR' && mkdir -p '$REMOTE_TLS_DIR'"
+ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" "rm -rf '$REMOTE_TLS_DIR' && mkdir -p '$REMOTE_TLS_DIR'"
 e2e_ssh_peer "$VM_IP" "$PEER_VM_PRIVATE_IP" "$SSH_KEY_PATH" "$VM_ADMIN" \
 	"rm -rf '$REMOTE_TLS_DIR' && mkdir -p '$REMOTE_TLS_DIR'"
-scp $SSH_OPTS -i "$SSH_KEY_PATH" -r "$TLS_DIR/." "${VM_ADMIN}@${VM_IP}:${REMOTE_TLS_DIR}/"
+scp "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" -r "$TLS_DIR/." "${VM_ADMIN}@${VM_IP}:${REMOTE_TLS_DIR}/"
 e2e_scp_dir_to_peer "$VM_IP" "$PEER_VM_PRIVATE_IP" "$SSH_KEY_PATH" "$VM_ADMIN" \
 	"$TLS_DIR/." "${REMOTE_TLS_DIR}/"
 
 echo "Installing SSH key on control VM for peer runner management..."
-scp $SSH_OPTS -i "$SSH_KEY_PATH" "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}:~/.ssh/e2e-peer-key"
-ssh $SSH_OPTS -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" "chmod 600 ~/.ssh/e2e-peer-key"
+scp "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}:~/.ssh/e2e-peer-key"
+ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" "chmod 600 ~/.ssh/e2e-peer-key"
 
 echo "Starting peer Firecracker runner on ${PEER_VM_PRIVATE_IP}..."
 e2e_ssh_peer "$VM_IP" "$PEER_VM_PRIVATE_IP" "$SSH_KEY_PATH" "$VM_ADMIN" bash -s <<EOF
@@ -57,7 +57,10 @@ RUNNER2_PID=$(e2e_ssh_peer "$VM_IP" "$PEER_VM_PRIVATE_IP" "$SSH_KEY_PATH" "$VM_A
 	"cat ~/project/e2e/.fc-runner-b.pid")
 
 echo "Running two-runner tests on control VM ${VM_IP}..."
-ssh $SSH_OPTS -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" bash -s -- "$@" <<EOF
+# Unquoted heredoc on purpose: the local values below are interpolated into the
+# script that runs on the VM.
+# shellcheck disable=SC2087
+ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PATH" "${VM_ADMIN}@${VM_IP}" bash -s -- "$@" <<EOF
 set -euo pipefail
 export PATH=/usr/local/go/bin:\$HOME/go/bin:\$PATH
 cd ~/project

--- a/e2e/run-firecracker-two-runners.sh
+++ b/e2e/run-firecracker-two-runners.sh
@@ -160,6 +160,9 @@ runner_env=(
 } >"$RUNNER1_ENV_FILE"
 
 echo "Starting Firecracker runner 1..."
+# The redirect runs as the calling user on purpose, so the harness can read the
+# log without sudo.
+# shellcheck disable=SC2024
 sudo env "${runner_env[@]}" "$PROJECT_DIR/bin/runner-firecracker" >"$RUNNER1_LOG" 2>&1 &
 RUNNER1_PID=$!
 echo "export E2E_RUNNER_PID=${RUNNER1_PID}" >>"$RUNNER1_ENV_FILE"

--- a/e2e/run-firecracker.sh
+++ b/e2e/run-firecracker.sh
@@ -193,6 +193,9 @@ FC_RUNNER_ENV_FILE="${E2E_FIRECRACKER_RUNNER_ENV_FILE:-$SCRIPT_DIR/.fc-runner-en
 } >"$FC_RUNNER_ENV_FILE"
 export E2E_FIRECRACKER_RUNNER_ENV_FILE="$FC_RUNNER_ENV_FILE"
 
+# The redirect runs as the calling user on purpose, so the harness can read the
+# log without sudo.
+# shellcheck disable=SC2024
 sudo env "${RUNNER_ENV[@]}" "$RUNNER_BIN" >"$RUNNER_LOG" 2>&1 &
 RUNNER_PID=$!
 export E2E_RUNNER_PID="$RUNNER_PID"

--- a/e2e/run-postgres-multi-pod.sh
+++ b/e2e/run-postgres-multi-pod.sh
@@ -65,6 +65,7 @@ fi
 
 e2e_bootstrap_mtls_maybe "$PROJECT_DIR" "$TLS_DIR_OWNED" "$TLS_DIR" "$API_TLS_DNS" "$RUNNER_CONTROL_ALIAS"
 API_DOCKER_USER=()
+# shellcheck disable=SC2034  # declared for the e2e_setup_api_container contract
 API_DATA_VOLUME_ARGS=()
 e2e_setup_api_container "$TLS_DIR" "$API_IMAGE"
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -34,13 +34,13 @@ API_TLS_DNS="${E2E_API_TLS_DNS:-sandbox-api-e2e-mtls}"
 RUNNER_CONTROL_ALIAS="runner-control"
 
 cleanup() {
-  local exit_code=$?
-  if [ $exit_code -ne 0 ]; then
-    echo "=== API container logs ==="
-    docker logs "$API_CONTAINER_NAME" 2>&1 || true
-    echo "=== Runner container logs ==="
-    docker logs "$RUNNER_CONTAINER_NAME" 2>&1 || true
-  fi
+	local exit_code=$?
+	if [ $exit_code -ne 0 ]; then
+		echo "=== API container logs ==="
+		docker logs "$API_CONTAINER_NAME" 2>&1 || true
+		echo "=== Runner container logs ==="
+		docker logs "$RUNNER_CONTAINER_NAME" 2>&1 || true
+	fi
 
 	echo "Stopping e2e resources..."
 	docker stop "$API_CONTAINER_NAME" >/dev/null 2>&1 || true

--- a/scripts/bootstrap-mtls.sh
+++ b/scripts/bootstrap-mtls.sh
@@ -19,50 +19,50 @@ set -euo pipefail
 
 usage() {
 	cat <<-'USAGE'
-	Usage: bootstrap-mtls.sh [OPTIONS]
+		Usage: bootstrap-mtls.sh [OPTIONS]
 
-	Generate mTLS certificates for n8n-sandbox-service API ↔ runner communication.
-	Certificates are organized into api/ and runner/ subdirectories.
+		Generate mTLS certificates for n8n-sandbox-service API ↔ runner communication.
+		Certificates are organized into api/ and runner/ subdirectories.
 
-	Options:
-	  -o, --out-dir DIR              Output directory (default: ./.tls, env: OUT_DIR)
-	  -n, --runners N                Number of runners; generates control SANs as
-	                                   PREFIX-1,...,PREFIX-N,localhost
-	                                   (default: 2, env: NUM_RUNNERS)
-	      --api-san NAME             DNS SAN for API server cert
-	                                   (default: n8n-sandbox-service-api-local,
-	                                   env: API_DNS)
-	      --client-san NAME          DNS SAN for runner client cert
-	                                   (default: sandbox-runner-mtls-client,
-	                                   env: CLIENT_DNS)
-	      --control-san-prefix PFX   Prefix for auto-generated runner control SANs;
-	                                   generates PFX-1,...,PFX-N,localhost
-	                                   (default: n8n-sandbox-service-runner-dind-local,
-	                                   env: CONTROL_SAN_PREFIX)
-	      --control-sans NAMES       Comma-separated DNS SANs for runner control server
-	                                   cert; overrides --runners and --control-san-prefix
-	                                   (env: CONTROL_SANS)
-	      --control-client-san NAME  DNS SAN for API control client cert
-	                                   (default: sandbox-api-control-mtls-client,
-	                                   env: CONTROL_API_CLIENT_DNS)
-	      --world-readable           Set key file permissions to 644 instead of 600
-	      --force                    Force regeneration even if certs exist
-	                                   (env: SANDBOX_TLS_REGEN=1)
-	  -h, --help                     Show this help
+		Options:
+		  -o, --out-dir DIR              Output directory (default: ./.tls, env: OUT_DIR)
+		  -n, --runners N                Number of runners; generates control SANs as
+		                                   PREFIX-1,...,PREFIX-N,localhost
+		                                   (default: 2, env: NUM_RUNNERS)
+		      --api-san NAME             DNS SAN for API server cert
+		                                   (default: n8n-sandbox-service-api-local,
+		                                   env: API_DNS)
+		      --client-san NAME          DNS SAN for runner client cert
+		                                   (default: sandbox-runner-mtls-client,
+		                                   env: CLIENT_DNS)
+		      --control-san-prefix PFX   Prefix for auto-generated runner control SANs;
+		                                   generates PFX-1,...,PFX-N,localhost
+		                                   (default: n8n-sandbox-service-runner-dind-local,
+		                                   env: CONTROL_SAN_PREFIX)
+		      --control-sans NAMES       Comma-separated DNS SANs for runner control server
+		                                   cert; overrides --runners and --control-san-prefix
+		                                   (env: CONTROL_SANS)
+		      --control-client-san NAME  DNS SAN for API control client cert
+		                                   (default: sandbox-api-control-mtls-client,
+		                                   env: CONTROL_API_CLIENT_DNS)
+		      --world-readable           Set key file permissions to 644 instead of 600
+		      --force                    Force regeneration even if certs exist
+		                                   (env: SANDBOX_TLS_REGEN=1)
+		  -h, --help                     Show this help
 
-	Examples:
-	  # Local development with defaults (2 runners)
-	  bootstrap-mtls.sh
+		Examples:
+		  # Local development with defaults (2 runners)
+		  bootstrap-mtls.sh
 
-	  # CI with explicit SANs
-	  bootstrap-mtls.sh -o /tmp/tls --api-san my-api --control-sans "runner-a,runner-b"
+		  # CI with explicit SANs
+		  bootstrap-mtls.sh -o /tmp/tls --api-san my-api --control-sans "runner-a,runner-b"
 
-	  # Production VM with 3 runners
-	  bootstrap-mtls.sh -o /etc/sandbox/tls --runners 3
+		  # Production VM with 3 runners
+		  bootstrap-mtls.sh -o /etc/sandbox/tls --runners 3
 
-	  # Docker Compose init container with prefix-based SANs
-	  bootstrap-mtls.sh --out-dir /tls --api-san my-api \
-	      --control-san-prefix my-runner --runners 2
+		  # Docker Compose init container with prefix-based SANs
+		  bootstrap-mtls.sh --out-dir /tls --api-san my-api \
+		      --control-san-prefix my-runner --runners 2
 	USAGE
 }
 
@@ -70,21 +70,51 @@ usage() {
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
-		-o|--out-dir)            OUT_DIR="$2";              shift 2 ;;
-		-n|--runners)            NUM_RUNNERS="$2";          shift 2 ;;
-		--api-san)               API_DNS="$2";              shift 2 ;;
-		--client-san)            CLIENT_DNS="$2";           shift 2 ;;
-		--control-san-prefix)    CONTROL_SAN_PREFIX="$2";   shift 2 ;;
-		--control-sans)          CONTROL_SANS="$2";         shift 2 ;;
-		--control-client-san)    CONTROL_API_CLIENT_DNS="$2"; shift 2 ;;
-		--world-readable)        WORLD_READABLE=1;          shift ;;
-		--force)                 FORCE=1;                   shift ;;
-		-h|--help)               usage; exit 0 ;;
-		*)
-			echo "Unknown option: $1" >&2
-			echo "Run with --help for usage." >&2
-			exit 1
-			;;
+	-o | --out-dir)
+		OUT_DIR="$2"
+		shift 2
+		;;
+	-n | --runners)
+		NUM_RUNNERS="$2"
+		shift 2
+		;;
+	--api-san)
+		API_DNS="$2"
+		shift 2
+		;;
+	--client-san)
+		CLIENT_DNS="$2"
+		shift 2
+		;;
+	--control-san-prefix)
+		CONTROL_SAN_PREFIX="$2"
+		shift 2
+		;;
+	--control-sans)
+		CONTROL_SANS="$2"
+		shift 2
+		;;
+	--control-client-san)
+		CONTROL_API_CLIENT_DNS="$2"
+		shift 2
+		;;
+	--world-readable)
+		WORLD_READABLE=1
+		shift
+		;;
+	--force)
+		FORCE=1
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "Unknown option: $1" >&2
+		echo "Run with --help for usage." >&2
+		exit 1
+		;;
 	esac
 done
 
@@ -118,12 +148,12 @@ fi
 # --- Idempotency: skip if all PEMs already exist ---
 
 tls_complete() {
-	[[ -f "$API_DIR/ca.crt" ]] \
-		&& [[ -f "$API_DIR/grpc-server.crt" ]] && [[ -f "$API_DIR/grpc-server.key" ]] \
-		&& [[ -f "$API_DIR/control-grpc-api-client.crt" ]] && [[ -f "$API_DIR/control-grpc-api-client.key" ]] \
-		&& [[ -f "$RUNNER_DIR/ca.crt" ]] \
-		&& [[ -f "$RUNNER_DIR/grpc-client.crt" ]] && [[ -f "$RUNNER_DIR/grpc-client.key" ]] \
-		&& [[ -f "$RUNNER_DIR/control-grpc-server.crt" ]] && [[ -f "$RUNNER_DIR/control-grpc-server.key" ]]
+	[[ -f "$API_DIR/ca.crt" ]] &&
+		[[ -f "$API_DIR/grpc-server.crt" ]] && [[ -f "$API_DIR/grpc-server.key" ]] &&
+		[[ -f "$API_DIR/control-grpc-api-client.crt" ]] && [[ -f "$API_DIR/control-grpc-api-client.key" ]] &&
+		[[ -f "$RUNNER_DIR/ca.crt" ]] &&
+		[[ -f "$RUNNER_DIR/grpc-client.crt" ]] && [[ -f "$RUNNER_DIR/grpc-client.key" ]] &&
+		[[ -f "$RUNNER_DIR/control-grpc-server.crt" ]] && [[ -f "$RUNNER_DIR/control-grpc-server.key" ]]
 }
 
 if [[ "$FORCE" != "1" ]] && tls_complete; then

--- a/scripts/firecracker.ee/build-rootfs-template.sh
+++ b/scripts/firecracker.ee/build-rootfs-template.sh
@@ -203,7 +203,7 @@ if [[ -z "$FIRECRACKER_CI_VMLINUX" ]]; then
 	fi
 	FIRECRACKER_CI_VERSION="$FIRECRACKER_CI_VERSION" \
 		"$FIRECRACKER_CI_ASSETS_BIN" download "$ci_assets_dir"
-	# shellcheck disable=SC1090
+	# shellcheck source=/dev/null  # written by firecracker-ci-assets.sh at runtime
 	source "${ci_assets_dir}/manifest.env"
 fi
 

--- a/scripts/firecracker.ee/configure-host-nat.sh
+++ b/scripts/firecracker.ee/configure-host-nat.sh
@@ -19,9 +19,9 @@ if [[ -z "$default_iface" ]]; then
 	exit 1
 fi
 
-maybe_sudo iptables -t nat -C POSTROUTING -o "$default_iface" -j MASQUERADE 2>/dev/null \
-	|| maybe_sudo iptables -t nat -A POSTROUTING -o "$default_iface" -j MASQUERADE
-maybe_sudo iptables -C FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null \
-	|| maybe_sudo iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-maybe_sudo iptables -C FORWARD -i fc-veth+ -j ACCEPT 2>/dev/null \
-	|| maybe_sudo iptables -A FORWARD -i fc-veth+ -j ACCEPT
+maybe_sudo iptables -t nat -C POSTROUTING -o "$default_iface" -j MASQUERADE 2>/dev/null ||
+	maybe_sudo iptables -t nat -A POSTROUTING -o "$default_iface" -j MASQUERADE
+maybe_sudo iptables -C FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null ||
+	maybe_sudo iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+maybe_sudo iptables -C FORWARD -i fc-veth+ -j ACCEPT 2>/dev/null ||
+	maybe_sudo iptables -A FORWARD -i fc-veth+ -j ACCEPT

--- a/scripts/firecracker.ee/setup-firecracker-e2e-vm.sh
+++ b/scripts/firecracker.ee/setup-firecracker-e2e-vm.sh
@@ -174,7 +174,7 @@ build_template_assets() {
 
 	FIRECRACKER_CI_VERSION="$FIRECRACKER_CI_VERSION" \
 		FIRECRACKER_ROOTFS_SIZE_MB="$FIRECRACKER_E2E_ROOTFS_SIZE_MB" \
-		SANDBOX_IMAGE= \
+		SANDBOX_IMAGE='' \
 		SANDBOX_ROOTFS_TAR="$rootfs_tar" \
 		TEMPLATE_DIR="/srv/firecracker/template" \
 		bash "${SCRIPT_DIR}/build-rootfs-template.sh"
@@ -217,7 +217,9 @@ curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar
 sudo rm -rf /usr/local/go
 sudo tar -C /usr/local -xzf /tmp/go.tar.gz
 rm /tmp/go.tar.gz
-echo 'export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH' >> ~/.bashrc
+# Single quotes on purpose: $HOME must stay literal in .bashrc.
+# shellcheck disable=SC2016
+echo 'export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH' >>~/.bashrc
 export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH
 sudo ln -sf /usr/local/go/bin/go /usr/local/bin/go
 sudo ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt

--- a/scripts/run-locally.sh
+++ b/scripts/run-locally.sh
@@ -4,8 +4,8 @@ cd "$(dirname "$0")/.."
 
 echo "==> Ensuring local gRPC mTLS material (.tls/) ..."
 bash scripts/bootstrap-mtls.sh \
-    --api-san n8n-sandbox-service-api-local \
-    --control-sans "n8n-sandbox-service-runner-dind-local-1,n8n-sandbox-service-runner-dind-local-2,localhost"
+	--api-san n8n-sandbox-service-api-local \
+	--control-sans "n8n-sandbox-service-runner-dind-local-1,n8n-sandbox-service-runner-dind-local-2,localhost"
 if [[ ! -f .tls/api/grpc-server.crt ]] || [[ ! -f .tls/runner/control-grpc-server.crt ]]; then
 	echo "Expected .tls/api/grpc-server.crt and .tls/runner/control-grpc-server.crt after bootstrap. Install openssl and retry."
 	exit 1

--- a/scripts/setup-sysbox.sh
+++ b/scripts/setup-sysbox.sh
@@ -28,8 +28,8 @@ detect_arch() {
 	local arch
 	arch=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
 	case "$arch" in
-		amd64|arm64) echo "$arch" ;;
-		*) err "Unsupported architecture: $(uname -m). Only amd64 and arm64 are supported." ;;
+	amd64 | arm64) echo "$arch" ;;
+	*) err "Unsupported architecture: $(uname -m). Only amd64 and arm64 are supported." ;;
 	esac
 }
 
@@ -44,19 +44,19 @@ check_distro() {
 	local major_version="${VERSION_ID%%.*}"
 
 	case "$ID" in
-		ubuntu)
-			case "$major_version" in
-				18|20|22|24) ;;
-				*) err "Unsupported Ubuntu version: ${VERSION_ID}. Supported: 18, 20, 22, 24." ;;
-			esac
-			;;
-		debian)
-			case "$major_version" in
-				10|11) ;;
-				*) err "Unsupported Debian version: ${VERSION_ID}. Supported: 10, 11." ;;
-			esac
-			;;
-		*) err "Unsupported distribution: ${ID}. Only Ubuntu and Debian are supported." ;;
+	ubuntu)
+		case "$major_version" in
+		18 | 20 | 22 | 24) ;;
+		*) err "Unsupported Ubuntu version: ${VERSION_ID}. Supported: 18, 20, 22, 24." ;;
+		esac
+		;;
+	debian)
+		case "$major_version" in
+		10 | 11) ;;
+		*) err "Unsupported Debian version: ${VERSION_ID}. Supported: 10, 11." ;;
+		esac
+		;;
+	*) err "Unsupported distribution: ${ID}. Only Ubuntu and Debian are supported." ;;
 	esac
 
 	echo "==> Distribution: ${ID} ${VERSION_ID}"
@@ -65,7 +65,7 @@ check_distro() {
 check_kernel() {
 	local kernel major minor
 	kernel=$(uname -r)
-	IFS='.-' read -r major minor _ <<< "$kernel"
+	IFS='.-' read -r major minor _ <<<"$kernel"
 
 	if [[ "$major" -lt 5 ]] || { [[ "$major" -eq 5 ]] && [[ "$minor" -le 19 ]]; }; then
 		err "Kernel version ${kernel} is too old. Sysbox requires kernel > 5.19."
@@ -130,8 +130,8 @@ download_sysbox() {
 	local expected_sha
 
 	case "$arch" in
-		amd64) expected_sha="$SHA256_AMD64" ;;
-		arm64) expected_sha="$SHA256_ARM64" ;;
+	amd64) expected_sha="$SHA256_AMD64" ;;
+	arm64) expected_sha="$SHA256_ARM64" ;;
 	esac
 
 	DL_DIR=$(mktemp -d)
@@ -196,8 +196,8 @@ verify_sysbox() {
 main() {
 	for arg in "$@"; do
 		case "$arg" in
-			--dry-run) DRY_RUN=1 ;;
-			*) err "Unknown argument: $arg" ;;
+		--dry-run) DRY_RUN=1 ;;
+		*) err "Unknown argument: $arg" ;;
 		esac
 	done
 

--- a/scripts/smoke-dev-sandbox.sh
+++ b/scripts/smoke-dev-sandbox.sh
@@ -2,6 +2,6 @@
 # Backward-compatible wrapper for deployed environments (dev/stage/prod).
 # Prefer: SMOKE_ENV=dev sh scripts/smoke-sandbox.sh
 set -eu
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 export SMOKE_ENV_FILE="${SMOKE_ENV_FILE:-${SMOKE_DEV_ENV_FILE:-${SCRIPT_DIR}/smoke-dev-sandbox.env}}"
 exec "${SCRIPT_DIR}/smoke-sandbox.sh" "$@"

--- a/scripts/smoke-local-sandbox.sh
+++ b/scripts/smoke-local-sandbox.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Smoke test against local `make up` (compose defaults).
 set -eu
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 export SANDBOX_API_BASE="${SANDBOX_API_BASE:-http://localhost:8080}"
 export SANDBOX_API_KEY="${SANDBOX_API_KEY:-test}"
 exec "${SCRIPT_DIR}/smoke-sandbox.sh" "$@"

--- a/scripts/smoke-sandbox.sh
+++ b/scripts/smoke-sandbox.sh
@@ -17,9 +17,11 @@
 #   SMOKE_VERBOSE          — Set to 1 to print full exec NDJSON streams
 #   SMOKE_EXEC_TIMEOUT_MS  — Exec timeout in ms (default: 60000)
 #   SMOKE_EXTENDED         — Set to 1 to create a second sandbox (snapshot restore path)
+# `local` is not in POSIX, but every sh this runs under (dash, ash, bash) has it.
+# shellcheck disable=SC3043
 set -eu
 
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 
 if [ -n "${SMOKE_ENV:-}" ]; then
 	PRESET_FILE="${SCRIPT_DIR}/smoke-sandbox.${SMOKE_ENV}.env"
@@ -181,8 +183,8 @@ assert_exec() {
 	while [ "${attempt}" -lt 5 ]; do
 		attempt=$((attempt + 1))
 		if api_json -N -X POST "${BASE}/sandboxes/${target_sid}/executions" \
-			-d "{\"command\":$(jq -n --arg c "${command}" '$c'),\"timeout_ms\":${EXEC_TIMEOUT_MS}}" >"${out}" \
-			&& jq -se 'map(select(.type=="exit")) | length > 0' "${out}" >/dev/null 2>&1; then
+			-d "{\"command\":$(jq -n --arg c "${command}" '$c'),\"timeout_ms\":${EXEC_TIMEOUT_MS}}" >"${out}" &&
+			jq -se 'map(select(.type=="exit")) | length > 0' "${out}" >/dev/null 2>&1; then
 			got_exit="$(trim_output "$(exec_exit_code "${out}")")"
 			if [ "${got_exit}" = "${want_exit}" ]; then
 				break

--- a/scripts/start-runner.sh
+++ b/scripts/start-runner.sh
@@ -8,9 +8,9 @@ DOCKERD_CONFIG_FILE=${DOCKERD_CONFIG_FILE:-${DOCKERD_CONFIG_DIR}/daemon.json}
 INSECURE_ARGS=""
 DOCKERD_ARGS=""
 if [ -n "${SANDBOX_RUNNER_DOCKER_INSECURE_REGISTRIES:-}" ]; then
-  for reg in $(echo "$SANDBOX_RUNNER_DOCKER_INSECURE_REGISTRIES" | tr ',' ' '); do
-    INSECURE_ARGS="$INSECURE_ARGS --insecure-registry $reg"
-  done
+	for reg in $(echo "$SANDBOX_RUNNER_DOCKER_INSECURE_REGISTRIES" | tr ',' ' '); do
+		INSECURE_ARGS="$INSECURE_ARGS --insecure-registry $reg"
+	done
 fi
 
 # Disk-quota storage pool: a loopback xfs+prjquota image used as the inner
@@ -27,51 +27,51 @@ CAPACITY_TOTAL=${SANDBOX_RUNNER_CAPACITY_TOTAL:-1000}
 # for sandbox image layers shared across sandboxes), rounded up to whole GB.
 # Operators can override with SANDBOX_RUNNER_DISK_QUOTA_POOL_SIZE_GB.
 if [ -n "${SANDBOX_RUNNER_DISK_QUOTA_POOL_SIZE_GB:-}" ]; then
-  POOL_SIZE_GB=$SANDBOX_RUNNER_DISK_QUOTA_POOL_SIZE_GB
+	POOL_SIZE_GB=$SANDBOX_RUNNER_DISK_QUOTA_POOL_SIZE_GB
 else
-  POOL_SIZE_GB=$(( (DEFAULT_DISK_QUOTA_MB * CAPACITY_TOTAL * 12 / 10 + 1023) / 1024 ))
+	POOL_SIZE_GB=$(((DEFAULT_DISK_QUOTA_MB * CAPACITY_TOTAL * 12 / 10 + 1023) / 1024))
 fi
 
 setup_quota_pool() {
-  # If there's an existing mount, make sure it uses prjquota.
-  existing_mount=$(mount | grep " on ${DOCKER_DATA_ROOT} type xfs " || true)
-  if [ -n "$existing_mount" ]; then
-    if echo "$existing_mount" | grep -q '[(,]prjquota[,)]'; then
-      echo "[start-runner] storage pool already mounted at ${DOCKER_DATA_ROOT} (xfs+prjquota)"
-      return 0
-    fi
-    echo "[start-runner] existing xfs mount at ${DOCKER_DATA_ROOT} lacks prjquota; refusing to claim quota enforcement" >&2
-    echo "  mount line: ${existing_mount}" >&2
-    return 1
-  fi
-  if [ ! -f "$POOL_PATH" ]; then
-    echo "[start-runner] allocating ${POOL_SIZE_GB}G storage pool at ${POOL_PATH}"
-    if ! truncate -s "${POOL_SIZE_GB}G" "$POOL_PATH"; then
-      echo "[start-runner] truncate failed for ${POOL_PATH}" >&2
-      return 1
-    fi
-    if ! mkfs.xfs -m crc=1,reflink=1 -L sandboxes -q "$POOL_PATH"; then
-      echo "[start-runner] mkfs.xfs failed for ${POOL_PATH}" >&2
-      rm -f "$POOL_PATH"
-      return 1
-    fi
-  fi
-  mkdir -p "$DOCKER_DATA_ROOT"
-  if ! mount -o loop,prjquota "$POOL_PATH" "$DOCKER_DATA_ROOT" 2>/tmp/mount-pool.log; then
-    echo "[start-runner] mount with prjquota failed:" >&2
-    cat /tmp/mount-pool.log >&2
-    return 1
-  fi
-  echo "[start-runner] storage pool mounted: ${POOL_PATH} on ${DOCKER_DATA_ROOT} (xfs+prjquota)"
-  return 0
+	# If there's an existing mount, make sure it uses prjquota.
+	existing_mount=$(mount | grep " on ${DOCKER_DATA_ROOT} type xfs " || true)
+	if [ -n "$existing_mount" ]; then
+		if echo "$existing_mount" | grep -q '[(,]prjquota[,)]'; then
+			echo "[start-runner] storage pool already mounted at ${DOCKER_DATA_ROOT} (xfs+prjquota)"
+			return 0
+		fi
+		echo "[start-runner] existing xfs mount at ${DOCKER_DATA_ROOT} lacks prjquota; refusing to claim quota enforcement" >&2
+		echo "  mount line: ${existing_mount}" >&2
+		return 1
+	fi
+	if [ ! -f "$POOL_PATH" ]; then
+		echo "[start-runner] allocating ${POOL_SIZE_GB}G storage pool at ${POOL_PATH}"
+		if ! truncate -s "${POOL_SIZE_GB}G" "$POOL_PATH"; then
+			echo "[start-runner] truncate failed for ${POOL_PATH}" >&2
+			return 1
+		fi
+		if ! mkfs.xfs -m crc=1,reflink=1 -L sandboxes -q "$POOL_PATH"; then
+			echo "[start-runner] mkfs.xfs failed for ${POOL_PATH}" >&2
+			rm -f "$POOL_PATH"
+			return 1
+		fi
+	fi
+	mkdir -p "$DOCKER_DATA_ROOT"
+	if ! mount -o loop,prjquota "$POOL_PATH" "$DOCKER_DATA_ROOT" 2>/tmp/mount-pool.log; then
+		echo "[start-runner] mount with prjquota failed:" >&2
+		cat /tmp/mount-pool.log >&2
+		return 1
+	fi
+	echo "[start-runner] storage pool mounted: ${POOL_PATH} on ${DOCKER_DATA_ROOT} (xfs+prjquota)"
+	return 0
 }
 
 STORAGE_ARGS=""
 if [ "$DEFAULT_DISK_QUOTA_MB" -le 0 ]; then
-  echo "[start-runner] disk quota enforcement: not requested (SANDBOX_RUNNER_DEFAULT_DISK_QUOTA_MB unset or 0)"
-  if [ -n "${SANDBOX_RUNNER_DOCKER_STORAGE_DRIVER:-}" ]; then
-    mkdir -p "$DOCKERD_CONFIG_DIR"
-    cat >"$DOCKERD_CONFIG_FILE" <<EOF
+	echo "[start-runner] disk quota enforcement: not requested (SANDBOX_RUNNER_DEFAULT_DISK_QUOTA_MB unset or 0)"
+	if [ -n "${SANDBOX_RUNNER_DOCKER_STORAGE_DRIVER:-}" ]; then
+		mkdir -p "$DOCKERD_CONFIG_DIR"
+		cat >"$DOCKERD_CONFIG_FILE" <<EOF
 {
   "features": {
     "containerd-snapshotter": false
@@ -79,17 +79,17 @@ if [ "$DEFAULT_DISK_QUOTA_MB" -le 0 ]; then
   "storage-driver": "${SANDBOX_RUNNER_DOCKER_STORAGE_DRIVER}"
 }
 EOF
-    echo "[start-runner] dockerd storage driver: ${SANDBOX_RUNNER_DOCKER_STORAGE_DRIVER}"
-    echo "[start-runner] dockerd containerd snapshotter: disabled"
-    echo "[start-runner] dockerd config file: ${DOCKERD_CONFIG_FILE}"
-    DOCKERD_ARGS="$DOCKERD_ARGS --config-file=${DOCKERD_CONFIG_FILE}"
-  fi
+		echo "[start-runner] dockerd storage driver: ${SANDBOX_RUNNER_DOCKER_STORAGE_DRIVER}"
+		echo "[start-runner] dockerd containerd snapshotter: disabled"
+		echo "[start-runner] dockerd config file: ${DOCKERD_CONFIG_FILE}"
+		DOCKERD_ARGS="$DOCKERD_ARGS --config-file=${DOCKERD_CONFIG_FILE}"
+	fi
 elif setup_quota_pool; then
-  STORAGE_ARGS="--storage-driver=overlay2 --data-root=${DOCKER_DATA_ROOT}"
-  export SANDBOX_RUNNER_DISK_QUOTA_ACTIVE=true
-  echo "[start-runner] disk quota enforcement: ENABLED (pool ${POOL_SIZE_GB}G, per-sandbox ${DEFAULT_DISK_QUOTA_MB}M)"
+	STORAGE_ARGS="--storage-driver=overlay2 --data-root=${DOCKER_DATA_ROOT}"
+	export SANDBOX_RUNNER_DISK_QUOTA_ACTIVE=true
+	echo "[start-runner] disk quota enforcement: ENABLED (pool ${POOL_SIZE_GB}G, per-sandbox ${DEFAULT_DISK_QUOTA_MB}M)"
 else
-  echo "[start-runner] disk quota enforcement: DISABLED (kernel lacks xfs quota support or mount failed); sandboxes will use dockerd default storage" >&2
+	echo "[start-runner] disk quota enforcement: DISABLED (kernel lacks xfs quota support or mount failed); sandboxes will use dockerd default storage" >&2
 fi
 
 # shellcheck disable=SC2086
@@ -98,47 +98,47 @@ DOCKERD_PID=$!
 RUNNER_PID=""
 
 cleanup() {
-  if [ -n "$RUNNER_PID" ]; then
-    kill "$RUNNER_PID" >/dev/null 2>&1 || true
-  fi
-  kill "$DOCKERD_PID" >/dev/null 2>&1 || true
-  wait >/dev/null 2>&1 || true
+	if [ -n "$RUNNER_PID" ]; then
+		kill "$RUNNER_PID" >/dev/null 2>&1 || true
+	fi
+	kill "$DOCKERD_PID" >/dev/null 2>&1 || true
+	wait >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 trap 'exit 143' INT TERM
 
 for _ in $(seq 1 60); do
-  if docker info >/dev/null 2>&1; then
-    break
-  fi
-  sleep 1
+	if docker info >/dev/null 2>&1; then
+		break
+	fi
+	sleep 1
 done
 
 if ! docker info >/dev/null 2>&1; then
-  cat "$DOCKERD_LOG"
-  exit 1
+	cat "$DOCKERD_LOG"
+	exit 1
 fi
 
 # Ensure the iptables binary uses the same backend (legacy vs nft) as dockerd.
 if ! iptables -n -L DOCKER-USER >/dev/null 2>&1; then
-  for bin in iptables-legacy iptables-nft; do
-    if command -v "$bin" >/dev/null 2>&1 && "$bin" -n -L DOCKER-USER >/dev/null 2>&1; then
-      ln -sf "$(command -v "$bin")" "$(command -v iptables)"
-      break
-    fi
-  done
+	for bin in iptables-legacy iptables-nft; do
+		if command -v "$bin" >/dev/null 2>&1 && "$bin" -n -L DOCKER-USER >/dev/null 2>&1; then
+			ln -sf "$(command -v "$bin")" "$(command -v iptables)"
+			break
+		fi
+	done
 fi
 
 if [ -z "${SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE:-}" ]; then
-  echo "SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE must be set" >&2
-  exit 1
+	echo "SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE must be set" >&2
+	exit 1
 fi
 
 if ! docker network inspect runner-bridge >/dev/null 2>&1; then
-  docker network create \
-    --driver bridge \
-    --opt "com.docker.network.bridge.enable_icc=false" \
-    runner-bridge >/dev/null
+	docker network create \
+		--driver bridge \
+		--opt "com.docker.network.bridge.enable_icc=false" \
+		runner-bridge >/dev/null
 fi
 
 /usr/local/bin/sandbox-runner &


### PR DESCRIPTION
## Summary

Added shellcheck and shfmt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `shellcheck` (v0.11.0) and `shfmt` (v3.13.1) to CI and the Makefile, formats all shell scripts, and fixes lint findings. This standardizes shell style and hardens scripts without changing runtime behavior.

- CI/Makefile: Pin and install `shfmt`/`shellcheck`, add `shell-fmt`, `shell-fmt-check`, and `shell-lint` targets over git-tracked `*.sh` with a guard; run format check and lint before build.
- Scripts: Mechanical formatting; switch SSH option strings to arrays for `ssh`/`scp`; safer heredocs and quoting; isolate CDPATH; fail fast on `cd` errors; add targeted `shellcheck` annotations; minor robustness tweaks across e2e and utility scripts.
- Docs: Update local dev steps to use the new targets and match pinned tool versions.
- Required: Install `shfmt` and `shellcheck` locally and run `make shell-fmt` and `make shell-lint` before committing; use `shellcheck` v0.11.0 to match CI.

<sup>Written for commit 70c84a8cb68b26123d6d78e21d41ec6c90b9e0f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

