### PR TITLE
feat: measure sandbox create latency (CP-2920)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -11,7 +11,7 @@ Load tests for the n8n Sandbox Service using [k6](https://grafana.com/docs/k6/).
 
 | Script | Description |
 |--------|-------------|
-| `k6-sandbox-lifecycle.js` | Full sandbox lifecycle: create, execute `echo 'hello'`, delete. Ramps to 50 VUs. |
+| `k6-sandbox-lifecycle.js` | Full sandbox lifecycle: create, execute `echo 'hello'`, optionally wake, delete. |
 
 ## Running
 
@@ -21,11 +21,32 @@ Smoke test (single iteration):
 k6 run --vus 1 --iterations 1 benchmarks/k6-sandbox-lifecycle.js
 ```
 
-Full run (default stages: ramp to 50 VUs over 30s, hold 1m, ramp down):
+Load run (`SCENARIO=load`, the default: ramp to 50 VUs over 30s, hold 1m, ramp down):
 
 ```sh
 k6 run benchmarks/k6-sandbox-lifecycle.js
 ```
+
+Baseline run (one operation at a time, which is what [docs/performance.md](../docs/performance.md) records):
+
+```sh
+k6 run -e SCENARIO=baseline -e ITERATIONS=30 benchmarks/k6-sandbox-lifecycle.js
+```
+
+## Measuring wake
+
+`WAKE_AFTER` idles between the first and second exec so the API's idle sweeper
+stops the sandbox, which turns the second exec into a wake. The sandbox only
+stops if the wait exceeds `SANDBOX_API_IDLE_STOP_AFTER` (default 1h) plus up to
+one `SANDBOX_API_IDLE_SWEEP_INTERVAL` (default 1m), so set both low on the
+environment under test:
+
+```sh
+k6 run -e SCENARIO=baseline -e WAKE_AFTER=8 benchmarks/k6-sandbox-lifecycle.js
+```
+
+With `SANDBOX_API_IDLE_STOP_AFTER=3s` and `SANDBOX_API_IDLE_SWEEP_INTERVAL=2s`,
+a `WAKE_AFTER=8` wait reliably lands after a sweep.
 
 ## Environment variables
 
@@ -33,6 +54,9 @@ k6 run benchmarks/k6-sandbox-lifecycle.js
 |----------|---------|-------------|
 | `BASE_URL` | `http://127.0.0.1:8080` | Sandbox service API base URL |
 | `API_KEY` | `test` | API key for `X-Api-Key` header |
+| `SCENARIO` | `load` | `load` for the ramped run, `baseline` for one operation at a time |
+| `ITERATIONS` | `30` | Iterations in the baseline scenario |
+| `WAKE_AFTER` | `0` | Seconds to idle before the second exec; `0` skips the wake step |
 
 Example:
 
@@ -46,4 +70,9 @@ Each script reports per-step latency trends in addition to k6's built-in HTTP me
 
 - `sandbox_create_duration` — time to create a sandbox
 - `sandbox_exec_duration` — time to execute a command and receive the full response
+- `sandbox_wake_exec_duration` — same, for the exec that wakes a stopped sandbox (only with `WAKE_AFTER`)
 - `sandbox_delete_duration` — time to delete a sandbox
+
+Client-side numbers include network latency to the API. To attribute time inside
+the service, join them with the server-side events described in
+[docs/observability.md](../docs/observability.md).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -36,10 +36,12 @@ k6 run -e SCENARIO=baseline -e ITERATIONS=30 benchmarks/k6-sandbox-lifecycle.js
 ## Measuring wake
 
 `WAKE_AFTER` idles between the first and second exec so the API's idle sweeper
-stops the sandbox, which turns the second exec into a wake. The sandbox only
-stops if the wait exceeds `SANDBOX_API_IDLE_STOP_AFTER` (default 1h) plus up to
-one `SANDBOX_API_IDLE_SWEEP_INTERVAL` (default 1m), so set both low on the
-environment under test:
+stops the sandbox, which turns the second exec into a wake. The sandbox is only
+stopped once the wait exceeds `SANDBOX_API_IDLE_STOP_AFTER` (default 1h) plus
+up to one full `SANDBOX_API_IDLE_SWEEP_INTERVAL` (default 1m), since the sweeper
+only notices on its next tick. Set `WAKE_AFTER` comfortably above the sum of the
+two, or some iterations will exec against a still-running sandbox and record a
+normal exec as a wake:
 
 ```sh
 k6 run -e SCENARIO=baseline -e WAKE_AFTER=8 benchmarks/k6-sandbox-lifecycle.js
@@ -47,6 +49,14 @@ k6 run -e SCENARIO=baseline -e WAKE_AFTER=8 benchmarks/k6-sandbox-lifecycle.js
 
 With `SANDBOX_API_IDLE_STOP_AFTER=3s` and `SANDBOX_API_IDLE_SWEEP_INTERVAL=2s`,
 a `WAKE_AFTER=8` wait reliably lands after a sweep.
+
+Confirm afterwards that the runner logged one `firecracker sandbox woke` event
+per iteration. A wake trend with fewer wake events behind it is measuring the
+wrong thing.
+
+Because each iteration then takes at least `WAKE_AFTER` seconds, keep the
+iteration count low for wake runs and give the run enough headroom with
+`MAX_DURATION`.
 
 ## Environment variables
 
@@ -56,6 +66,7 @@ a `WAKE_AFTER=8` wait reliably lands after a sweep.
 | `API_KEY` | `test` | API key for `X-Api-Key` header |
 | `SCENARIO` | `load` | `load` for the ramped run, `baseline` for one operation at a time |
 | `ITERATIONS` | `30` | Iterations in the baseline scenario |
+| `MAX_DURATION` | `30m` | Cutoff for the baseline scenario; raise it if iterations × `WAKE_AFTER` exceeds it |
 | `WAKE_AFTER` | `0` | Seconds to idle before the second exec; `0` skips the wake step |
 
 Example:

--- a/benchmarks/k6-sandbox-lifecycle.js
+++ b/benchmarks/k6-sandbox-lifecycle.js
@@ -17,9 +17,15 @@ const deleteDuration = new Trend("sandbox_delete_duration", true);
 
 // The baseline scenario measures one operation at a time, which is what
 // docs/performance.md records. The load scenario is the concurrent run.
+//
+// maxDuration is set explicitly because k6 would otherwise cut the run off
+// after 10 minutes and report fewer iterations than asked for, which is easy
+// to miss when WAKE_AFTER makes each iteration take the better part of a
+// minute.
 const baselineOptions = {
   vus: 1,
   iterations: ITERATIONS,
+  maxDuration: __ENV.MAX_DURATION || "30m",
   thresholds: {
     http_req_failed: ["rate<0.01"],
   },

--- a/benchmarks/k6-sandbox-lifecycle.js
+++ b/benchmarks/k6-sandbox-lifecycle.js
@@ -1,15 +1,31 @@
 import http from "k6/http";
-import { check, fail } from "k6";
+import { check, fail, sleep } from "k6";
 import { Trend } from "k6/metrics";
 
 const BASE_URL = __ENV.BASE_URL || "http://127.0.0.1:8080";
 const API_KEY = __ENV.API_KEY || "test";
+const SCENARIO = __ENV.SCENARIO || "load";
+const ITERATIONS = Number(__ENV.ITERATIONS || 30);
+// Seconds to idle after the first exec so the API's idle sweeper stops the
+// sandbox, which makes the second exec a wake. 0 skips the wake step.
+const WAKE_AFTER = Number(__ENV.WAKE_AFTER || 0);
 
 const createDuration = new Trend("sandbox_create_duration", true);
 const execDuration = new Trend("sandbox_exec_duration", true);
+const wakeExecDuration = new Trend("sandbox_wake_exec_duration", true);
 const deleteDuration = new Trend("sandbox_delete_duration", true);
 
-export const options = {
+// The baseline scenario measures one operation at a time, which is what
+// docs/performance.md records. The load scenario is the concurrent run.
+const baselineOptions = {
+  vus: 1,
+  iterations: ITERATIONS,
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+  },
+};
+
+const loadOptions = {
   stages: [
     { duration: "30s", target: 50 },
     { duration: "1m", target: 50 },
@@ -21,10 +37,35 @@ export const options = {
   },
 };
 
+export const options = SCENARIO === "baseline" ? baselineOptions : loadOptions;
+
 const headers = {
   "Content-Type": "application/json",
   "X-Api-Key": API_KEY,
 };
+
+function exec(sandboxId) {
+  const payload = JSON.stringify({ command: "echo 'hello'" });
+  const res = http.post(
+    `${BASE_URL}/sandboxes/${sandboxId}/executions`,
+    payload,
+    { headers },
+  );
+
+  if (
+    !check(res, {
+      "exec status is 200": (r) => r.status === 200,
+      "exec completed successfully": (r) => {
+        const lines = r.body.trim().split("\n");
+        const last = JSON.parse(lines[lines.length - 1]);
+        return last.type === "exit" && last.exit_code === 0;
+      },
+    })
+  ) {
+    fail(`exec failed: ${res.status} ${res.body}`);
+  }
+  return res;
+}
 
 export default function () {
   // 1. Create sandbox
@@ -41,29 +82,16 @@ export default function () {
 
   const sandboxId = createRes.json().id;
 
-  // 2. Execute echo 'hello'
-  const execPayload = JSON.stringify({ command: "echo 'hello'" });
-  const execRes = http.post(
-    `${BASE_URL}/sandboxes/${sandboxId}/executions`,
-    execPayload,
-    { headers },
-  );
-  execDuration.add(execRes.timings.duration);
+  // 2. Execute echo 'hello' on the running sandbox
+  execDuration.add(exec(sandboxId).timings.duration);
 
-  if (
-    !check(execRes, {
-      "exec status is 200": (r) => r.status === 200,
-      "exec completed successfully": (r) => {
-        const lines = r.body.trim().split("\n");
-        const last = JSON.parse(lines[lines.length - 1]);
-        return last.type === "exit" && last.exit_code === 0;
-      },
-    })
-  ) {
-    fail(`exec failed: ${execRes.status} ${execRes.body}`);
+  // 3. Optionally let the sandbox go idle, then exec again to measure a wake
+  if (WAKE_AFTER > 0) {
+    sleep(WAKE_AFTER);
+    wakeExecDuration.add(exec(sandboxId).timings.duration);
   }
 
-  // 3. Delete sandbox
+  // 4. Delete sandbox
   const deleteRes = http.del(`${BASE_URL}/sandboxes/${sandboxId}`, null, {
     headers,
   });

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -20,13 +20,14 @@ import (
 	"github.com/n8n-io/sandbox-service/internal/api/store"
 	"github.com/n8n-io/sandbox-service/internal/grpctls"
 	"github.com/n8n-io/sandbox-service/internal/metrics"
+	"github.com/n8n-io/sandbox-service/internal/obs"
 	"google.golang.org/grpc"
 )
 
 func main() {
 	var logLevel slog.LevelVar
 	logLevel.Set(slog.LevelInfo)
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel}))
+	logger := slog.New(obs.TraceHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel})))
 	slog.SetDefault(logger)
 
 	cfg, err := config.LoadAPI()

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,6 +10,22 @@ A tenant key may only create sandboxes for that tenant and may only list/get/del
 
 Tenant keys are returned in plaintext once on create; only a hash is stored.
 
+### Request tracing
+
+Every request carries a trace id through the API, the runner, and the runner's
+sandbox lifecycle events. Clients may send a [W3C `traceparent`](https://www.w3.org/TR/trace-context/#traceparent-header)
+header to join their own trace:
+
+```
+traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+```
+
+The header is optional. A missing or malformed value is replaced with a freshly
+generated trace context, and a value from a later spec version is reduced to the
+fields above, so a caller cannot make the service log or relay content of their
+choosing. The trace id is not returned in responses; it appears in the service's
+log events. See [observability.md](observability.md).
+
 ---
 
 ## Error Response Format

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,6 @@ The n8n Sandbox Service provides isolated execution environments via a REST API.
 ## Operations
 
 - [Observability](observability.md) — trace ids, the per-request and per-lifecycle events, and how to query them
-- [Performance baseline](performance.md) — recorded Firecracker numbers and how to reproduce them
+- [Performance baseline](performance.md) — recorded numbers and how to reproduce them
 - [Debugging gRPC with grpcurl](grpcurl-debug.md)
 - [cert-manager on Kubernetes](cert-manager-k8s.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,5 +27,7 @@ The n8n Sandbox Service provides isolated execution environments via a REST API.
 
 ## Operations
 
+- [Observability](observability.md) — trace ids, the per-request and per-lifecycle events, and how to query them
+- [Performance baseline](performance.md) — recorded Firecracker numbers and how to reproduce them
 - [Debugging gRPC with grpcurl](grpcurl-debug.md)
 - [cert-manager on Kubernetes](cert-manager-k8s.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,7 @@ Series exposed today:
 - `sandbox_http_requests_total{role,route,method,status}` and `sandbox_http_request_duration_seconds{role,route,method}` (both binaries).
 - API: `sandbox_sandbox_operations_total{operation,result}`, `sandbox_sandboxes_active`, `sandbox_runners_registered`.
 - Runner: `sandbox_container_operations_total{operation,result}`, `sandbox_container_operation_duration_seconds{operation}`, `sandbox_containers_active`.
+- Firecracker runner: `sandbox_lifecycle_step_duration_seconds{operation,step}`, the per-step breakdown of a create or wake. See [observability.md](observability.md).
 - Plus the standard `go_*` and `process_*` collectors.
 
 ## Disk quotas

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,117 @@
+# Observability
+
+The service answers "why was this request slow?" with two things: a trace id
+that runs through every log event a request touches, and events wide enough that
+one line explains one operation. Metrics stay for aggregates and alerting.
+
+## Trace context
+
+The API establishes a [W3C trace context](https://www.w3.org/TR/trace-context/)
+for every request in its outermost middleware, then forwards it to the runner:
+
+| Hop | Carrier |
+|-----|---------|
+| Client → API | `traceparent` HTTP header (optional, see [API.md](API.md#request-tracing)) |
+| API → runner (exec, files) | `traceparent` HTTP header on the proxied request |
+| API → runner (create, stop, delete) | `traceparent` gRPC metadata |
+| Runner → sandbox lifecycle | Go context, down to the create and wake events |
+
+Rules:
+
+- An inbound `traceparent` is adopted only if it is a valid W3C value, and only
+  its trace id, parent id, and flags are kept; anything else is replaced with a
+  freshly generated one. What the API logs and forwards to the runner is always
+  rebuilt from those parsed fields, so a caller cannot inject content into the
+  service's logs or make it relay bytes of their choosing.
+- `tracestate` and vendor extensions are not propagated.
+- Every event carries `trace_id`, the 32 hex character trace-id field of the
+  traceparent. That is the join key across processes.
+- A wake started by one request may be shared by others that arrive while it
+  runs, so the wake event carries the trace id of the request that started it.
+
+## Events
+
+### API: one event per request
+
+The API emits exactly one `request` event per request, whatever the outcome:
+
+| Field | Notes |
+|-------|-------|
+| `trace_id` | Join key for every other event of this request |
+| `method`, `path`, `query`, `status`, `duration_ms` | Always present |
+| `tenant_id` | Present for tenant-authenticated requests |
+| `sandbox_id`, `runner_id` | Present on create and on proxied sandbox routes |
+| `ttfb_ms` | Proxied routes: time until the runner's response headers arrived. For a streamed exec this is time to first byte, not the full response |
+
+`/healthz` and `/metrics` are not logged.
+
+### Runner: one event per sandbox lifecycle operation
+
+The Firecracker runner emits `firecracker sandbox created` and
+`firecracker sandbox woke` with the full step breakdown:
+
+| Field | Notes |
+|-------|-------|
+| `trace_id` | Matches the API event for the request that caused the operation |
+| `sandbox_id`, `vm_id`, `slot` | Identity of the sandbox and the slot it occupies |
+| `op` | `create` or `ensure_running`, matching the metric labels |
+| `total_ms` | Whole operation |
+| `<step>_ms` | One field per step below |
+
+Steps, in order:
+
+| Step | Operation | What it covers |
+|------|-----------|----------------|
+| `clone_rootfs` | create | Copy the template rootfs for the new sandbox |
+| `clone_snapshot` | create | Copy the golden memory and state snapshot |
+| `prepare_jail` | create, wake | Jailer directory and device setup |
+| `setup_network` | create, wake | Network namespace, tap device, and rules |
+| `start_jailer` | create, wake | Launch the jailer and Firecracker process |
+| `wait_socket` | create, wake | Wait for the Firecracker API socket |
+| `load_snapshot` | create, wake | Restore the VM from the snapshot |
+| `start_proxy` | create, wake | Start the host-side daemon proxy |
+| `probe_daemon` | create, wake | First successful call to the in-guest daemon |
+
+A wake skips the two clone steps, since the sandbox's disk already exists.
+
+## Metrics
+
+The step timings also go to `sandbox_lifecycle_step_duration_seconds{operation,step}`
+on the runner, for percentiles across the fleet. Use the events to take apart a
+single slow operation, the histogram to see whether it is representative.
+
+Related series:
+
+- `sandbox_container_operation_duration_seconds{operation}` — the totals the
+  steps add up to.
+- `sandbox_http_request_duration_seconds{role,route,method}` — end-to-end per
+  route on both binaries.
+
+Full list in [configuration.md](configuration.md#metrics).
+
+## Working with the events
+
+Both binaries log JSON to stdout, so the examples below work on any log stream —
+`kubectl logs`, `journalctl -o cat`, or a log file from the e2e scripts.
+
+Everything one request touched, across both processes:
+
+```sh
+cat api.log runner.log | jq 'select(.trace_id == "4bf92f3577b34da6a3ce929d0e0e4736")'
+```
+
+The ten slowest wakes, with their step breakdown:
+
+```sh
+jq -c 'select(.msg == "firecracker sandbox woke")' runner.log \
+  | jq -s 'sort_by(-.total_ms) | .[:10]'
+```
+
+Which step dominates wakes:
+
+```sh
+jq -s '[.[] | select(.msg == "firecracker sandbox woke")]
+       | (map(.load_snapshot_ms) | add / length) as $snapshot
+       | (map(.total_ms) | add / length) as $total
+       | {mean_total_ms: $total, mean_load_snapshot_ms: $snapshot}' runner.log
+```

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -31,6 +31,33 @@ Rules:
 
 ## Events
 
+Four log messages are canonical events: one line that explains one operation,
+and what the queries below select on.
+
+| Event | Emitter | Emitted when |
+| --- | --- | --- |
+| `request` | API | A request finishes, including one rejected by middleware |
+| `request` | Runner | A request proxied from the API (exec, files) finishes |
+| `firecracker sandbox created` | Runner | A sandbox is created and its guest daemon answers |
+| `firecracker sandbox woke` | Runner | A stopped sandbox is restored and its guest daemon answers |
+
+The runner's `request` event only records `trace_id`, `method`, `path`, and
+`duration_ms`; the API's is the wide one, and the runner's lifecycle events hold
+the detail of what happened underneath. Health and metrics routes are logged on
+neither binary.
+
+Diagnostics are the other lines the two binaries log. They are not part of this
+contract — no guarantee of one per operation, and their fields change with the
+code that emits them — but a diagnostic logged with a request's context also
+carries that request's `trace_id`, so the step a failed create died on comes
+back alongside its canonical event. The create path does this for runner
+selection, the gRPC create, and the store write.
+
+To get it in new code, log through `slog`'s context-taking functions
+(`InfoContext`, `ErrorContext`, and so on): the handler both binaries install
+adds the trace id whenever the context has one. Background work such as the
+idle sweeper has no request context and so no trace id.
+
 ### API: one event per request
 
 The API emits exactly one `request` event per request, whatever the outcome:
@@ -42,8 +69,6 @@ The API emits exactly one `request` event per request, whatever the outcome:
 | `tenant_id` | Present for tenant-authenticated requests |
 | `sandbox_id`, `runner_id` | Present on create and on proxied sandbox routes |
 | `ttfb_ms` | Proxied routes: time until the runner's response headers arrived. For a streamed exec this is time to first byte, not the full response |
-
-`/healthz` and `/metrics` are not logged.
 
 ### Runner: one event per sandbox lifecycle operation
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -10,7 +10,7 @@ The API establishes a [W3C trace context](https://www.w3.org/TR/trace-context/)
 for every request in its outermost middleware, then forwards it to the runner:
 
 | Hop | Carrier |
-|-----|---------|
+| --- | --- |
 | Client → API | `traceparent` HTTP header (optional, see [API.md](API.md#request-tracing)) |
 | API → runner (exec, files) | `traceparent` HTTP header on the proxied request |
 | API → runner (create, stop, delete) | `traceparent` gRPC metadata |
@@ -36,7 +36,7 @@ Rules:
 The API emits exactly one `request` event per request, whatever the outcome:
 
 | Field | Notes |
-|-------|-------|
+| --- | --- |
 | `trace_id` | Join key for every other event of this request |
 | `method`, `path`, `query`, `status`, `duration_ms` | Always present |
 | `tenant_id` | Present for tenant-authenticated requests |
@@ -51,7 +51,7 @@ The Firecracker runner emits `firecracker sandbox created` and
 `firecracker sandbox woke` with the full step breakdown:
 
 | Field | Notes |
-|-------|-------|
+| --- | --- |
 | `trace_id` | Matches the API event for the request that caused the operation |
 | `sandbox_id`, `vm_id`, `slot` | Identity of the sandbox and the slot it occupies |
 | `op` | `create` or `ensure_running`, matching the metric labels |
@@ -61,7 +61,7 @@ The Firecracker runner emits `firecracker sandbox created` and
 Steps, in order:
 
 | Step | Operation | What it covers |
-|------|-----------|----------------|
+| --- | --- | --- |
 | `clone_rootfs` | create | Copy the template rootfs for the new sandbox |
 | `clone_snapshot` | create | Copy the golden memory and state snapshot |
 | `prepare_jail` | create, wake | Jailer directory and device setup |
@@ -94,6 +94,10 @@ Full list in [configuration.md](configuration.md#metrics).
 Both binaries log JSON to stdout, so the examples below work on any log stream —
 `kubectl logs`, `journalctl -o cat`, or a log file from the e2e scripts.
 
+A runner's journal is not pure JSON: the runtime shells out through `sudo` for
+jail and network setup, and those lines land in the same unit. Select the events
+you want with `grep` before handing anything to `jq`.
+
 Everything one request touched, across both processes:
 
 ```sh
@@ -103,15 +107,22 @@ cat api.log runner.log | jq 'select(.trace_id == "4bf92f3577b34da6a3ce929d0e0e47
 The ten slowest wakes, with their step breakdown:
 
 ```sh
-jq -c 'select(.msg == "firecracker sandbox woke")' runner.log \
+grep -a '"firecracker sandbox woke"' runner.log \
   | jq -s 'sort_by(-.total_ms) | .[:10]'
 ```
 
-Which step dominates wakes:
+Percentiles for every step of an operation, which is what a baseline entry
+needs. This runs on a stream of any size and prints a summary small enough to
+come back through `az vmss run-command`:
 
 ```sh
-jq -s '[.[] | select(.msg == "firecracker sandbox woke")]
-       | (map(.load_snapshot_ms) | add / length) as $snapshot
-       | (map(.total_ms) | add / length) as $total
-       | {mean_total_ms: $total, mean_load_snapshot_ms: $snapshot}' runner.log
+grep -a '"firecracker sandbox created"' runner.log | jq -s '
+  . as $e
+  | (map(keys[] | select(endswith("_ms"))) | unique) as $steps
+  | {n: length,
+     steps: [$steps[] | . as $s
+       | {key: $s, value: (($e | map(.[$s]) | sort) as $v
+           | {p50: $v[(($v|length-1) * 0.5) | floor],
+              p95: $v[(($v|length-1) * 0.95) | round],
+              max: ($v | max)})}] | from_entries}'
 ```

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,79 @@
+# Performance baseline
+
+Recorded numbers for the Firecracker runner, so later changes can be judged
+against something instead of against memory. Each entry states what was
+measured, on what, and how to reproduce it.
+
+Measurements are only comparable within the same host shape and commit. When
+either changes, record a new entry rather than editing an old one.
+
+## How to record a baseline
+
+1. Deploy the commit under test and note the API and runner image tags.
+2. Run the k6 baseline scenario from inside the cluster, so client-side numbers
+   are not dominated by the trip to the ingress:
+
+   ```sh
+   kubectl run k6-baseline --rm -i --restart=Never --image=grafana/k6:latest \
+     --env BASE_URL=http://n8n-sandbox-service-api:8080 \
+     --env API_KEY=<key> \
+     --env SCENARIO=baseline \
+     --env ITERATIONS=30 \
+     --env WAKE_AFTER=8 \
+     -- run - < benchmarks/k6-sandbox-lifecycle.js
+   ```
+
+   `WAKE_AFTER` only produces wakes if the API's idle sweeper stops the sandbox
+   in time; see [benchmarks/README.md](../benchmarks/README.md#measuring-wake).
+3. Take the server-side split from the runner's lifecycle events, which is the
+   part that a change to the runtime actually moves:
+
+   ```sh
+   jq -c 'select(.msg == "firecracker sandbox created" or .msg == "firecracker sandbox woke")' runner.log
+   ```
+
+   Field meanings are in [observability.md](observability.md#events).
+4. Add an entry below with the host shape, the commit, and the numbers.
+
+## Entries
+
+None recorded yet. The instrumentation this depends on landed in the same change
+as this document; the first entry follows the next stage deploy.
+
+Use this shape:
+
+### YYYY-MM-DD — stage, Firecracker
+
+| Field | Value |
+|-------|-------|
+| Commit | `<sha>` |
+| Runner host | e.g. Azure `Standard_D8ds_v5`, 8 vCPU, 32 GB, local NVMe |
+| Sandboxes on host during run | e.g. 0 other sandboxes |
+| Scenario | `SCENARIO=baseline ITERATIONS=30 WAKE_AFTER=8` |
+
+Client-side, from k6:
+
+| Metric | p50 | p95 | max |
+|--------|-----|-----|-----|
+| `sandbox_create_duration` | | | |
+| `sandbox_exec_duration` | | | |
+| `sandbox_wake_exec_duration` | | | |
+| `sandbox_delete_duration` | | | |
+
+Server-side, from the runner's create and wake events:
+
+| Step | create p50 | wake p50 |
+|------|-----------|----------|
+| `clone_rootfs` | | n/a |
+| `clone_snapshot` | | n/a |
+| `prepare_jail` | | |
+| `setup_network` | | |
+| `start_jailer` | | |
+| `wait_socket` | | |
+| `load_snapshot` | | |
+| `start_proxy` | | |
+| `probe_daemon` | | |
+| `total_ms` | | |
+
+Notes: anything unusual about the run — errors, retries, noisy neighbours, or
+capacity limits hit.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,11 +1,10 @@
 # Performance baseline
 
-Recorded numbers for the Firecracker runner, so later changes can be judged
-against something instead of against memory. Each entry states what was
-measured, on what, and how to reproduce it.
+Recorded numbers for the sandbox service. Each entry states what was measured,
+on which runtime, on what host shape, and at which commit.
 
-Measurements are only comparable within the same host shape and commit. When
-either changes, record a new entry rather than editing an old one.
+Measurements are only comparable within the same runtime, host shape and commit.
+When any of them changes, record a new entry rather than editing an old one.
 
 ## How to record a baseline
 
@@ -15,65 +14,131 @@ either changes, record a new entry rather than editing an old one.
 
    ```sh
    kubectl run k6-baseline --rm -i --restart=Never --image=grafana/k6:latest \
-     --env BASE_URL=http://n8n-sandbox-service-api:8080 \
+     --env BASE_URL=http://<api service>:8080 \
      --env API_KEY=<key> \
      --env SCENARIO=baseline \
      --env ITERATIONS=30 \
-     --env WAKE_AFTER=8 \
      -- run - < benchmarks/k6-sandbox-lifecycle.js
    ```
 
-   `WAKE_AFTER` only produces wakes if the API's idle sweeper stops the sandbox
-   in time; see [benchmarks/README.md](../benchmarks/README.md#measuring-wake).
-3. Take the server-side split from the runner's lifecycle events, which is the
-   part that a change to the runtime actually moves:
+3. Measure wakes as a separate, shorter run. Each iteration has to idle long
+   enough for the sweeper to stop the sandbox, so a wake run costs roughly
+   `WAKE_AFTER` seconds per iteration and needs far fewer of them:
 
    ```sh
-   jq -c 'select(.msg == "firecracker sandbox created" or .msg == "firecracker sandbox woke")' runner.log
+   kubectl run k6-wake --rm -i --restart=Never --image=grafana/k6:latest \
+     --env BASE_URL=http://<api service>:8080 \
+     --env API_KEY=<key> \
+     --env SCENARIO=baseline \
+     --env ITERATIONS=10 \
+     --env WAKE_AFTER=<idle stop + sweep interval, plus margin> \
+     -- run - < benchmarks/k6-sandbox-lifecycle.js
+   ```
+
+   Sizing `WAKE_AFTER` and checking that the wakes really happened is covered in
+   [benchmarks/README.md](../benchmarks/README.md#measuring-wake).
+4. On the Firecracker runtime, take the server-side split from the runner's
+   lifecycle events. No other runtime emits step timings, so entries for those
+   are client-side only. Select the events by message before parsing, because a
+   runner's journal interleaves non-JSON lines from the `sudo` calls the runtime
+   makes:
+
+   ```sh
+   grep -a '"firecracker sandbox created"' runner.log | jq -c .
    ```
 
    Field meanings are in [observability.md](observability.md#events).
-4. Add an entry below with the host shape, the commit, and the numbers.
+5. Add an entry below with the runtime, the host shape, the commit, and the
+   numbers.
+
+Keep environment identifiers — cluster, scale set, namespace, host names — out
+of the entries. Record the host shape and the configuration that affects the
+result, not where it ran.
 
 ## Entries
 
-None recorded yet. The instrumentation this depends on landed in the same change
-as this document; the first entry follows the next stage deploy.
-
-Use this shape:
-
-### YYYY-MM-DD — stage, Firecracker
+### 2026-08-18 — staging, Firecracker
 
 | Field | Value |
-|-------|-------|
-| Commit | `<sha>` |
-| Runner host | e.g. Azure `Standard_D8ds_v5`, 8 vCPU, 32 GB, local NVMe |
-| Sandboxes on host during run | e.g. 0 other sandboxes |
-| Scenario | `SCENARIO=baseline ITERATIONS=30 WAKE_AFTER=8` |
+| --- | --- |
+| Commit | `94afb97` |
+| Runner host | Azure `Standard_D4s_v3`, 4 vCPU, 16 GB, 2 instances |
+| Scenario | create `ITERATIONS=30`, wake `ITERATIONS=10 WAKE_AFTER=60`, 1 VU, k6 in-cluster |
+| Idle settings during run | `idleStopAfter: 30s`, `idleSweepInterval: 15s` |
 
 Client-side, from k6:
 
-| Metric | p50 | p95 | max |
-|--------|-----|-----|-----|
-| `sandbox_create_duration` | | | |
-| `sandbox_exec_duration` | | | |
-| `sandbox_wake_exec_duration` | | | |
-| `sandbox_delete_duration` | | | |
+| Metric | p50 | p95 |
+| --- | --- | --- |
+| `sandbox_create_duration` | 732 ms | 762 ms |
+| `sandbox_exec_duration` | 82 ms | 90 ms |
+| `sandbox_wake_exec_duration` | 240 ms | 252 ms |
+| `sandbox_delete_duration` | 112 ms | 121 ms |
 
-Server-side, from the runner's create and wake events:
+Server-side, from the runner's create (n=58) and wake (n=23) events. Ranges span
+the two runner instances:
 
-| Step | create p50 | wake p50 |
-|------|-----------|----------|
-| `clone_rootfs` | | n/a |
-| `clone_snapshot` | | n/a |
-| `prepare_jail` | | |
-| `setup_network` | | |
-| `start_jailer` | | |
-| `wait_socket` | | |
-| `load_snapshot` | | |
-| `start_proxy` | | |
-| `probe_daemon` | | |
-| `total_ms` | | |
+| Step | create p50 | create p95 | wake p50 | wake p95 |
+| --- | --- | --- | --- | --- |
+| `clone_rootfs` | 396–400 ms | 413–414 ms | n/a | n/a |
+| `clone_snapshot` | 118–120 ms | 122–132 ms | n/a | n/a |
+| `prepare_jail` | 26 ms | 39–41 ms | 28–30 ms | 37 ms |
+| `setup_network` | 85–89 ms | 103–105 ms | 89–92 ms | 96–105 ms |
+| `start_jailer` | 0 ms | 0 ms | 0 ms | 0 ms |
+| `wait_socket` | 20 ms | 21–40 ms | 20 ms | 20–21 ms |
+| `load_snapshot` | 3 ms | 5 ms | 3–4 ms | 4–7 ms |
+| `start_proxy` | 0 ms | 0 ms | 0 ms | 0 ms |
+| `probe_daemon` | 56–61 ms | 65–66 ms | 36–37 ms | 39–42 ms |
+| `total_ms` | 713–726 ms | 768–773 ms | 183–185 ms | 192–208 ms |
 
-Notes: anything unusual about the run — errors, retries, noisy neighbours, or
-capacity limits hit.
+Conditions:
+
+- `http_req_failed` was 0% on both k6 runs.
+- The runner data directory was on the OS disk, formatted ext4, and the golden
+  template files were resident in page cache throughout. `clone_rootfs` and
+  `clone_snapshot` are copy-through-cache times under those conditions.
+- The event window covered more traffic than the k6 runs alone: 58 creates and
+  23 wakes against 40 and 10 driven by k6.
+- Client-side create p50 exceeded runner-side create p50 by 6 ms.
+- Minimum `sandbox_wake_exec_duration` was 229 ms against a warm
+  `sandbox_exec_duration` p50 of 82 ms, so every wake iteration hit a stopped
+  sandbox.
+
+---
+
+Template for further entries:
+
+### YYYY-MM-DD — `<environment class>`, `<runtime>`
+
+| Field | Value |
+| --- | --- |
+| Commit | `<sha>` |
+| Runner host | e.g. Azure `Standard_D8ds_v5`, 8 vCPU, 32 GB, local NVMe |
+| Scenario | e.g. create `ITERATIONS=30`, wake `ITERATIONS=10 WAKE_AFTER=60` |
+| Idle settings during run | `idleStopAfter`, `idleSweepInterval` |
+
+Client-side, from k6:
+
+| Metric | p50 | p95 |
+| --- | --- | --- |
+| `sandbox_create_duration` | | |
+| `sandbox_exec_duration` | | |
+| `sandbox_wake_exec_duration` | | |
+| `sandbox_delete_duration` | | |
+
+Server-side, from the runner's create and wake events. Firecracker only:
+
+| Step | create p50 | create p95 | wake p50 | wake p95 |
+| --- | --- | --- | --- | --- |
+| `clone_rootfs` | | | n/a | n/a |
+| `clone_snapshot` | | | n/a | n/a |
+| `prepare_jail` | | | | |
+| `setup_network` | | | | |
+| `start_jailer` | | | | |
+| `wait_socket` | | | | |
+| `load_snapshot` | | | | |
+| `start_proxy` | | | | |
+| `probe_daemon` | | | | |
+| `total_ms` | | | | |
+
+Conditions: sample counts, error rates, and any configuration set for the run.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/n8n-io/sandbox-service/internal/api/runnerctl"
 	"github.com/n8n-io/sandbox-service/internal/api/store"
 	"github.com/n8n-io/sandbox-service/internal/metrics"
+	"github.com/n8n-io/sandbox-service/internal/obs"
 	"github.com/n8n-io/sandbox-service/internal/sandboxproxy"
 )
 
@@ -72,8 +73,16 @@ func sandboxProxyHandler(s store.SandboxStore, cfg *config.APIConfig) func(bool)
 			_ = s.UpdateLastActive(id)
 			_ = s.UpdateStatus(id, "running")
 
+			fields := obs.FieldsFrom(r.Context())
+			fields.Add("sandbox_id", id)
+			fields.Add("runner_id", rec.RunnerID)
+
 			u, _ := url.Parse(strings.TrimRight(rec.RunnerHTTPBase, "/"))
+			upstreamStart := time.Now()
 			proxy := newRunnerReverseProxy(u, cfg.RunnerAPIKey, func(resp *http.Response) {
+				// Response headers are in, so for a streamed exec this is the
+				// time to first byte rather than the full round trip.
+				fields.Add("ttfb_ms", time.Since(upstreamStart).Milliseconds())
 				reapSandboxIfRunnerGone(s, id, resp)
 			})
 			if limitBody {
@@ -286,6 +295,10 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 		controlAddr := run.ControlGRPCAddr
 		tlsCfg := runnerControlTLS(cfg)
 
+		fields := obs.FieldsFrom(r.Context())
+		fields.Add("sandbox_id", sandboxID)
+		fields.Add("runner_id", run.ID)
+
 		now := time.Now().Unix()
 		slog.Info(
 			"create sandbox: runner selected",
@@ -435,6 +448,13 @@ func newRunnerReverseProxy(runnerURL *url.URL, runnerAPIKey string, onResponse f
 				pr.Out.Header.Set("X-Api-Key", runnerAPIKey)
 			} else {
 				pr.Out.Header.Del("X-Api-Key")
+			}
+			// Forward the trace context we established, never the caller's raw
+			// header, which LoggingMiddleware has already validated or replaced.
+			if tp := obs.Traceparent(pr.In.Context()); tp != "" {
+				pr.Out.Header.Set(obs.HeaderTraceparent, tp)
+			} else {
+				pr.Out.Header.Del(obs.HeaderTraceparent)
 			}
 		},
 		ModifyResponse: func(resp *http.Response) error {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -74,8 +74,7 @@ func sandboxProxyHandler(s store.SandboxStore, cfg *config.APIConfig) func(bool)
 			_ = s.UpdateStatus(id, "running")
 
 			fields := obs.FieldsFrom(r.Context())
-			fields.Add("sandbox_id", id)
-			fields.Add("runner_id", rec.RunnerID)
+			fields.Add("sandbox_id", id, "runner_id", rec.RunnerID)
 
 			u, _ := url.Parse(strings.TrimRight(rec.RunnerHTTPBase, "/"))
 			upstreamStart := time.Now()
@@ -283,10 +282,10 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 		run, err := reg.PickLowestUsed()
 		if err != nil {
 			if errors.Is(err, registry.ErrNoRunners) {
-				slog.Warn("create sandbox failed: no eligible runners")
+				slog.WarnContext(r.Context(), "create sandbox failed: no eligible runners")
 				writeError(w, http.StatusServiceUnavailable, err.Error())
 			} else {
-				slog.Error("create sandbox failed: pick runner", "error", err)
+				slog.ErrorContext(r.Context(), "create sandbox failed: pick runner", "error", err)
 				writeError(w, http.StatusInternalServerError, err.Error())
 			}
 			return
@@ -296,11 +295,11 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 		tlsCfg := runnerControlTLS(cfg)
 
 		fields := obs.FieldsFrom(r.Context())
-		fields.Add("sandbox_id", sandboxID)
-		fields.Add("runner_id", run.ID)
+		fields.Add("sandbox_id", sandboxID, "runner_id", run.ID)
 
 		now := time.Now().Unix()
-		slog.Info(
+		slog.InfoContext(
+			r.Context(),
 			"create sandbox: runner selected",
 			"sandbox_id", sandboxID,
 			"runner_id", run.ID,
@@ -314,7 +313,8 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 		)
 		gresp, err := runnerctl.CreateSandbox(r.Context(), controlAddr, cfg.RunnerAPIKey, tlsCfg, sandboxID, "{}")
 		if err != nil {
-			slog.Error(
+			slog.ErrorContext(
+				r.Context(),
 				"create sandbox failed: runner control create",
 				"sandbox_id", sandboxID,
 				"runner_id", run.ID,
@@ -349,7 +349,8 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 				writeError(w, http.StatusConflict, "sandbox id unavailable")
 				return
 			}
-			slog.Error(
+			slog.ErrorContext(
+				r.Context(),
 				"create sandbox failed: store record",
 				"sandbox_id", sandboxID,
 				"runner_id", run.ID,
@@ -363,7 +364,8 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 			writeError(w, http.StatusInternalServerError, "failed to store sandbox: "+err.Error())
 			return
 		}
-		slog.Info(
+		slog.InfoContext(
+			r.Context(),
 			"create sandbox succeeded",
 			"sandbox_id", sandboxID,
 			"runner_id", run.ID,

--- a/internal/api/handlers_create_sandbox_test.go
+++ b/internal/api/handlers_create_sandbox_test.go
@@ -43,6 +43,32 @@ func postCreateSandbox(t *testing.T, router http.Handler, apiKey, body string) *
 	return rr
 }
 
+// A failed create must be diagnosable from the canonical event: the step that
+// failed carries the same trace id, so both lines come back from one query.
+func TestCreateSandboxFailureIsTraceCorrelated(t *testing.T) {
+	logs := captureLogs(t)
+	router, _ := newTestGateway(t, "admin-key")
+
+	// No runner ever registered, so the create fails at runner selection.
+	if rr := postCreateSandbox(t, router, "admin-key", ""); rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("create without runners: expected %d, got %d body=%s", http.StatusServiceUnavailable, rr.Code, rr.Body.String())
+	}
+
+	traceIDs := map[string]string{}
+	for _, event := range logs() {
+		msg, _ := event["msg"].(string)
+		traceIDs[msg], _ = event["trace_id"].(string)
+	}
+
+	failure := traceIDs["create sandbox failed: no eligible runners"]
+	if len(failure) != 32 {
+		t.Fatalf("failure event trace_id = %q, want a 32 hex character id", failure)
+	}
+	if request := traceIDs["request"]; request != failure {
+		t.Fatalf("request event trace_id = %q, want the failure event's %q", request, failure)
+	}
+}
+
 func TestCreateSandboxClientIDCrossTenantConflict(t *testing.T) {
 	router, s := newTestGateway(t, "admin-key")
 	a := mintTenantKey(t, router, `{"name":"a"}`)

--- a/internal/api/middleware_auth.go
+++ b/internal/api/middleware_auth.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/n8n-io/sandbox-service/internal/api/store"
+	"github.com/n8n-io/sandbox-service/internal/obs"
 )
 
 type authRole string
@@ -80,6 +81,7 @@ func AuthMiddleware(adminKeys map[string]struct{}, s store.SandboxStore) func(ht
 			wantHash := hashAPIKey(key)
 			for _, c := range candidates {
 				if subtle.ConstantTimeCompare([]byte(c.KeyHash), []byte(wantHash)) == 1 {
+					obs.FieldsFrom(r.Context()).Add("tenant_id", c.TenantID)
 					next.ServeHTTP(w, r.WithContext(withAuthIdentity(r.Context(), authIdentity{
 						Role:     roleTenant,
 						TenantID: c.TenantID,

--- a/internal/api/middleware_logging.go
+++ b/internal/api/middleware_logging.go
@@ -4,25 +4,39 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/n8n-io/sandbox-service/internal/obs"
 )
 
-// LoggingMiddleware logs request method, path, status, and duration.
+// LoggingMiddleware establishes the request's trace context and emits one
+// canonical event per request when it finishes.
+//
+// It runs outermost so that rejected requests are logged too, which means the
+// contexts that later middleware and handlers derive are invisible here. They
+// contribute fields through the *obs.Fields pointer instead.
 func LoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/healthz" || r.URL.Path == "/metrics" {
 			next.ServeHTTP(w, r)
 			return
 		}
+		traceparent := obs.EnsureTraceparent(r.Header.Get(obs.HeaderTraceparent))
+		ctx, fields := obs.WithFields(obs.WithTraceparent(r.Context(), traceparent))
+		r = r.WithContext(ctx)
+
 		start := time.Now()
 		sw := &statusWriter{ResponseWriter: w, status: 200}
 		next.ServeHTTP(sw, r)
-		slog.Info("request",
+
+		attrs := []any{
+			"trace_id", obs.TraceIDOf(traceparent),
 			"method", r.Method,
 			"path", r.URL.Path,
 			"query", r.URL.RawQuery,
 			"status", sw.status,
 			"duration_ms", time.Since(start).Milliseconds(),
-		)
+		}
+		slog.Info("request", append(attrs, fields.Attrs()...)...)
 	})
 }
 

--- a/internal/api/middleware_logging_test.go
+++ b/internal/api/middleware_logging_test.go
@@ -12,12 +12,14 @@ import (
 )
 
 // captureLogs redirects the default logger into a buffer for the duration of
-// the test and returns the events it recorded.
+// the test and returns the events it recorded. The handler is wrapped the same
+// way cmd/api/main.go wraps it, so events logged with a request context are
+// traced here as they are in production.
 func captureLogs(t *testing.T) func() []map[string]any {
 	t.Helper()
 	var buf bytes.Buffer
 	previous := slog.Default()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	slog.SetDefault(slog.New(obs.TraceHandler(slog.NewJSONHandler(&buf, nil))))
 	t.Cleanup(func() { slog.SetDefault(previous) })
 
 	return func() []map[string]any {

--- a/internal/api/middleware_logging_test.go
+++ b/internal/api/middleware_logging_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/n8n-io/sandbox-service/internal/obs"
+)
+
+// captureLogs redirects the default logger into a buffer for the duration of
+// the test and returns the events it recorded.
+func captureLogs(t *testing.T) func() []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	return func() []map[string]any {
+		var events []map[string]any
+		for _, line := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n")) {
+			if len(line) == 0 {
+				continue
+			}
+			var event map[string]any
+			if err := json.Unmarshal(line, &event); err != nil {
+				t.Fatalf("log line is not JSON: %v", err)
+			}
+			events = append(events, event)
+		}
+		return events
+	}
+}
+
+func TestLoggingMiddlewareEmitsCanonicalEvent(t *testing.T) {
+	logs := captureLogs(t)
+
+	handler := LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Stands in for the handlers and middleware that contribute fields
+		// from a request context the outer middleware never sees.
+		obs.FieldsFrom(r.Context()).Add("sandbox_id", "sandbox-1")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/sandboxes/sandbox-1/executions?wait=1", nil))
+
+	events := logs()
+	if len(events) != 1 {
+		t.Fatalf("got %d log events, want exactly one canonical event", len(events))
+	}
+	event := events[0]
+	for field, want := range map[string]any{
+		"msg":        "request",
+		"method":     http.MethodPost,
+		"path":       "/sandboxes/sandbox-1/executions",
+		"query":      "wait=1",
+		"status":     float64(http.StatusAccepted),
+		"sandbox_id": "sandbox-1",
+	} {
+		if event[field] != want {
+			t.Fatalf("event[%q] = %v, want %v", field, event[field], want)
+		}
+	}
+	if _, ok := event["duration_ms"]; !ok {
+		t.Fatalf("event is missing duration_ms: %v", event)
+	}
+	if traceID, _ := event["trace_id"].(string); len(traceID) != 32 {
+		t.Fatalf("event trace_id = %q, want a 32 hex character id", traceID)
+	}
+}
+
+func TestLoggingMiddlewareAdoptsInboundTraceparent(t *testing.T) {
+	logs := captureLogs(t)
+
+	const inbound = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	var forwarded string
+	handler := LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwarded = obs.Traceparent(r.Context())
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/sandboxes", nil)
+	req.Header.Set(obs.HeaderTraceparent, inbound)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if forwarded != inbound {
+		t.Fatalf("context traceparent = %q, want the inbound header %q", forwarded, inbound)
+	}
+	if got := logs()[0]["trace_id"]; got != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("event trace_id = %v, want the inbound trace id", got)
+	}
+}
+
+func TestLoggingMiddlewareReplacesMalformedTraceparent(t *testing.T) {
+	captureLogs(t)
+
+	var forwarded string
+	handler := LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwarded = obs.Traceparent(r.Context())
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/sandboxes", nil)
+	req.Header.Set(obs.HeaderTraceparent, "not-a-traceparent")
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if obs.TraceIDOf(forwarded) == "" {
+		t.Fatalf("context traceparent = %q, want a freshly minted one", forwarded)
+	}
+}
+
+func TestLoggingMiddlewareSkipsProbes(t *testing.T) {
+	logs := captureLogs(t)
+
+	handler := LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	for _, path := range []string{"/healthz", "/metrics"} {
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, path, nil))
+	}
+
+	if events := logs(); len(events) != 0 {
+		t.Fatalf("got %d log events for probe endpoints, want none", len(events))
+	}
+}

--- a/internal/api/runnerctl/client.go
+++ b/internal/api/runnerctl/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/n8n-io/sandbox-service/internal/api/grpc/pb"
 	"github.com/n8n-io/sandbox-service/internal/grpctls"
+	"github.com/n8n-io/sandbox-service/internal/obs"
 )
 
 // TLS holds required mTLS material for the API dialing a runner.
@@ -39,12 +40,17 @@ func dialOpts(target string, tlsCfg *TLS) ([]grpc.DialOption, error) {
 	return []grpc.DialOption{grpc.WithTransportCredentials(creds)}, nil
 }
 
-func withAPIKey(ctx context.Context, apiKey string) context.Context {
+// withCallMetadata attaches the runner API key and, when the caller is inside a
+// traced request, the trace context so the runner's events join ours.
+func withCallMetadata(ctx context.Context, apiKey string) context.Context {
 	apiKey = strings.TrimSpace(apiKey)
-	if apiKey == "" {
-		return ctx
+	if apiKey != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "x-api-key", apiKey)
 	}
-	return metadata.AppendToOutgoingContext(ctx, "x-api-key", apiKey)
+	if tp := obs.Traceparent(ctx); tp != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, obs.HeaderTraceparent, tp)
+	}
+	return ctx
 }
 
 // CreateSandbox calls SandboxControl.CreateSandbox and closes the connection.
@@ -60,7 +66,7 @@ func CreateSandbox(ctx context.Context, target, apiKey string, tlsCfg *TLS, sand
 	defer conn.Close()
 
 	cli := pb.NewSandboxControlClient(conn)
-	return cli.CreateSandbox(withAPIKey(ctx, apiKey), &pb.CreateSandboxRequest{
+	return cli.CreateSandbox(withCallMetadata(ctx, apiKey), &pb.CreateSandboxRequest{
 		SandboxId:  sandboxID,
 		CreateJson: createJSON,
 	})
@@ -79,7 +85,7 @@ func StopSandbox(ctx context.Context, target, apiKey string, tlsCfg *TLS, sandbo
 	defer conn.Close()
 
 	cli := pb.NewSandboxControlClient(conn)
-	_, err = cli.StopSandbox(withAPIKey(ctx, apiKey), &pb.StopSandboxRequest{SandboxId: sandboxID})
+	_, err = cli.StopSandbox(withCallMetadata(ctx, apiKey), &pb.StopSandboxRequest{SandboxId: sandboxID})
 	return err
 }
 
@@ -96,6 +102,6 @@ func DeleteSandbox(ctx context.Context, target, apiKey string, tlsCfg *TLS, sand
 	defer conn.Close()
 
 	cli := pb.NewSandboxControlClient(conn)
-	_, err = cli.DeleteSandbox(withAPIKey(ctx, apiKey), &pb.DeleteSandboxRequest{SandboxId: sandboxID})
+	_, err = cli.DeleteSandbox(withCallMetadata(ctx, apiKey), &pb.DeleteSandboxRequest{SandboxId: sandboxID})
 	return err
 }

--- a/internal/api/runnerctl/client_test.go
+++ b/internal/api/runnerctl/client_test.go
@@ -1,0 +1,35 @@
+package runnerctl
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+
+	"github.com/n8n-io/sandbox-service/internal/obs"
+)
+
+func TestWithCallMetadataForwardsTrace(t *testing.T) {
+	const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	ctx := withCallMetadata(obs.WithTraceparent(context.Background(), traceparent), "runner-key")
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatal("outgoing context has no metadata")
+	}
+	if got := md.Get(obs.HeaderTraceparent); len(got) != 1 || got[0] != traceparent {
+		t.Fatalf("traceparent metadata = %v, want [%s]", got, traceparent)
+	}
+	if got := md.Get("x-api-key"); len(got) != 1 || got[0] != "runner-key" {
+		t.Fatalf("x-api-key metadata = %v", got)
+	}
+}
+
+func TestWithCallMetadataWithoutTrace(t *testing.T) {
+	ctx := withCallMetadata(context.Background(), "runner-key")
+
+	md, _ := metadata.FromOutgoingContext(ctx)
+	if got := md.Get(obs.HeaderTraceparent); len(got) != 0 {
+		t.Fatalf("traceparent metadata = %v, want none for an untraced call", got)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -172,8 +172,15 @@ func (r *APIRecorder) SetRunnersRegistered(f func() float64) {
 
 // containerOpBuckets sizes the runner's container-op latency histogram for the
 // observed range: container creation is slow (image pull, dind warm-up) and
-// can take tens of seconds in cold cases, so the upper bound runs to 120s.
-var containerOpBuckets = []float64{0.5, 1, 2, 5, 10, 30, 60, 120}
+// can take tens of seconds in cold cases, so the upper bound runs to 120s. The
+// lower bound has to stay well under a second because Firecracker create and
+// wake are sub-second and would otherwise all land in the first bucket.
+var containerOpBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120}
+
+// lifecycleStepBuckets sizes the per-step histogram. Individual create/wake
+// steps run from a few milliseconds (jail setup) to a couple of seconds
+// (snapshot load on a cold page cache), far below the container-op range.
+var lifecycleStepBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5}
 
 // RunnerRecorder owns the metric instruments emitted by the runner binary.
 type RunnerRecorder struct {
@@ -182,6 +189,7 @@ type RunnerRecorder struct {
 	httpDuration        *prometheus.HistogramVec
 	containerOps        *prometheus.CounterVec
 	containerOpDuration *prometheus.HistogramVec
+	lifecycleSteps      *prometheus.HistogramVec
 }
 
 // NewRunnerRecorder builds the runner recorder. If enabled is false, the
@@ -211,13 +219,24 @@ func NewRunnerRecorder(enabled bool) *RunnerRecorder {
 		},
 		[]string{"operation"},
 	)
-	reg.MustRegister(containerOps, containerOpDuration)
+	lifecycleSteps := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace:   Namespace,
+			Name:        "lifecycle_step_duration_seconds",
+			Help:        "Duration of the individual steps of a sandbox create or wake, labeled by operation and step.",
+			Buckets:     lifecycleStepBuckets,
+			ConstLabels: prometheus.Labels{"role": RoleRunner},
+		},
+		[]string{"operation", "step"},
+	)
+	reg.MustRegister(containerOps, containerOpDuration, lifecycleSteps)
 	return &RunnerRecorder{
 		reg:                 reg,
 		httpRequests:        httpReq,
 		httpDuration:        httpDur,
 		containerOps:        containerOps,
 		containerOpDuration: containerOpDuration,
+		lifecycleSteps:      lifecycleSteps,
 	}
 }
 
@@ -244,6 +263,16 @@ func (r *RunnerRecorder) ObserveContainerOp(operation string, success bool, dur 
 	}
 	r.containerOps.WithLabelValues(operation, resultLabel(success)).Inc()
 	r.containerOpDuration.WithLabelValues(operation).Observe(dur.Seconds())
+}
+
+// ObserveLifecycleStep records how long one step of a create or wake took.
+// Operation matches the container-op labels (OpCreate, OpEnsureRunning) so the
+// steps join the totals; step is a fixed name such as "load_snapshot".
+func (r *RunnerRecorder) ObserveLifecycleStep(operation, step string, dur time.Duration) {
+	if r == nil || r.reg == nil {
+		return
+	}
+	r.lifecycleSteps.WithLabelValues(operation, step).Observe(dur.Seconds())
 }
 
 // SetActiveContainers registers a scrape-time gauge that calls f to read the

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -111,6 +111,29 @@ func TestRunnerRecorderObservations(t *testing.T) {
 	}
 }
 
+func TestRunnerRecorderLifecycleSteps(t *testing.T) {
+	r := NewRunnerRecorder(true)
+
+	r.ObserveLifecycleStep(OpCreate, "clone_rootfs", 30*time.Millisecond)
+	r.ObserveLifecycleStep(OpCreate, "load_snapshot", 120*time.Millisecond)
+	r.ObserveLifecycleStep(OpEnsureRunning, "load_snapshot", 90*time.Millisecond)
+
+	if got := testutil.CollectAndCount(r.lifecycleSteps); got != 3 {
+		t.Errorf("lifecycle_step_duration_seconds series = %d, want 3", got)
+	}
+
+	body := scrape(t, r.Registry())
+	for _, want := range []string{
+		"sandbox_lifecycle_step_duration_seconds",
+		`operation="create",role="runner",step="clone_rootfs"`,
+		`operation="ensure_running",role="runner",step="load_snapshot"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("scrape body missing %q", want)
+		}
+	}
+}
+
 func TestRunnerRecorderDisabled(t *testing.T) {
 	r := NewRunnerRecorder(false)
 	if r.Enabled() {
@@ -118,6 +141,7 @@ func TestRunnerRecorderDisabled(t *testing.T) {
 	}
 	r.ObserveHTTP("/x", http.MethodGet, http.StatusOK, time.Millisecond)
 	r.ObserveContainerOp(OpCreate, true, time.Second)
+	r.ObserveLifecycleStep(OpCreate, "clone_rootfs", time.Millisecond)
 	r.SetActiveContainers(func() float64 { return 1 })
 }
 

--- a/internal/obs/fields.go
+++ b/internal/obs/fields.go
@@ -1,0 +1,54 @@
+package obs
+
+import (
+	"context"
+	"sync"
+)
+
+// Fields collects attributes for the canonical event that a logging middleware
+// emits once per request.
+//
+// The outermost middleware puts a *Fields on the request context; middleware
+// and handlers further in add to it through that pointer. They cannot pass
+// values back any other way, because each of them runs with a request derived
+// from the outer one, whose context the outer middleware never sees.
+type Fields struct {
+	mu sync.Mutex
+	kv []any
+}
+
+type fieldsKey struct{}
+
+// WithFields returns a context carrying a fresh Fields, plus the Fields itself
+// so the caller can read it back when the request is done.
+func WithFields(ctx context.Context) (context.Context, *Fields) {
+	f := &Fields{}
+	return context.WithValue(ctx, fieldsKey{}, f), f
+}
+
+// FieldsFrom returns the Fields carried on ctx, or nil when there is none.
+// Add on a nil *Fields is a no-op, so callers never need a nil check.
+func FieldsFrom(ctx context.Context) *Fields {
+	f, _ := ctx.Value(fieldsKey{}).(*Fields)
+	return f
+}
+
+// Add records one key/value pair for the request's event.
+func (f *Fields) Add(key string, value any) {
+	if f == nil {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.kv = append(f.kv, key, value)
+}
+
+// Attrs returns the collected pairs as a slog-style variadic argument list.
+func (f *Fields) Attrs() []any {
+	if f == nil {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]any(nil), f.kv...)
+}

--- a/internal/obs/fields.go
+++ b/internal/obs/fields.go
@@ -33,14 +33,19 @@ func FieldsFrom(ctx context.Context) *Fields {
 	return f
 }
 
-// Add records one key/value pair for the request's event.
-func (f *Fields) Add(key string, value any) {
+// Add records a key/value pair for the request's event, plus any further pairs
+// passed as trailing arguments: Add("sandbox_id", id, "runner_id", run.ID).
+//
+// A trailing list that does not pair up is left for slog to report, the same as
+// any other malformed argument list handed to it.
+func (f *Fields) Add(key string, value any, more ...any) {
 	if f == nil {
 		return
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.kv = append(f.kv, key, value)
+	f.kv = append(f.kv, more...)
 }
 
 // Attrs returns the collected pairs as a slog-style variadic argument list.

--- a/internal/obs/fields_test.go
+++ b/internal/obs/fields_test.go
@@ -1,0 +1,63 @@
+package obs
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestFieldsCollectedThroughContext(t *testing.T) {
+	ctx, fields := WithFields(context.Background())
+
+	// Simulates a handler deeper in the chain, which only has the context.
+	FieldsFrom(ctx).Add("sandbox_id", "abc")
+	FieldsFrom(ctx).Add("ttfb_ms", int64(12))
+
+	got := fields.Attrs()
+	want := []any{"sandbox_id", "abc", "ttfb_ms", int64(12)}
+	if len(got) != len(want) {
+		t.Fatalf("Attrs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Attrs()[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFieldsWithoutContextIsNoOp(t *testing.T) {
+	FieldsFrom(context.Background()).Add("sandbox_id", "abc")
+	if got := FieldsFrom(context.Background()).Attrs(); got != nil {
+		t.Fatalf("Attrs() = %v, want nil", got)
+	}
+}
+
+func TestFieldsAttrsIsACopy(t *testing.T) {
+	_, fields := WithFields(context.Background())
+	fields.Add("sandbox_id", "abc")
+
+	attrs := fields.Attrs()
+	attrs[1] = "mutated"
+
+	if got := fields.Attrs(); got[1] != "abc" {
+		t.Fatalf("Attrs() = %v, want the caller's mutation not to leak back", got)
+	}
+}
+
+func TestFieldsConcurrentAdd(t *testing.T) {
+	ctx, fields := WithFields(context.Background())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			FieldsFrom(ctx).Add("key", "value")
+		}()
+	}
+	wg.Wait()
+
+	if got := len(fields.Attrs()); got != 16 {
+		t.Fatalf("len(Attrs()) = %d, want 16", got)
+	}
+}

--- a/internal/obs/fields_test.go
+++ b/internal/obs/fields_test.go
@@ -25,6 +25,23 @@ func TestFieldsCollectedThroughContext(t *testing.T) {
 	}
 }
 
+func TestFieldsAddManyPairsAtOnce(t *testing.T) {
+	_, fields := WithFields(context.Background())
+
+	fields.Add("sandbox_id", "abc", "runner_id", "runner-1")
+
+	got := fields.Attrs()
+	want := []any{"sandbox_id", "abc", "runner_id", "runner-1"}
+	if len(got) != len(want) {
+		t.Fatalf("Attrs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Attrs()[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
 func TestFieldsWithoutContextIsNoOp(t *testing.T) {
 	FieldsFrom(context.Background()).Add("sandbox_id", "abc")
 	if got := FieldsFrom(context.Background()).Attrs(); got != nil {

--- a/internal/obs/loghandler.go
+++ b/internal/obs/loghandler.go
@@ -1,0 +1,41 @@
+package obs
+
+import (
+	"context"
+	"log/slog"
+)
+
+// TraceHandler wraps h so that every record logged with a context carrying a
+// traceparent gets a trace_id attribute.
+//
+// It is what makes the diagnostics a request emits along the way joinable with
+// the canonical event for that request: log through the context-taking slog
+// functions (InfoContext, ErrorContext, ...) and the join key comes for free.
+// Records logged without a context, and those from background work that has no
+// trace, are passed through untouched rather than tagged with an empty id.
+func TraceHandler(h slog.Handler) slog.Handler {
+	return traceHandler{Handler: h}
+}
+
+type traceHandler struct {
+	slog.Handler
+}
+
+func (h traceHandler) Handle(ctx context.Context, rec slog.Record) error {
+	if traceID := TraceID(ctx); traceID != "" {
+		rec = rec.Clone()
+		rec.AddAttrs(slog.String("trace_id", traceID))
+	}
+	return h.Handler.Handle(ctx, rec)
+}
+
+// WithAttrs and WithGroup rewrap the derived handler; the embedded methods
+// would return the inner handler and quietly drop the trace id.
+
+func (h traceHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return traceHandler{Handler: h.Handler.WithAttrs(attrs)}
+}
+
+func (h traceHandler) WithGroup(name string) slog.Handler {
+	return traceHandler{Handler: h.Handler.WithGroup(name)}
+}

--- a/internal/obs/loghandler_test.go
+++ b/internal/obs/loghandler_test.go
@@ -1,0 +1,67 @@
+package obs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+)
+
+// traceLogger returns a logger writing JSON through TraceHandler, plus a reader
+// for the single event it recorded.
+func traceLogger(t *testing.T) (*slog.Logger, func() map[string]any) {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := slog.New(TraceHandler(slog.NewJSONHandler(&buf, nil)))
+
+	return logger, func() map[string]any {
+		var event map[string]any
+		if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &event); err != nil {
+			t.Fatalf("log line is not JSON: %v", err)
+		}
+		return event
+	}
+}
+
+func TestTraceHandlerAddsTraceID(t *testing.T) {
+	logger, event := traceLogger(t)
+
+	ctx := WithTraceparent(context.Background(), validTraceparent)
+	logger.ErrorContext(ctx, "create sandbox failed", "sandbox_id", "abc")
+
+	got := event()
+	if got["trace_id"] != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("trace_id = %v, want the trace id of the context's traceparent", got["trace_id"])
+	}
+	if got["sandbox_id"] != "abc" {
+		t.Fatalf("sandbox_id = %v, want the caller's attribute to survive", got["sandbox_id"])
+	}
+}
+
+func TestTraceHandlerLeavesUntracedRecordsAlone(t *testing.T) {
+	logger, event := traceLogger(t)
+
+	logger.Info("idle sweep failed")
+
+	if got, ok := event()["trace_id"]; ok {
+		t.Fatalf("trace_id = %v, want no trace_id on a record logged without a trace", got)
+	}
+}
+
+// The embedded handler's WithAttrs returns the inner handler, so a logger
+// derived with With must keep the wrapper to stay traced.
+func TestTraceHandlerSurvivesWith(t *testing.T) {
+	logger, event := traceLogger(t)
+
+	ctx := WithTraceparent(context.Background(), validTraceparent)
+	logger.With("runner_id", "runner-1").InfoContext(ctx, "create sandbox: runner selected")
+
+	got := event()
+	if got["trace_id"] != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("trace_id = %v, want the derived logger to stay traced", got["trace_id"])
+	}
+	if got["runner_id"] != "runner-1" {
+		t.Fatalf("runner_id = %v, want the derived logger's attribute", got["runner_id"])
+	}
+}

--- a/internal/obs/trace.go
+++ b/internal/obs/trace.go
@@ -1,0 +1,123 @@
+// Package obs carries a W3C trace context across the API and the runner, and
+// collects the fields that make up a request's canonical log event.
+//
+// Nothing here depends on OpenTelemetry. The ids are W3C-shaped so that events
+// carrying them can become spans later without re-instrumenting.
+package obs
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+)
+
+// HeaderTraceparent is the W3C header the API and the runner exchange, both as
+// an HTTP header and as gRPC metadata.
+const HeaderTraceparent = "traceparent"
+
+const (
+	zeroTraceID = "00000000000000000000000000000000"
+	zeroSpanID  = "0000000000000000"
+)
+
+type traceparentKey struct{}
+
+// WithTraceparent returns a context carrying tp.
+func WithTraceparent(ctx context.Context, tp string) context.Context {
+	return context.WithValue(ctx, traceparentKey{}, tp)
+}
+
+// Traceparent returns the traceparent carried on ctx, or "" when there is none.
+// Use it to forward the trace context to the next hop.
+func Traceparent(ctx context.Context) string {
+	tp, _ := ctx.Value(traceparentKey{}).(string)
+	return tp
+}
+
+// TraceID returns just the trace-id field of the traceparent on ctx, which is
+// what log events carry so that events from both processes can be joined.
+func TraceID(ctx context.Context) string {
+	return TraceIDOf(Traceparent(ctx))
+}
+
+// EnsureTraceparent returns the traceparent to use for a request: the inbound
+// header's ids in canonical form when they are usable, and a freshly minted
+// traceparent otherwise.
+//
+// The header is attacker-controlled on public endpoints and we forward it to
+// the runner, so the result is always rebuilt from the four fields we parsed.
+// A caller cannot make us relay bytes of their choosing: what we send on is at
+// most 55 characters of hex drawn from fields we validated.
+func EnsureTraceparent(header string) string {
+	traceID, spanID, flags, ok := parseTraceparent(header)
+	if !ok {
+		return NewTraceparent()
+	}
+	return "00-" + traceID + "-" + spanID + "-" + flags
+}
+
+// NewTraceparent mints a sampled traceparent with random trace and span ids.
+func NewTraceparent() string {
+	return "00-" + randomHex(16) + "-" + randomHex(8) + "-01"
+}
+
+// TraceIDOf returns the trace-id field of a traceparent header value, or ""
+// when the value is not one we adopt.
+func TraceIDOf(tp string) string {
+	traceID, _, _, _ := parseTraceparent(tp)
+	return traceID
+}
+
+// parseTraceparent splits a traceparent into the fields we understand. SplitN
+// caps the slice at five regardless of how long the header is, so an oversized
+// header costs nothing to reject.
+func parseTraceparent(tp string) (traceID, spanID, flags string, ok bool) {
+	parts := strings.SplitN(tp, "-", 5)
+	if len(parts) < 4 {
+		return "", "", "", false
+	}
+	version := parts[0]
+	traceID, spanID, flags = parts[1], parts[2], parts[3]
+	// Version ff is forbidden by the spec. Version 00 has exactly four fields;
+	// later versions may append more, which we drop rather than relay.
+	if !isHex(version, 2) || version == "ff" {
+		return "", "", "", false
+	}
+	if version == "00" && len(parts) != 4 {
+		return "", "", "", false
+	}
+	if !isHex(traceID, 32) || traceID == zeroTraceID {
+		return "", "", "", false
+	}
+	if !isHex(spanID, 16) || spanID == zeroSpanID {
+		return "", "", "", false
+	}
+	if !isHex(flags, 2) {
+		return "", "", "", false
+	}
+	return traceID, spanID, flags, true
+}
+
+// isHex reports whether s is exactly n lowercase hex digits, which is what the
+// traceparent spec allows.
+func isHex(s string, n int) bool {
+	if len(s) != n {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	// crypto/rand.Read cannot fail: it crashes the program if the system
+	// source is unavailable.
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/obs/trace_test.go
+++ b/internal/obs/trace_test.go
@@ -1,0 +1,111 @@
+package obs
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+const validTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+func TestTraceIDOf(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"valid", validTraceparent, "4bf92f3577b34da6a3ce929d0e0e4736"},
+		{"unsampled flags", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00", "4bf92f3577b34da6a3ce929d0e0e4736"},
+		{"future version with extra fields", "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra-more", "4bf92f3577b34da6a3ce929d0e0e4736"},
+		{"empty", "", ""},
+		{"too few fields", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7", ""},
+		{"version 00 with extra field", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra", ""},
+		{"forbidden version", "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", ""},
+		{"all-zero trace id", "00-00000000000000000000000000000000-00f067aa0ba902b7-01", ""},
+		{"all-zero span id", "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01", ""},
+		{"uppercase hex", "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01", ""},
+		{"short trace id", "00-4bf92f3577b34da6-00f067aa0ba902b7-01", ""},
+		{"not hex", "00-4bf92f3577b34da6a3ce929d0e0e473g-00f067aa0ba902b7-01", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TraceIDOf(tc.header); got != tc.want {
+				t.Fatalf("TraceIDOf(%q) = %q, want %q", tc.header, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEnsureTraceparentKeepsValidHeader(t *testing.T) {
+	if got := EnsureTraceparent(validTraceparent); got != validTraceparent {
+		t.Fatalf("EnsureTraceparent() = %q, want the inbound header unchanged", got)
+	}
+}
+
+func TestEnsureTraceparentDropsTrailingFields(t *testing.T) {
+	// A later-version header carries fields we do not understand. We adopt its
+	// ids but must not relay the rest: the header is attacker-controlled and we
+	// forward the result to the runner over HTTP and gRPC.
+	padding := strings.Repeat("a", 4096)
+	got := EnsureTraceparent("01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-" + padding)
+
+	if got != validTraceparent {
+		t.Fatalf("EnsureTraceparent() = %q, want the canonical form %q", got, validTraceparent)
+	}
+	if strings.Contains(got, padding) {
+		t.Fatal("EnsureTraceparent() relayed caller-supplied trailing fields")
+	}
+}
+
+func TestEnsureTraceparentIsBounded(t *testing.T) {
+	for _, header := range []string{
+		"",
+		strings.Repeat("-", 100000),
+		strings.Repeat("00-4bf92f3577b34da6a3ce929d0e0e4736", 1000),
+		"01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-" + strings.Repeat("x", 100000),
+	} {
+		if got := EnsureTraceparent(header); len(got) != 55 {
+			t.Fatalf("EnsureTraceparent(%.20q...) length = %d, want 55", header, len(got))
+		}
+	}
+}
+
+func TestEnsureTraceparentReplacesUnusableHeader(t *testing.T) {
+	// The header is attacker-controlled on public endpoints, so anything that
+	// is not a valid traceparent must be replaced rather than propagated.
+	for _, header := range []string{"", "garbage", "00-00000000000000000000000000000000-00f067aa0ba902b7-01"} {
+		got := EnsureTraceparent(header)
+		if got == header {
+			t.Fatalf("EnsureTraceparent(%q) propagated the unusable header", header)
+		}
+		if TraceIDOf(got) == "" {
+			t.Fatalf("EnsureTraceparent(%q) = %q, which is not a valid traceparent", header, got)
+		}
+	}
+}
+
+func TestNewTraceparentIsUnique(t *testing.T) {
+	first, second := NewTraceparent(), NewTraceparent()
+	if first == second {
+		t.Fatal("NewTraceparent() returned the same value twice")
+	}
+}
+
+func TestContextRoundTrip(t *testing.T) {
+	ctx := WithTraceparent(context.Background(), validTraceparent)
+	if got := Traceparent(ctx); got != validTraceparent {
+		t.Fatalf("Traceparent() = %q, want %q", got, validTraceparent)
+	}
+	if got := TraceID(ctx); got != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("TraceID() = %q", got)
+	}
+}
+
+func TestContextWithoutTraceIsEmpty(t *testing.T) {
+	if got := Traceparent(context.Background()); got != "" {
+		t.Fatalf("Traceparent() = %q, want empty", got)
+	}
+	if got := TraceID(context.Background()); got != "" {
+		t.Fatalf("TraceID() = %q, want empty", got)
+	}
+}

--- a/internal/runner/app/app.go
+++ b/internal/runner/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/n8n-io/sandbox-service/internal/api/grpc/pb"
 	"github.com/n8n-io/sandbox-service/internal/grpctls"
 	"github.com/n8n-io/sandbox-service/internal/metrics"
+	"github.com/n8n-io/sandbox-service/internal/obs"
 	"github.com/n8n-io/sandbox-service/internal/runner"
 	"github.com/n8n-io/sandbox-service/internal/runner/config"
 	"github.com/n8n-io/sandbox-service/internal/runner/register"
@@ -28,7 +29,7 @@ type RuntimeFactory func(*config.Config) (runnerruntime.Runtime, error)
 func Main(runtimeName string, factory RuntimeFactory) {
 	var logLevel slog.LevelVar
 	logLevel.Set(slog.LevelInfo)
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel}))
+	logger := slog.New(obs.TraceHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel})))
 	slog.SetDefault(logger)
 
 	cfg, err := config.Load()

--- a/internal/runner/grpc_control.go
+++ b/internal/runner/grpc_control.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/n8n-io/sandbox-service/internal/api/grpc/pb"
 	"github.com/n8n-io/sandbox-service/internal/metrics"
+	"github.com/n8n-io/sandbox-service/internal/obs"
 	"github.com/n8n-io/sandbox-service/internal/runner/config"
 	runnerruntime "github.com/n8n-io/sandbox-service/internal/runner/runtime"
 )
@@ -37,6 +38,20 @@ func toGRPCError(err error) error {
 		return status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error())
 	}
 	return status.Errorf(codes.Internal, "%v", err)
+}
+
+// withTrace carries the API's trace context into the runtime call so the
+// lifecycle event the runner emits joins the API's event for the same request.
+// A missing or malformed header yields a fresh id, so events always correlate
+// internally even when the caller sends nothing.
+func withTrace(ctx context.Context) context.Context {
+	header := ""
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if v := md.Get(obs.HeaderTraceparent); len(v) > 0 {
+			header = v[0]
+		}
+	}
+	return obs.WithTraceparent(ctx, obs.EnsureTraceparent(header))
 }
 
 func (s *SandboxControlGRPC) checkAPIKey(ctx context.Context) error {
@@ -69,6 +84,7 @@ func (s *SandboxControlGRPC) CreateSandbox(ctx context.Context, req *pb.CreateSa
 	if !isValidID(sandboxID) {
 		return nil, status.Error(codes.InvalidArgument, "invalid sandbox id")
 	}
+	ctx = withTrace(ctx)
 	start := time.Now()
 	info, err := s.Runtime.CreateSandbox(ctx, sandboxID, &runnerruntime.CreateOptions{})
 	s.Rec.ObserveContainerOp(metrics.OpCreate, err == nil && info != nil, time.Since(start))
@@ -90,6 +106,7 @@ func (s *SandboxControlGRPC) StopSandbox(ctx context.Context, req *pb.StopSandbo
 	if !isValidID(sandboxID) {
 		return nil, status.Error(codes.InvalidArgument, "invalid sandbox id")
 	}
+	ctx = withTrace(ctx)
 	start := time.Now()
 	if err := s.Runtime.StopSandbox(ctx, sandboxID); err != nil {
 		if errors.Is(err, runnerruntime.ErrSandboxNotFound) {
@@ -112,6 +129,7 @@ func (s *SandboxControlGRPC) DeleteSandbox(ctx context.Context, req *pb.DeleteSa
 	if !isValidID(sandboxID) {
 		return nil, status.Error(codes.InvalidArgument, "invalid sandbox id")
 	}
+	ctx = withTrace(ctx)
 	start := time.Now()
 	err := s.Runtime.DeleteSandbox(ctx, sandboxID)
 	s.Rec.ObserveContainerOp(metrics.OpDelete, err == nil, time.Since(start))

--- a/internal/runner/grpc_control_trace_test.go
+++ b/internal/runner/grpc_control_trace_test.go
@@ -1,0 +1,65 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+
+	"github.com/n8n-io/sandbox-service/internal/api/grpc/pb"
+	"github.com/n8n-io/sandbox-service/internal/metrics"
+	"github.com/n8n-io/sandbox-service/internal/obs"
+	"github.com/n8n-io/sandbox-service/internal/runner/config"
+)
+
+type traceCapturingRuntime struct {
+	fakeRuntime
+	traceID string
+}
+
+func (r *traceCapturingRuntime) StopSandbox(ctx context.Context, _ string) error {
+	r.traceID = obs.TraceID(ctx)
+	return nil
+}
+
+func stopWithMetadata(t *testing.T, pairs ...string) string {
+	t.Helper()
+	rt := &traceCapturingRuntime{}
+	srv := &SandboxControlGRPC{
+		Runtime: rt,
+		Cfg:     &config.Config{APIKeys: map[string]struct{}{"runner-key": {}}},
+		Rec:     metrics.NewRunnerRecorder(false),
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(pairs...))
+	if _, err := srv.StopSandbox(ctx, &pb.StopSandboxRequest{SandboxId: "11111111-1111-4111-8111-111111111111"}); err != nil {
+		t.Fatalf("StopSandbox() failed: %v", err)
+	}
+	return rt.traceID
+}
+
+func TestSandboxControlGRPCAdoptsCallerTrace(t *testing.T) {
+	got := stopWithMetadata(t,
+		"x-api-key", "runner-key",
+		obs.HeaderTraceparent, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+	)
+	if got != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("runtime trace id = %q, want the caller's trace id", got)
+	}
+}
+
+func TestSandboxControlGRPCMintsTraceWhenCallerSendsNone(t *testing.T) {
+	if got := stopWithMetadata(t, "x-api-key", "runner-key"); len(got) != 32 {
+		t.Fatalf("runtime trace id = %q, want a freshly minted id", got)
+	}
+}
+
+func TestSandboxControlGRPCReplacesMalformedTrace(t *testing.T) {
+	got := stopWithMetadata(t,
+		"x-api-key", "runner-key",
+		obs.HeaderTraceparent, "not-a-traceparent",
+	)
+	if len(got) != 32 {
+		t.Fatalf("runtime trace id = %q, want a freshly minted id", got)
+	}
+}

--- a/internal/runner/middleware_logging.go
+++ b/internal/runner/middleware_logging.go
@@ -4,9 +4,13 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/n8n-io/sandbox-service/internal/obs"
 )
 
-// LoggingMiddleware logs HTTP requests.
+// LoggingMiddleware establishes the request's trace context from the header the
+// API forwards, so lifecycle events emitted deeper in the runner carry the same
+// trace id, and logs one line per request.
 func LoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -14,12 +18,16 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+		traceparent := obs.EnsureTraceparent(r.Header.Get(obs.HeaderTraceparent))
+		r = r.WithContext(obs.WithTraceparent(r.Context(), traceparent))
+
 		start := time.Now()
 		next.ServeHTTP(w, r)
 		slog.Info("request",
+			"trace_id", obs.TraceIDOf(traceparent),
 			"method", r.Method,
 			"path", r.URL.Path,
-			"duration", time.Since(start),
+			"duration_ms", time.Since(start).Milliseconds(),
 		)
 	})
 }

--- a/internal/runner/runtime/firecracker.ee/runtime.go
+++ b/internal/runner/runtime/firecracker.ee/runtime.go
@@ -248,19 +248,24 @@ func (r *Runtime) CreateSandbox(ctx context.Context, sandboxID string, _ *runner
 		_ = r.deleteSandbox(ctx, state)
 	}
 
+	timer := newStepTimer(metrics.OpCreate, r.metrics)
 	templateRootfs := filepath.Join(r.config.TemplateDir, "rootfs.ext4")
 	slog.Debug("firecracker cloning rootfs", "sandbox_id", sandboxID, "template", templateRootfs, "dest", state.rootfsPath)
-	if err := r.deps.cloneRootfs(ctx, templateRootfs, state.rootfsPath); err != nil {
+	if err := timer.step(stepCloneRootfs, func() error {
+		return r.deps.cloneRootfs(ctx, templateRootfs, state.rootfsPath)
+	}); err != nil {
 		cleanupOnError()
 		return nil, fmt.Errorf("clone sandbox rootfs: %w", err)
 	}
 	slog.Debug("firecracker cloning golden snapshot", "sandbox_id", sandboxID, "data_dir", state.dataDir)
-	if err := r.deps.cloneGoldenSnapshot(ctx, r.config.SnapshotMemPath, r.config.SnapshotStatePath, state.dataDir); err != nil {
+	if err := timer.step(stepCloneSnapshot, func() error {
+		return r.deps.cloneGoldenSnapshot(ctx, r.config.SnapshotMemPath, r.config.SnapshotStatePath, state.dataDir)
+	}); err != nil {
 		cleanupOnError()
 		return nil, fmt.Errorf("clone sandbox snapshot assets: %w", err)
 	}
 
-	if err := r.activateSandboxVM(ctx, state); err != nil {
+	if err := r.activateSandboxVM(ctx, state, timer); err != nil {
 		cleanupOnError()
 		return nil, err
 	}
@@ -269,7 +274,13 @@ func (r *Runtime) CreateSandbox(ctx context.Context, sandboxID string, _ *runner
 	state.running = true
 	info := *state.info
 	r.mu.Unlock()
-	slog.Info("firecracker sandbox created", "sandbox_id", sandboxID, "vm_id", state.vmID, "slot", state.slot, "daemon_url", state.daemonURL)
+	slog.Info("firecracker sandbox created",
+		append([]any{
+			"sandbox_id", sandboxID,
+			"vm_id", state.vmID,
+			"slot", state.slot,
+			"daemon_url", state.daemonURL,
+		}, timer.attrsFor(ctx)...)...)
 	return &info, nil
 }
 

--- a/internal/runner/runtime/firecracker.ee/steps.go
+++ b/internal/runner/runtime/firecracker.ee/steps.go
@@ -1,0 +1,68 @@
+package firecracker
+
+import (
+	"context"
+	"time"
+
+	"github.com/n8n-io/sandbox-service/internal/metrics"
+	"github.com/n8n-io/sandbox-service/internal/obs"
+)
+
+// Step names recorded for a create or a wake. They are the label values of
+// sandbox_lifecycle_step_duration_seconds and the field names on the create and
+// wake events, so they are fixed strings rather than derived from anything.
+const (
+	stepCloneRootfs   = "clone_rootfs"
+	stepCloneSnapshot = "clone_snapshot"
+	stepPrepareJail   = "prepare_jail"
+	stepSetupNetwork  = "setup_network"
+	stepStartJailer   = "start_jailer"
+	stepWaitSocket    = "wait_socket"
+	stepLoadSnapshot  = "load_snapshot"
+	stepStartProxy    = "start_proxy"
+	stepProbeDaemon   = "probe_daemon"
+)
+
+// stepTimer measures each phase of one create or wake. The durations go to the
+// per-step histogram, for fleet-wide percentiles, and to the event the runtime
+// logs when the operation finishes, which is where a single slow create can be
+// taken apart after the fact.
+type stepTimer struct {
+	op    string
+	rec   *metrics.RunnerRecorder
+	start time.Time
+	attrs []any
+}
+
+func newStepTimer(op string, rec *metrics.RunnerRecorder) *stepTimer {
+	return &stepTimer{op: op, rec: rec, start: time.Now()}
+}
+
+// step runs fn, recording how long it took under name. The error is returned
+// untouched so callers keep their own wrapping.
+func (t *stepTimer) step(name string, fn func() error) error {
+	if t == nil {
+		return fn()
+	}
+	stepStart := time.Now()
+	err := fn()
+	dur := time.Since(stepStart)
+	t.attrs = append(t.attrs, name+"_ms", dur.Milliseconds())
+	t.rec.ObserveLifecycleStep(t.op, name, dur)
+	return err
+}
+
+// attrsFor returns the log attributes for the finished operation: the trace id
+// that ties this event to the API's event for the same request, the operation,
+// its total duration, and every step measured along the way.
+func (t *stepTimer) attrsFor(ctx context.Context) []any {
+	if t == nil {
+		return nil
+	}
+	attrs := []any{
+		"trace_id", obs.TraceID(ctx),
+		"op", t.op,
+		"total_ms", time.Since(t.start).Milliseconds(),
+	}
+	return append(attrs, t.attrs...)
+}

--- a/internal/runner/runtime/firecracker.ee/steps_test.go
+++ b/internal/runner/runtime/firecracker.ee/steps_test.go
@@ -1,0 +1,134 @@
+package firecracker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/n8n-io/sandbox-service/internal/metrics"
+	"github.com/n8n-io/sandbox-service/internal/obs"
+)
+
+const testTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+// captureLifecycleEvents redirects the default logger into a buffer and returns
+// the lifecycle events logged with the given message.
+func captureLifecycleEvents(t *testing.T) func(msg string) []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	return func(msg string) []map[string]any {
+		var events []map[string]any
+		for _, line := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n")) {
+			if len(line) == 0 {
+				continue
+			}
+			var event map[string]any
+			if err := json.Unmarshal(line, &event); err != nil {
+				t.Fatalf("log line is not JSON: %v", err)
+			}
+			if event["msg"] == msg {
+				events = append(events, event)
+			}
+		}
+		return events
+	}
+}
+
+func requireStepFields(t *testing.T, event map[string]any, steps ...string) {
+	t.Helper()
+	for _, step := range steps {
+		if _, ok := event[step+"_ms"]; !ok {
+			t.Fatalf("event is missing %s_ms: %v", step, event)
+		}
+	}
+	if _, ok := event["total_ms"]; !ok {
+		t.Fatalf("event is missing total_ms: %v", event)
+	}
+}
+
+func TestCreateSandboxEmitsStepTimings(t *testing.T) {
+	events := captureLifecycleEvents(t)
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+	rt.SetMetricsRecorder(metrics.NewRunnerRecorder(true))
+
+	ctx := obs.WithTraceparent(context.Background(), testTraceparent)
+	if _, err := rt.CreateSandbox(ctx, "sandbox-id-123456", nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+
+	created := events("firecracker sandbox created")
+	if len(created) != 1 {
+		t.Fatalf("got %d create events, want 1", len(created))
+	}
+	if got := created[0]["trace_id"]; got != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("create event trace_id = %v, want the caller's trace id", got)
+	}
+	if got := created[0]["op"]; got != metrics.OpCreate {
+		t.Fatalf("create event op = %v, want %q", got, metrics.OpCreate)
+	}
+	requireStepFields(t, created[0],
+		stepCloneRootfs, stepCloneSnapshot, stepPrepareJail, stepSetupNetwork,
+		stepStartJailer, stepWaitSocket, stepLoadSnapshot, stepStartProxy, stepProbeDaemon)
+}
+
+func TestEnsureSandboxRunningEmitsStepTimings(t *testing.T) {
+	events := captureLifecycleEvents(t)
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+	if err := rt.StopSandbox(context.Background(), sandboxID); err != nil {
+		t.Fatalf("StopSandbox() failed: %v", err)
+	}
+
+	ctx := obs.WithTraceparent(context.Background(), testTraceparent)
+	if err := rt.EnsureSandboxRunning(ctx, sandboxID); err != nil {
+		t.Fatalf("EnsureSandboxRunning() failed: %v", err)
+	}
+
+	woke := events("firecracker sandbox woke")
+	if len(woke) != 1 {
+		t.Fatalf("got %d wake events, want 1", len(woke))
+	}
+	if got := woke[0]["trace_id"]; got != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("wake event trace_id = %v, want the caller's trace id", got)
+	}
+	if got := woke[0]["op"]; got != metrics.OpEnsureRunning {
+		t.Fatalf("wake event op = %v, want %q", got, metrics.OpEnsureRunning)
+	}
+	requireStepFields(t, woke[0],
+		stepPrepareJail, stepSetupNetwork, stepStartJailer,
+		stepWaitSocket, stepLoadSnapshot, stepStartProxy, stepProbeDaemon)
+	// A wake reuses the sandbox's disk, so it must not repeat the clone steps.
+	if _, ok := woke[0][stepCloneRootfs+"_ms"]; ok {
+		t.Fatalf("wake event records a rootfs clone: %v", woke[0])
+	}
+}
+
+func TestStepTimingsWorkWithoutRecorder(t *testing.T) {
+	events := captureLifecycleEvents(t)
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+
+	if _, err := rt.CreateSandbox(context.Background(), "sandbox-id-123456", nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+
+	created := events("firecracker sandbox created")
+	if len(created) != 1 {
+		t.Fatalf("got %d create events, want 1", len(created))
+	}
+	if got, ok := created[0]["trace_id"]; !ok || got != "" {
+		t.Fatalf("create event trace_id = %v, want empty for an untraced call", got)
+	}
+}

--- a/internal/runner/runtime/firecracker.ee/stop_wake.go
+++ b/internal/runner/runtime/firecracker.ee/stop_wake.go
@@ -85,7 +85,11 @@ func (r *Runtime) EnsureSandboxRunning(ctx context.Context, sandboxID string) er
 		return err
 	}
 	_, err, _ := r.wakeGroup.Do(sandboxID, func() (interface{}, error) {
-		wakeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		// The wake outlives the request that triggered it, so it runs on a
+		// detached context. WithoutCancel keeps the trace context, which the
+		// wake event needs. Concurrent callers share one wake, so the event
+		// carries the trace id of whichever caller started it.
+		wakeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
 		defer cancel()
 		return nil, r.ensureSandboxRunningOnce(wakeCtx, sandboxID)
 	})
@@ -116,7 +120,8 @@ func (r *Runtime) ensureSandboxRunningOnce(ctx context.Context, sandboxID string
 	state.socketPath = socketPath
 	state.daemonURL = daemonURL
 
-	if err := r.activateSandboxVM(ctx, state); err != nil {
+	timer := newStepTimer(metrics.OpEnsureRunning, r.metrics)
+	if err := r.activateSandboxVM(ctx, state, timer); err != nil {
 		_ = r.teardownRunningVM(ctx, state)
 		r.mu.Lock()
 		state.running = false
@@ -135,37 +140,51 @@ func (r *Runtime) ensureSandboxRunningOnce(ctx context.Context, sandboxID string
 	state.running = true
 	state.stopped = false
 	r.mu.Unlock()
-	slog.Info("firecracker sandbox woke", "sandbox_id", sandboxID, "vm_id", state.vmID, "slot", slot)
+	slog.Info("firecracker sandbox woke",
+		append([]any{"sandbox_id", sandboxID, "vm_id", state.vmID, "slot", slot}, timer.attrsFor(ctx)...)...)
 	return nil
 }
 
 // activateSandboxVM prepares jail/netns, starts Firecracker, loads snapshot, and
-// exposes the guest daemon through the host proxy.
-func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState) error {
-	if err := r.prepareJail(ctx, state); err != nil {
+// exposes the guest daemon through the host proxy. Each phase is timed through
+// t, which the caller emits once the operation finishes.
+func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState, t *stepTimer) error {
+	if err := t.step(stepPrepareJail, func() error { return r.prepareJail(ctx, state) }); err != nil {
 		return fmt.Errorf("prepare firecracker jail: %w", err)
 	}
-	if err := r.setupNetwork(ctx, state); err != nil {
+	if err := t.step(stepSetupNetwork, func() error { return r.setupNetwork(ctx, state) }); err != nil {
 		return fmt.Errorf("setup firecracker network: %w", err)
 	}
-	process, err := r.startJailer(ctx, state)
+	var process process
+	err := t.step(stepStartJailer, func() error {
+		var startErr error
+		process, startErr = r.startJailer(ctx, state)
+		return startErr
+	})
 	if err != nil {
 		return fmt.Errorf("start firecracker jailer: %w", err)
 	}
 	state.process = process
-	if err := r.waitForSocket(ctx, state.socketPath); err != nil {
+	if err := t.step(stepWaitSocket, func() error { return r.waitForSocket(ctx, state.socketPath) }); err != nil {
 		return fmt.Errorf("wait for firecracker socket: %w", err)
 	}
-	if err := r.deps.loadSnapshot(ctx, state.socketPath, r.config); err != nil {
+	if err := t.step(stepLoadSnapshot, func() error {
+		return r.deps.loadSnapshot(ctx, state.socketPath, r.config)
+	}); err != nil {
 		return fmt.Errorf("load firecracker snapshot: %w", err)
 	}
 	guestAddr := net.JoinHostPort(r.config.GuestIP, fmt.Sprintf("%d", r.config.DaemonPort))
-	proxy, err := r.deps.newProxy(ctx, state.daemonURLAddr(), state.netnsName, guestAddr)
+	var proxy daemonProxy
+	err = t.step(stepStartProxy, func() error {
+		var proxyErr error
+		proxy, proxyErr = r.deps.newProxy(ctx, state.daemonURLAddr(), state.netnsName, guestAddr)
+		return proxyErr
+	})
 	if err != nil {
 		return fmt.Errorf("start firecracker daemon proxy: %w", err)
 	}
 	state.proxy = proxy
-	if err := r.deps.probeDaemon(ctx, state.daemonURL); err != nil {
+	if err := t.step(stepProbeDaemon, func() error { return r.deps.probeDaemon(ctx, state.daemonURL) }); err != nil {
 		return fmt.Errorf("connect to firecracker daemon: %w", err)
 	}
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Measures end-to-end sandbox latency and correlates API, runner, and Firecracker lifecycle with a shared W3C trace id. Previously API and runner logs couldn’t be joined; now each request and lifecycle operation emits one canonical event with step timings and `trace_id` to satisfy CP-2920.

- Establishes/validates `traceparent` on every API request, logs a single JSON `request` event with `trace_id`, method/path/status, `duration_ms`, and adds `tenant_id`, `sandbox_id`, `runner_id`, `ttfb_ms` (execs measure time-to-first-byte). Health/metrics are excluded.
- Forwards a sanitized `traceparent` to the runner on proxied HTTP and gRPC calls; runner control adopts or mints the trace context. Runner HTTP also adopts `traceparent` and logs a minimal `request` with `trace_id` and `duration_ms`.
- Firecracker runtime emits `firecracker sandbox created` and `firecracker sandbox woke` with `trace_id`, `op` (`create`/`ensure_running`), `total_ms`, and per-step fields: `clone_rootfs_ms`, `clone_snapshot_ms`, `prepare_jail_ms`, `setup_network_ms`, `start_jailer_ms`, `wait_socket_ms`, `load_snapshot_ms`, `start_proxy_ms`, `probe_daemon_ms` (wakes skip clone steps). Wakes run on a detached context but keep the originating `trace_id`.
- Adds `sandbox_lifecycle_step_duration_seconds{operation,step}` and refines runner container-op histogram buckets for sub‑second ranges.
- Introduces tracing/field helpers and a log handler that injects `trace_id` into any slog record logged with a traced context; wide test coverage for trace propagation and events.
- Benchmarks: `k6-sandbox-lifecycle.js` gains `SCENARIO=baseline|load`, `ITERATIONS`, `MAX_DURATION`, `WAKE_AFTER`, and a `sandbox_wake_exec_duration` trend. Docs add API tracing notes, an observability guide (what to join/how), and a performance baseline playbook.

**Ops/Migration**
- No API surface changes. Clients may optionally send a W3C `traceparent`; invalid or future-version values are sanitized or replaced.
- Ensure log pipelines parse JSON and index `trace_id`. Scrape and dashboard `sandbox_lifecycle_step_duration_seconds{operation,step}`.
- To measure wakes with k6, lower idle stop, set `SCENARIO=baseline`, choose `WAKE_AFTER` > idle stop + sweep interval, and size `ITERATIONS`/`MAX_DURATION` accordingly.

<sup>Written for commit 2bebad32d1a0cda9964d5c3f7af50d14269d57c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

