### PR TITLE
feat: document security model and write more security related e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ Registration vs lifecycle: Runners dial the API over gRPC for registration. Sand
 
 Debugging gRPC: See [`docs/grpcurl-debug.md`](docs/grpcurl-debug.md).
 
-Security FAQ (draft): See [`docs/security-faq.md`](docs/security-faq.md).
-
-Weak points + hardening plan (draft): See [`docs/security-weak-points-and-hardening.md`](docs/security-weak-points-and-hardening.md).
+Trust boundaries and non-guarantees: See [`docs/security-model.md`](docs/security-model.md).
 
 Bearer token: Still required in metadata (`Authorization: Bearer …`) in addition to mTLS for registration.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ The n8n Sandbox Service provides isolated execution environments via a REST API.
 ## Reference
 
 - [Architecture](architecture.md) — system design, component overview, communication patterns, and deployment
+- [Security model](security-model.md) — trust boundaries, what is enforced where, and non-guarantees
 - [Configuration](configuration.md) — environment variables for API, Runner, and Daemon
 - [gRPC mTLS](../README.md#runner-registration-grpc-mtls) — certificate bootstrap, rotation, and trust model
 - [REST API](API.md) — endpoint reference

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,6 +181,8 @@ File read, write, list, stat, copy, move, and delete follow the same two-hop rev
 
 ## Security Model
 
+See [security-model.md](security-model.md) for the trust boundaries behind these mechanisms and the non-guarantees that come with them.
+
 | Layer | Mechanism | Purpose |
 | --- | --- | --- |
 | Client → API | `X-Api-Key` (admin env keys or hashed tenant keys) | Authenticate and authorize API consumers |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,150 @@
+# Security Model
+
+What the sandbox service isolates, where each boundary is enforced, and what it
+explicitly does not promise. [architecture.md](architecture.md) has a summary
+table of the same mechanisms; this document is the longer form, aimed at anyone
+reviewing the service or deciding what it is safe to run on it.
+
+## Trust boundaries
+
+Three boundaries carry the isolation guarantees. They are enforced by different
+components and fail in different ways.
+
+| Boundary | Enforced by | Protects against |
+| --- | --- | --- |
+| Client → API | API key auth and per-request tenant checks | One tenant reaching another tenant's sandboxes |
+| API → Runner | mTLS and a shared runner API key | Unauthorized control of sandbox lifecycles |
+| Guest → host and network | Network namespaces, iptables, and the container or microVM boundary | Untrusted code escaping its sandbox or reaching other sandboxes |
+
+Everything trusts the layer above it. Sandboxes trust nothing.
+
+## Client to API
+
+The API is the only component that knows about tenants. Every other component
+trusts it to have made the decision correctly.
+
+Requests carry an `X-Api-Key` header. Keys listed in `SANDBOX_API_KEYS` are
+admin keys with full access. All other keys are tenant keys, minted by an admin
+and stored only as a SHA-256 hash alongside an 8-character lookup prefix, so a
+database read does not yield usable credentials. Revocation sets `revoked_at`,
+which the lookup query filters on.
+
+Authorization runs on every sandbox request through `canAccessSandbox` in
+[internal/api/middleware_auth.go](../internal/api/middleware_auth.go):
+
+- Read, delete and all proxied routes (exec and files) load the sandbox record
+  and compare its `tenant_id` against the caller's.
+- List is scoped at the query level with `ListByTenant`.
+- Create sets `tenant_id` from the authenticated identity. A caller cannot
+  assign a sandbox to another tenant.
+- Sandboxes owned by the admin pseudo-tenant are not visible to tenant keys.
+- Admin routes under `/admin` require an admin key.
+
+Cross-tenant and non-existent sandboxes both return `404`, so a tenant cannot
+use the status code to learn whether an ID exists.
+
+## API to runner
+
+Runners do not know about tenants. A runner authenticates its caller and then
+executes what it is asked to do, on the assumption that the API has already
+decided the caller is entitled to it.
+
+Runners register by opening a long-lived gRPC stream to the API, secured with
+mTLS plus a bearer token, and advertise their ID, HTTP base URL and capacity.
+Lifecycle calls go the other way, over the runner's `SandboxControl` gRPC
+listener, which also requires mTLS with a client certificate signed by the
+configured CA, plus an API key in the call metadata. Exec and file traffic is
+proxied over the runner's HTTP listener, which is authenticated by that same
+shared API key.
+
+A runner only acts on sandbox IDs present in its own state, an in-memory map
+for the Firecracker runtime and a Docker label filter for the Sysbox runtime.
+An ID hosted by a different runner returns `404`. Routing is keyed entirely on
+the `{id}` path segment; no request body, header or query parameter can
+redirect a call to a different sandbox.
+
+## Guest to host and network
+
+Sandbox contents are untrusted. Both runtimes block egress to the same list of
+IPv4 destinations, defined once in
+[internal/runner/runtime/netpolicy/private_ranges.go](../internal/runner/runtime/netpolicy/private_ranges.go)
+and covering RFC1918 space, loopback, link-local (which includes the cloud
+metadata endpoint), carrier-grade NAT, benchmarking and reserved space.
+
+The Firecracker runtime gives every slot its own network namespace with a
+dedicated TAP device and veth uplink. The guest subnet is identical in every
+namespace, and there is no bridge between them, so guests have no layer-2 path
+to each other. The blocked ranges are dropped by iptables FORWARD rules inside
+each namespace, which also covers the uplink addresses of other slots and the
+runner's own addresses. Guest kernels boot with IPv6 disabled.
+
+The Sysbox runtime puts sandboxes on a shared Docker bridge created with
+inter-container communication disabled, and adds per-container chains in
+`DOCKER-USER`: an egress chain dropping the same ranges, and an ingress chain
+that only permits the bridge gateway to reach the sandbox daemon port. A third
+chain in `INPUT` drops connections the container opens to the runner host itself,
+which the egress chain cannot cover because `DOCKER-USER` is only consulted for
+forwarded packets, while anything addressed to a host-local address is delivered
+locally. Containers are created with IPv6 disabled.
+
+Within a sandbox, the daemon runs as a non-root user, and file operations are
+path-validated to keep them inside the sandbox.
+
+## Non-guarantees
+
+These are known and accepted. Do not read the section above as implying any of
+them.
+
+**Egress is not restricted to an allowlist.** Sandboxes can reach any public
+address. The blocked ranges above stop a sandbox reaching internal
+infrastructure, not the internet. Configurable per-sandbox allowlists are
+planned, not implemented.
+
+**The runner does not enforce tenancy.** It has no tenant concept at all. Anyone
+holding a runner API key with network access to a runner's HTTP listener can
+operate on any sandbox that runner hosts. Sandboxes themselves cannot reach that
+listener: on Firecracker its addresses sit inside the blocked ranges, and on
+Sysbox the per-container `INPUT` chain drops connections to the host. Runner
+credentials are shared across the fleet rather than issued per runner or per
+tenant, and the HTTP listener uses the API key alone, without mTLS. Deployments
+are expected to keep runner listeners reachable only from the API.
+
+**Client-supplied sandbox IDs leak existence.** Creating a sandbox with an ID
+that already belongs to another tenant returns `409` rather than `404`, so a
+caller can learn that an ID is taken. This is deliberate, so that a client can
+reconnect to its own deterministic IDs. Since IDs are UUIDs, it confirms an ID
+the caller already holds and does not help discover new ones.
+
+**Tenant quotas are not atomic.** `max_sandboxes` is a check-then-act before
+create, so concurrent requests can briefly exceed it.
+
+**Health and metrics endpoints are unauthenticated.** `/healthz` and `/metrics`
+bypass auth on both the API and the runner. They expose fleet-level counters —
+sandbox and runner counts, capacity, request and operation rates — and carry no
+tenant or sandbox identifiers. Sandboxes cannot reach the runner's, per the
+section above; the API serves its own on the public HTTP port, so a deployment
+that enables ingress publishes them. Restrict both to the monitoring system.
+
+**A sandbox escape is a runner compromise.** If code escapes its sandbox, treat
+every sandbox on that runner, and every credential mounted into it, as
+compromised. The Firecracker runtime's boundary is a microVM, which is why it is
+the target runtime for multi-tenant workloads. The macOS development setup runs
+runners privileged and is not an isolation boundary at all.
+
+**Sandboxes do not survive their runner.** If a runner is lost, its sandboxes
+are lost with it.
+
+## Verification
+
+The boundaries above are covered by tests rather than asserted on paper.
+
+| Boundary | Tests |
+| --- | --- |
+| Cross-tenant read, list, delete, exec, files | [internal/api/handlers_tenants_test.go](../internal/api/handlers_tenants_test.go), [internal/api/handlers_proxy_tenant_test.go](../internal/api/handlers_proxy_tenant_test.go), [e2e/tests/sandbox-api.spec.ts](../e2e/tests/sandbox-api.spec.ts) |
+| Client-supplied ID conflicts | [internal/api/handlers_create_sandbox_test.go](../internal/api/handlers_create_sandbox_test.go) |
+| Admin route gating and key revocation | [internal/api/handlers_tenants_test.go](../internal/api/handlers_tenants_test.go) |
+| Sandbox-to-sandbox and blocked-range egress | [e2e/tests/network-isolation.spec.ts](../e2e/tests/network-isolation.spec.ts) |
+| Egress rule generation | [internal/runner/runtime/firecracker.ee/network/egress_test.go](../internal/runner/runtime/firecracker.ee/network/egress_test.go) |
+
+The network isolation suite is untagged, so it runs against both the Sysbox and
+the Firecracker runner.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -79,13 +79,17 @@ each namespace, which also covers the uplink addresses of other slots and the
 runner's own addresses. Guest kernels boot with IPv6 disabled.
 
 The Sysbox runtime puts sandboxes on a shared Docker bridge created with
-inter-container communication disabled, and adds per-container chains in
-`DOCKER-USER`: an egress chain dropping the same ranges, and an ingress chain
-that only permits the bridge gateway to reach the sandbox daemon port. A third
-chain in `INPUT` drops connections the container opens to the runner host itself,
-which the egress chain cannot cover because `DOCKER-USER` is only consulted for
-forwarded packets, while anything addressed to a host-local address is delivered
-locally. Containers are created with IPv6 disabled.
+inter-container communication disabled, and adds two chains covering every
+container on that bridge: an egress chain in `DOCKER-USER` dropping the same
+ranges, and a chain in `INPUT` dropping the connections a container opens to the
+runner host itself. The second is needed because `DOCKER-USER` is only consulted
+for forwarded packets, while anything addressed to a host-local address is
+delivered locally and never reaches the egress chain. Both match on the bridge
+interface rather than on the address the runner assigned, because a sandbox can
+add addresses to its own interface and would otherwise only have to send from a
+different one. A per-container chain, keyed on the container's address as a
+destination, permits only the bridge gateway to reach its daemon port.
+Containers are created with IPv6 disabled.
 
 Within a sandbox, the daemon runs as a non-root user, and file operations are
 path-validated to keep them inside the sandbox.
@@ -104,7 +108,7 @@ planned, not implemented.
 holding a runner API key with network access to a runner's HTTP listener can
 operate on any sandbox that runner hosts. Sandboxes themselves cannot reach that
 listener: on Firecracker its addresses sit inside the blocked ranges, and on
-Sysbox the per-container `INPUT` chain drops connections to the host. Runner
+Sysbox the bridge's `INPUT` chain drops connections to the host. Runner
 credentials are shared across the fleet rather than issued per runner or per
 tenant, and the HTTP listener uses the API key alone, without mTLS. Deployments
 are expected to keep runner listeners reachable only from the API.

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -6,7 +6,7 @@ import { execFileSync } from 'node:child_process';
 
 /** Admin key from env (SANDBOX_API_KEYS). Used to mint tenant keys. */
 export const ADMIN_API_KEY = process.env.SANDBOX_API_KEY || 'test';
-const BASE_URL = process.env.BASE_URL || process.env.BASE_URL_A || 'http://localhost:8080';
+export const BASE_URL = process.env.BASE_URL || process.env.BASE_URL_A || 'http://localhost:8080';
 
 let tenantApiKey: string | null = null;
 let tenantMintPromise: Promise<string> | null = null;

--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -1,6 +1,16 @@
 import { test, expect } from '@playwright/test';
 import './matchers';
-import { createSandbox, deleteSandbox, exec, execWithTransientRetry } from './helpers';
+import {
+  ADMIN_API_KEY,
+  BASE_URL,
+  apiClient,
+  createSandbox,
+  deleteSandbox,
+  exec,
+  execWithTransientRetry,
+} from './helpers';
+import type { SandboxClient } from '@n8n/sandbox-client';
+
 const tcpConnect = (ip: string, port: number = 80, timeout: number = 3) =>
   `curl --connect-timeout ${timeout} -s -o /dev/null http://${ip}:${port}/`;
 
@@ -9,6 +19,12 @@ const tcpConnectV6 = (ip: string, port: number = 443, timeout: number = 3) =>
 
 const resolve = (host: string) =>
   `getent ahostsv4 ${host} | head -1 | awk '{print $1}'`;
+
+// Both runtimes put the gateway at .1 of the sandbox's own /24: the TAP address
+// on Firecracker, the bridge gateway on Sysbox. Deriving it beats reading it,
+// since iproute2 is absent from the image and the Firecracker guest has no
+// /proc/net/route either — the daemon runs as PID 1, so nothing mounts /proc.
+const gatewayOf = (ip: string) => ip.split('.').slice(0, 3).concat('1').join('.');
 
 test.describe('Network isolation', () => {
   test('sandbox can reach public internet', async () => {
@@ -27,11 +43,17 @@ test.describe('Network isolation', () => {
   test('sandbox cannot reach private IPs', async () => {
     const id = await createSandbox();
     try {
+      // One address per blocked range in netpolicy.PrivateRangesV4, except
+      // 127.0.0.0/8: the guest routes loopback to its own lo, so it never
+      // reaches the FORWARD chain and the assertion would prove nothing.
       const privateIPs = [
         '10.0.0.1',
         '172.16.0.1',
         '192.168.1.1',
         '169.254.169.254', // cloud metadata endpoint
+        '100.64.0.1', // carrier-grade NAT
+        '198.18.0.1', // benchmarking
+        '240.0.0.1', // reserved
       ];
 
       for (const ip of privateIPs) {
@@ -43,25 +65,83 @@ test.describe('Network isolation', () => {
     }
   });
 
-  test('sandboxes cannot reach each other', async () => {
+  test('sandboxes cannot reach each other across tenants', async ({ request }) => {
     const id1 = await createSandbox();
-    const id2 = await createSandbox();
+    let otherTenantId: string | undefined;
+    let otherClient: SandboxClient | undefined;
+    let id2: string | undefined;
+
     try {
+      // Sandbox 2 belongs to a second tenant, so this covers the network
+      // boundary and the tenant boundary at the same time.
+      const other = await request.post('/admin/tenants', {
+        headers: { 'X-Api-Key': ADMIN_API_KEY, 'Content-Type': 'application/json' },
+        data: { name: `netiso-${Date.now()}` },
+      });
+      expect(other.status()).toBe(201);
+      const otherBody = await other.json();
+      otherTenantId = otherBody.tenant.id as string;
+      otherClient = apiClient(BASE_URL, otherBody.key.api_key as string);
+
+      id2 = (await otherClient.createSandbox()).id;
+
       // Get sandbox 2's IP
-      const ipResult = await execWithTransientRetry(id2, 'hostname -I', { timeoutMs: 5_000 });
+      const ipResult = await execWithTransientRetry(id2, 'hostname -I', { timeoutMs: 5_000 }, otherClient);
       expect(ipResult).toHaveSucceeded();
       const sandbox2IP = ipResult.stdout.trim();
       expect(sandbox2IP).toBeTruthy();
 
       // Start an HTTP listener in sandbox 2 on port 9999
-      await exec(id2, `node -e "require('http').createServer((q,r)=>r.end('ok')).listen(9999,'0.0.0.0');setTimeout(()=>{},30000)" &`, { timeoutMs: 5_000 });
+      await execWithTransientRetry(
+        id2,
+        `node -e "require('http').createServer((q,r)=>r.end('ok')).listen(9999,'0.0.0.0');setTimeout(()=>{},30000)" &`,
+        { timeoutMs: 5_000 },
+        otherClient,
+      );
 
       // Sandbox 1 should not be able to reach sandbox 2
       const result = await execWithTransientRetry(id1, tcpConnect(sandbox2IP, 9999, 3), { timeoutMs: 10_000 });
       expect(result.exitCode, `expected sandbox 1 to not reach sandbox 2 at ${sandbox2IP}`).not.toBe(0);
     } finally {
-      await deleteSandbox(id1);
-      await deleteSandbox(id2);
+      if (id2 && otherClient) {
+        await deleteSandbox(id2, otherClient).catch(() => undefined);
+      }
+      await deleteSandbox(id1).catch(() => undefined);
+      if (otherTenantId) {
+        await request.delete(`/admin/tenants/${otherTenantId}`, {
+          headers: { 'X-Api-Key': ADMIN_API_KEY },
+        });
+      }
+    }
+  });
+
+  test('sandbox cannot reach the runner', async () => {
+    const id = await createSandbox();
+    try {
+      const ipResult = await execWithTransientRetry(id, 'hostname -I', { timeoutMs: 5_000 });
+      expect(ipResult).toHaveSucceeded();
+      const ownIP = ipResult.stdout.trim().split(/\s+/)[0];
+      expect(ownIP, 'expected the sandbox to report its own IPv4 address').toMatch(
+        /^\d+\.\d+\.\d+\.\d+$/,
+      );
+      const gateway = gatewayOf(ownIP);
+
+      // On Sysbox the gateway is a host address that the runner listens on, so
+      // this is the regression test for the INPUT chain in netrules. On
+      // Firecracker the gateway is the TAP inside the sandbox netns and the
+      // runner is not there at all, so it only asserts that this stays true;
+      // the guest's route to the host is covered by the private-range test.
+      for (const port of [8080, 9091]) {
+        const result = await execWithTransientRetry(id, tcpConnect(gateway, port, 3), {
+          timeoutMs: 10_000,
+        });
+        expect(
+          result.exitCode,
+          `expected runner port ${port} on ${gateway} to be unreachable`,
+        ).not.toBe(0);
+      }
+    } finally {
+      await deleteSandbox(id);
     }
   });
 

--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -14,6 +14,14 @@ import type { SandboxClient } from '@n8n/sandbox-client';
 const tcpConnect = (ip: string, port: number = 80, timeout: number = 3) =>
   `curl --connect-timeout ${timeout} -s -o /dev/null http://${ip}:${port}/`;
 
+// Keeps the response body, so a test can tell which listener answered rather
+// than only whether the connection succeeded.
+const httpGet = (ip: string, port: number, timeout: number = 3) =>
+  `curl --connect-timeout ${timeout} -s http://${ip}:${port}/`;
+
+const httpGetWithRetry = (ip: string, port: number) =>
+  `curl --retry 5 --retry-connrefused --retry-delay 1 --connect-timeout 3 -fsS http://${ip}:${port}/`;
+
 const tcpConnectV6 = (ip: string, port: number = 443, timeout: number = 3) =>
   `curl --connect-timeout ${timeout} -sk -o /dev/null -6 "https://[${ip}]:${port}/"`;
 
@@ -25,6 +33,36 @@ const resolve = (host: string) =>
 // since iproute2 is absent from the image and the Firecracker guest has no
 // /proc/net/route either — the daemon runs as PID 1, so nothing mounts /proc.
 const gatewayOf = (ip: string) => ip.split('.').slice(0, 3).concat('1').join('.');
+
+const siblingOf = (ip: string) => ip.split('.').slice(0, 3).concat('250').join('.');
+
+// Adds a second IPv4 address to eth0 through the legacy ioctl, since iproute2 is
+// absent from the sandbox image. The ':1' label keeps the address secondary, so
+// the sandbox's own address — and with it the daemon connection carrying this
+// exec — survives. Needs CAP_NET_ADMIN, hence sudo.
+const addAddress = (ip: string) =>
+  `sudo -n python3 -c "import fcntl,socket,struct;` +
+  `s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);` +
+  `fcntl.ioctl(s,0x8916,struct.pack('16sH2s4s16s',b'eth0:1',socket.AF_INET,` +
+  `b'\\x00\\x00',socket.inet_aton('${ip}'),b'\\x00'*16))"`;
+
+const tcpConnectFrom = (source: string, ip: string, port: number, timeout: number = 3) =>
+  `curl --interface ${source} --connect-timeout ${timeout} -s -o /dev/null http://${ip}:${port}/`;
+
+// Cleanup runs even when the test body has already failed, so a delete failure
+// is reported softly: throwing here would replace the real error with this one.
+// Returns whether the sandbox is gone, which decides whether its tenant can be
+// deleted at all. 404 is already treated as success by deleteSandbox, and the
+// SDK retries transient failures, so anything reaching here is a real leak.
+const cleanUpSandbox = async (id: string, c?: SandboxClient): Promise<boolean> => {
+  try {
+    await deleteSandbox(id, c);
+    return true;
+  } catch (err) {
+    expect.soft(err, `expected sandbox ${id} to be deleted`).toBeUndefined();
+    return false;
+  }
+};
 
 test.describe('Network isolation', () => {
   test('sandbox can reach public internet', async () => {
@@ -72,8 +110,16 @@ test.describe('Network isolation', () => {
     let id2: string | undefined;
 
     try {
-      // Sandbox 2 belongs to a second tenant, so this covers the network
-      // boundary and the tenant boundary at the same time.
+      // What makes this cross-tenant is the API side: id2 is created and exec'd
+      // with otherClient, and sandbox 1's key cannot name it. The runner has no
+      // tenant concept, so the network side proves only that one sandbox cannot
+      // reach another's listener, by whichever mechanism gets there first. On
+      // Sysbox that is the private-range drop, which covers the whole bridge
+      // subnet before the per-container chains see the packet. On Firecracker
+      // every guest holds the same address, so sandbox 1 ends up dialling
+      // itself. Neither can be narrowed from inside a sandbox, which is why the
+      // positive control below carries the weight: without it the assertion
+      // would also pass if nothing were listening at all.
       const other = await request.post('/admin/tenants', {
         headers: { 'X-Api-Key': ADMIN_API_KEY, 'Content-Type': 'application/json' },
         data: { name: `netiso-${Date.now()}` },
@@ -85,32 +131,56 @@ test.describe('Network isolation', () => {
 
       id2 = (await otherClient.createSandbox()).id;
 
-      // Get sandbox 2's IP
       const ipResult = await execWithTransientRetry(id2, 'hostname -I', { timeoutMs: 5_000 }, otherClient);
       expect(ipResult).toHaveSucceeded();
-      const sandbox2IP = ipResult.stdout.trim();
-      expect(sandbox2IP).toBeTruthy();
+      const sandbox2IP = ipResult.stdout.trim().split(/\s+/)[0];
+      expect(sandbox2IP, 'expected sandbox 2 to report its own IPv4 address').toMatch(
+        /^\d+\.\d+\.\d+\.\d+$/,
+      );
 
-      // Start an HTTP listener in sandbox 2 on port 9999
+      // A per-run token, so reaching sandbox 2's listener is distinguishable
+      // from reaching anything else that happens to answer on that port.
+      const token = `netiso${Date.now()}`;
       await execWithTransientRetry(
         id2,
-        `node -e "require('http').createServer((q,r)=>r.end('ok')).listen(9999,'0.0.0.0');setTimeout(()=>{},30000)" &`,
+        `node -e "require('http').createServer((q,r)=>r.end('${token}')).listen(9999,'0.0.0.0');setTimeout(()=>{},30000)" &`,
         { timeoutMs: 5_000 },
         otherClient,
       );
 
-      // Sandbox 1 should not be able to reach sandbox 2
-      const result = await execWithTransientRetry(id1, tcpConnect(sandbox2IP, 9999, 3), { timeoutMs: 10_000 });
-      expect(result.exitCode, `expected sandbox 1 to not reach sandbox 2 at ${sandbox2IP}`).not.toBe(0);
+      // Positive control. Sandbox 2 reaches the listener on its own address,
+      // which stays inside its netns and so is unaffected by the policy.
+      // --retry-connrefused covers the gap between backgrounding node and the
+      // port being bound.
+      const control = await execWithTransientRetry(
+        id2,
+        httpGetWithRetry(sandbox2IP, 9999),
+        { timeoutMs: 20_000 },
+        otherClient,
+      );
+      expect(
+        control,
+        `expected sandbox 2 to reach its own listener on ${sandbox2IP}:9999`,
+      ).toHaveSucceeded();
+      expect(control.stdout.trim(), 'expected the listener to answer with the token').toBe(token);
+
+      const result = await execWithTransientRetry(id1, httpGet(sandbox2IP, 9999), { timeoutMs: 10_000 });
+      expect(result.exitCode, `expected sandbox 1 to not reach ${sandbox2IP}:9999`).not.toBe(0);
+      expect(result.stdout, "expected sandbox 1 to not receive sandbox 2's response").not.toContain(
+        token,
+      );
     } finally {
-      if (id2 && otherClient) {
-        await deleteSandbox(id2, otherClient).catch(() => undefined);
-      }
-      await deleteSandbox(id1).catch(() => undefined);
-      if (otherTenantId) {
-        await request.delete(`/admin/tenants/${otherTenantId}`, {
+      const sandbox2Gone = id2 && otherClient ? await cleanUpSandbox(id2, otherClient) : true;
+      await cleanUpSandbox(id1);
+
+      // The API refuses to delete a tenant that still owns a sandbox, so the
+      // tenant delete is conditional: attempting it after a failed sandbox
+      // delete would report a conflict rather than the leak behind it.
+      if (otherTenantId && sandbox2Gone) {
+        const res = await request.delete(`/admin/tenants/${otherTenantId}`, {
           headers: { 'X-Api-Key': ADMIN_API_KEY },
         });
+        expect.soft(res.status(), `expected tenant ${otherTenantId} to be deleted`).toBe(204);
       }
     }
   });
@@ -138,6 +208,61 @@ test.describe('Network isolation', () => {
         expect(
           result.exitCode,
           `expected runner port ${port} on ${gateway} to be unreachable`,
+        ).not.toBe(0);
+      }
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+
+  // The host and private-range rules are matched on the bridge interface rather
+  // than on the address the runner assigned, because a sandbox that reaches
+  // CAP_NET_ADMIN can give itself another address and a source-matched rule
+  // would no longer apply to it. Passwordless sudo in the image plus Sysbox's
+  // full capability bounding set are enough to do that, so this asserts the
+  // policy still holds for traffic the runner never handed out an address for.
+  test('sandbox cannot escape the policy by adding an address', async () => {
+    const id = await createSandbox();
+    try {
+      const ipResult = await execWithTransientRetry(id, 'hostname -I', { timeoutMs: 5_000 });
+      expect(ipResult).toHaveSucceeded();
+      const ownIP = ipResult.stdout.trim().split(/\s+/)[0];
+      expect(ownIP, 'expected the sandbox to report its own IPv4 address').toMatch(
+        /^\d+\.\d+\.\d+\.\d+$/,
+      );
+      // An unused address in the sandbox's own subnet, so it stays inside the
+      // NAT source range and looks like a legitimate neighbour to any rule that
+      // matches on addresses.
+      const extraIP = siblingOf(ownIP);
+
+      const added = await execWithTransientRetry(id, addAddress(extraIP), { timeoutMs: 10_000 });
+      test.skip(
+        added.exitCode !== 0,
+        `sandbox cannot add an address (${added.stderr.trim() || 'no stderr'}), so this bypass does not apply to this runtime`,
+      );
+
+      // Establishes that the added address is usable as a source, so a failure
+      // below means the policy blocked the traffic rather than that it never
+      // left the sandbox.
+      const publicResult = await execWithTransientRetry(
+        id,
+        `curl --interface ${extraIP} -fsS -o /dev/null --max-time 15 https://example.com/`,
+        { timeoutMs: 30_000 },
+      );
+      expect(publicResult, `expected ${extraIP} to work as a source address`).toHaveSucceeded();
+
+      const blocked: [string, number][] = [
+        [gatewayOf(ownIP), 8080],
+        [gatewayOf(ownIP), 9091],
+        ['169.254.169.254', 80],
+      ];
+      for (const [ip, port] of blocked) {
+        const result = await execWithTransientRetry(id, tcpConnectFrom(extraIP, ip, port), {
+          timeoutMs: 10_000,
+        });
+        expect(
+          result.exitCode,
+          `expected ${ip}:${port} to be unreachable from the added address ${extraIP}`,
         ).not.toBe(0);
       }
     } finally {

--- a/internal/api/handlers_proxy_tenant_test.go
+++ b/internal/api/handlers_proxy_tenant_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/n8n-io/sandbox-service/internal/api/store"
+)
+
+// TestTenantCannotProxyToOtherTenantSandbox covers the exec and file routes,
+// which unlike GET/DELETE forward to a runner. The upstream counter proves the
+// tenant check runs before anything leaves the API, not just that the status
+// code looks right.
+func TestTenantCannotProxyToOtherTenantSandbox(t *testing.T) {
+	var upstreamHits atomic.Int64
+	runner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer runner.Close()
+
+	router, s := newTestGateway(t, "admin-key")
+	a := mintTenantKey(t, router, `{"name":"a"}`)
+	b := mintTenantKey(t, router, `{"name":"b"}`)
+	keyA, keyB := a.Key.APIKey, b.Key.APIKey
+
+	sid := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	if err := s.Create(&store.SandboxRecord{
+		ID: sid, Status: "running", CreatedAt: 1, LastActiveAt: 1,
+		TenantID: a.Tenant.ID, RunnerHTTPBase: runner.URL,
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	missing := "11111111-2222-3333-4444-555555555555"
+	routes := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodPost, "/executions", `{"command":"echo pwned"}`},
+		{http.MethodGet, "/executions/exec-1", ""},
+		{http.MethodDelete, "/executions/exec-1", ""},
+		{http.MethodGet, "/files", ""},
+		{http.MethodGet, "/files/content?path=/tmp/x", ""},
+		{http.MethodPut, "/files?path=/tmp/x", "pwned"},
+		{http.MethodPost, "/files?path=/tmp/x", "pwned"},
+		{http.MethodDelete, "/files?path=/tmp/x", ""},
+		{http.MethodPost, "/files/copy", `{"src":"/tmp/a","dest":"/tmp/b"}`},
+		{http.MethodPost, "/files/move", `{"src":"/tmp/a","dest":"/tmp/b"}`},
+		{http.MethodPost, "/mkdir?path=/tmp/pwned", ""},
+		{http.MethodGet, "/stat?path=/tmp/x", ""},
+	}
+
+	call := func(method, path, key, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		var req *http.Request
+		if body == "" {
+			req = httptest.NewRequest(method, path, nil)
+		} else {
+			req = httptest.NewRequest(method, path, strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.Header.Set("X-Api-Key", key)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		return rr
+	}
+
+	for _, route := range routes {
+		foreign := call(route.method, "/sandboxes/"+sid+route.path, keyB, route.body)
+		if foreign.Code != http.StatusNotFound {
+			t.Errorf("%s %s as other tenant: expected %d, got %d body=%s",
+				route.method, route.path, http.StatusNotFound, foreign.Code, foreign.Body.String())
+		}
+
+		// A sandbox that never existed must be indistinguishable from one the
+		// caller may not see, or the status becomes an enumeration oracle.
+		absent := call(route.method, "/sandboxes/"+missing+route.path, keyB, route.body)
+		if absent.Code != foreign.Code || absent.Body.String() != foreign.Body.String() {
+			t.Errorf("%s %s: cross-tenant (%d %s) differs from missing (%d %s)",
+				route.method, route.path,
+				foreign.Code, strings.TrimSpace(foreign.Body.String()),
+				absent.Code, strings.TrimSpace(absent.Body.String()))
+		}
+	}
+
+	if hits := upstreamHits.Load(); hits != 0 {
+		t.Fatalf("expected no request to reach the runner, got %d", hits)
+	}
+
+	// The owner still gets through, so the assertion above is about
+	// authorization rather than a proxy that never worked.
+	owner := call(http.MethodGet, "/sandboxes/"+sid+"/files", keyA, "")
+	if owner.Code != http.StatusOK {
+		t.Fatalf("owner proxy: expected %d, got %d body=%s", http.StatusOK, owner.Code, owner.Body.String())
+	}
+	if hits := upstreamHits.Load(); hits != 1 {
+		t.Fatalf("expected exactly one upstream request, got %d", hits)
+	}
+}

--- a/internal/runner/runtime/docker/docker_client.go
+++ b/internal/runner/runtime/docker/docker_client.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	runnerBridgeNetwork      = "runner-bridge"
+	bridgeNameOption         = "com.docker.network.bridge.name"
 	containerLabelManaged    = "sandbox-service.managed"
 	containerLabelManagedVal = "true"
 	containerLabelSandboxID  = "sandbox-service.id"
@@ -43,6 +44,7 @@ type containerState struct {
 }
 
 type networkInspect struct {
+	ID      string            `json:"Id"`
 	Name    string            `json:"Name"`
 	Options map[string]string `json:"Options"`
 	IPAM    struct {
@@ -237,6 +239,23 @@ func (dc *dockerClient) pullImage(ctx context.Context, image string) error {
 func firstGateway(inspect *networkInspect) string {
 	if inspect != nil && len(inspect.IPAM.Config) > 0 {
 		return inspect.IPAM.Config[0].Gateway
+	}
+	return ""
+}
+
+// bridgeInterface returns the host interface backing a Docker bridge network.
+// Networks this runner creates carry the name as an option; ones created by an
+// earlier version do not, and Docker then derives the device from the network
+// ID. netrules verifies the result exists before it builds rules on it.
+func bridgeInterface(inspect *networkInspect) string {
+	if inspect == nil {
+		return ""
+	}
+	if name := inspect.Options[bridgeNameOption]; name != "" {
+		return name
+	}
+	if len(inspect.ID) >= 12 {
+		return "br-" + inspect.ID[:12]
 	}
 	return ""
 }

--- a/internal/runner/runtime/docker/netrules/netrules.go
+++ b/internal/runner/runtime/docker/netrules/netrules.go
@@ -27,8 +27,12 @@ func ingressChainName(containerID string) string {
 	return ChainName(containerID) + "-IN"
 }
 
-// ApplyPolicy configures per-sandbox egress rules plus ingress protection for
-// the daemon port.
+func hostChainName(containerID string) string {
+	return ChainName(containerID) + "-HOST"
+}
+
+// ApplyPolicy configures per-sandbox egress rules, ingress protection for the
+// daemon port, and a block on reaching the runner host itself.
 func ApplyPolicy(containerID, sourceIP, gatewayIP string, daemonPort int) error {
 	if containerID == "" {
 		return fmt.Errorf("container id is required")
@@ -85,6 +89,28 @@ func ApplyPolicy(containerID, sourceIP, gatewayIP string, daemonPort int) error 
 		return fmt.Errorf("append ingress drop: %w", err)
 	}
 
+	// The egress chain cannot protect the runner host. DOCKER-USER is only
+	// consulted for forwarded packets, and anything addressed to a host-local
+	// address (the bridge gateway, the host's own private IP) is delivered via
+	// INPUT instead, so the private-range drops above never see it. Everything
+	// reaching INPUT is locally destined by definition, so dropping this
+	// container's new connections there covers every host address at once.
+	// Established traffic is exempt: the runner dials the sandbox daemon, and
+	// the replies arrive here.
+	hostChain := hostChainName(containerID)
+	if err := run("iptables", "-N", hostChain); err != nil {
+		return fmt.Errorf("create host chain: %w", err)
+	}
+	if err := run("iptables", "-I", "INPUT", "1", "-s", sourceIP+"/32", "-j", hostChain); err != nil {
+		return fmt.Errorf("insert host jump: %w", err)
+	}
+	if err := run("iptables", "-A", hostChain, "-m", "conntrack", "--ctstate", "ESTABLISHED,RELATED", "-j", "ACCEPT"); err != nil {
+		return fmt.Errorf("allow established host traffic: %w", err)
+	}
+	if err := run("iptables", "-A", hostChain, "-j", "DROP"); err != nil {
+		return fmt.Errorf("append host drop: %w", err)
+	}
+
 	return nil
 }
 
@@ -100,14 +126,17 @@ func teardownLocked(containerID string) error {
 		return nil
 	}
 
-	if err := removeJumpReferences(ChainName(containerID)); err != nil {
+	if err := removeJumpReferences("DOCKER-USER", ChainName(containerID)); err != nil {
 		return err
 	}
-	if err := removeJumpReferences(ingressChainName(containerID)); err != nil {
+	if err := removeJumpReferences("DOCKER-USER", ingressChainName(containerID)); err != nil {
+		return err
+	}
+	if err := removeJumpReferences("INPUT", hostChainName(containerID)); err != nil {
 		return err
 	}
 
-	for _, chain := range []string{ChainName(containerID), ingressChainName(containerID)} {
+	for _, chain := range []string{ChainName(containerID), ingressChainName(containerID), hostChainName(containerID)} {
 		_ = run("iptables", "-F", chain)
 		_ = run("iptables", "-X", chain)
 	}
@@ -122,8 +151,8 @@ func ensureDockerUserChain() error {
 	return nil
 }
 
-func removeJumpReferences(chain string) error {
-	out, err := output("iptables", "-S", "DOCKER-USER")
+func removeJumpReferences(parent, chain string) error {
+	out, err := output("iptables", "-S", parent)
 	if err != nil {
 		msg := strings.ToLower(err.Error())
 		if strings.Contains(msg, "no chain/target/match by that name") {
@@ -132,17 +161,18 @@ func removeJumpReferences(chain string) error {
 		return err
 	}
 
+	prefix := "-A " + parent + " "
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		if !strings.Contains(line, "-j "+chain) {
 			continue
 		}
 
 		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "-A DOCKER-USER ") {
+		if !strings.HasPrefix(trimmed, prefix) {
 			continue
 		}
-		args := strings.Fields(strings.TrimPrefix(trimmed, "-A DOCKER-USER "))
-		args = append([]string{"-D", "DOCKER-USER"}, args...)
+		args := strings.Fields(strings.TrimPrefix(trimmed, prefix))
+		args = append([]string{"-D", parent}, args...)
 		_ = run("iptables", args...)
 	}
 	return nil

--- a/internal/runner/runtime/docker/netrules/netrules.go
+++ b/internal/runner/runtime/docker/netrules/netrules.go
@@ -3,6 +3,7 @@ package netrules
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -12,9 +13,15 @@ import (
 
 const chainPrefix = "N8N-SB-"
 
+// Chains shared by every container on the runner bridge.
+const (
+	bridgeEgressChain = chainPrefix + "BR-EGRESS"
+	bridgeHostChain   = chainPrefix + "BR-HOST"
+)
+
 var mu sync.Mutex
 
-// ChainName returns the per-sandbox egress chain name.
+// ChainName returns the base name for a sandbox's own chains.
 func ChainName(containerID string) string {
 	short := containerID
 	if len(short) > 12 {
@@ -31,9 +38,9 @@ func hostChainName(containerID string) string {
 	return ChainName(containerID) + "-HOST"
 }
 
-// ApplyPolicy configures per-sandbox egress rules, ingress protection for the
-// daemon port, and a block on reaching the runner host itself.
-func ApplyPolicy(containerID, sourceIP, gatewayIP string, daemonPort int) error {
+// ApplyPolicy configures the policy shared by every container on the runner
+// bridge plus ingress protection for this container's daemon port.
+func ApplyPolicy(bridgeIface, containerID, sourceIP, gatewayIP string, daemonPort int) error {
 	if containerID == "" {
 		return fmt.Errorf("container id is required")
 	}
@@ -49,30 +56,14 @@ func ApplyPolicy(containerID, sourceIP, gatewayIP string, daemonPort int) error 
 	if err := ensureDockerUserChain(); err != nil {
 		return err
 	}
+	if err := ensureBridgePolicy(bridgeIface); err != nil {
+		return fmt.Errorf("ensure bridge policy: %w", err)
+	}
 	if err := teardownLocked(containerID); err != nil {
 		return err
 	}
 
-	egressChain := ChainName(containerID)
 	ingressChain := ingressChainName(containerID)
-
-	if err := run("iptables", "-N", egressChain); err != nil {
-		return fmt.Errorf("create egress chain: %w", err)
-	}
-	if err := run("iptables", "-I", "DOCKER-USER", "1", "-s", sourceIP+"/32", "-j", egressChain); err != nil {
-		return fmt.Errorf("insert egress jump: %w", err)
-	}
-	if err := run("iptables", "-A", egressChain, "-m", "conntrack", "--ctstate", "ESTABLISHED,RELATED", "-j", "ACCEPT"); err != nil {
-		return fmt.Errorf("allow established traffic: %w", err)
-	}
-	for _, cidr := range netpolicy.PrivateRangesV4 {
-		if err := run("iptables", "-A", egressChain, "-d", cidr, "-j", "DROP"); err != nil {
-			return fmt.Errorf("drop private range %s: %w", cidr, err)
-		}
-	}
-	if err := run("iptables", "-A", egressChain, "-j", "ACCEPT"); err != nil {
-		return fmt.Errorf("append default accept: %w", err)
-	}
 
 	if err := run("iptables", "-N", ingressChain); err != nil {
 		return fmt.Errorf("create ingress chain: %w", err)
@@ -89,29 +80,70 @@ func ApplyPolicy(containerID, sourceIP, gatewayIP string, daemonPort int) error 
 		return fmt.Errorf("append ingress drop: %w", err)
 	}
 
-	// The egress chain cannot protect the runner host. DOCKER-USER is only
-	// consulted for forwarded packets, and anything addressed to a host-local
-	// address (the bridge gateway, the host's own private IP) is delivered via
-	// INPUT instead, so the private-range drops above never see it. Everything
-	// reaching INPUT is locally destined by definition, so dropping this
-	// container's new connections there covers every host address at once.
-	// Established traffic is exempt: the runner dials the sandbox daemon, and
-	// the replies arrive here.
-	hostChain := hostChainName(containerID)
-	if err := run("iptables", "-N", hostChain); err != nil {
-		return fmt.Errorf("create host chain: %w", err)
+	return nil
+}
+
+// ensureBridgePolicy installs the rules that hold for every container on the
+// runner bridge: egress filtering on forwarded traffic, and a block on reaching
+// the runner host itself.
+//
+// Both match on the bridge interface rather than on a container address,
+// because a sandbox controls which address it sends from and would otherwise
+// only have to pick a different one to fall outside the rule. Under Sysbox the
+// capability bounding set is full even for a non-root container process, so the
+// sandbox image's passwordless sudo yields CAP_NET_ADMIN inside the container's
+// own netns, which is enough to add an address to its interface. The interface
+// a packet arrives on is not something the container can choose.
+//
+// The host block lives in INPUT because DOCKER-USER is only consulted for
+// forwarded packets: anything addressed to a host-local address (the bridge
+// gateway, the host's own private IP) is delivered locally and never reaches
+// the egress chain. Everything arriving in INPUT is locally destined by
+// definition, so one drop covers every host address at once. Established
+// traffic is exempt, because the runner dials the sandbox daemon and the
+// replies arrive here.
+func ensureBridgePolicy(bridgeIface string) error {
+	if bridgeIface == "" {
+		return fmt.Errorf("bridge interface is required")
 	}
-	if err := run("iptables", "-I", "INPUT", "1", "-s", sourceIP+"/32", "-j", hostChain); err != nil {
-		return fmt.Errorf("insert host jump: %w", err)
+	if strings.ContainsAny(bridgeIface, "/ ") {
+		return fmt.Errorf("bridge interface %q is not a valid interface name", bridgeIface)
 	}
-	if err := run("iptables", "-A", hostChain, "-m", "conntrack", "--ctstate", "ESTABLISHED,RELATED", "-j", "ACCEPT"); err != nil {
-		return fmt.Errorf("allow established host traffic: %w", err)
-	}
-	if err := run("iptables", "-A", hostChain, "-j", "DROP"); err != nil {
-		return fmt.Errorf("append host drop: %w", err)
+	// iptables accepts a rule naming an interface that does not exist, and that
+	// rule then matches nothing. Every sandbox would run unfiltered with no
+	// error anywhere, so refuse to build the policy instead.
+	if _, err := os.Stat("/sys/class/net/" + bridgeIface); err != nil {
+		return fmt.Errorf("bridge interface %q not found: %w", bridgeIface, err)
 	}
 
-	return nil
+	if err := ensureChain(bridgeEgressChain); err != nil {
+		return err
+	}
+	if err := ensureJump("DOCKER-USER", "-i", bridgeIface, "-j", bridgeEgressChain); err != nil {
+		return err
+	}
+	if err := ensureRule(bridgeEgressChain, "-m", "conntrack", "--ctstate", "ESTABLISHED,RELATED", "-j", "ACCEPT"); err != nil {
+		return err
+	}
+	for _, cidr := range netpolicy.PrivateRangesV4 {
+		if err := ensureRule(bridgeEgressChain, "-d", cidr, "-j", "DROP"); err != nil {
+			return err
+		}
+	}
+	if err := ensureRule(bridgeEgressChain, "-j", "ACCEPT"); err != nil {
+		return err
+	}
+
+	if err := ensureChain(bridgeHostChain); err != nil {
+		return err
+	}
+	if err := ensureJump("INPUT", "-i", bridgeIface, "-j", bridgeHostChain); err != nil {
+		return err
+	}
+	if err := ensureRule(bridgeHostChain, "-m", "conntrack", "--ctstate", "ESTABLISHED,RELATED", "-j", "ACCEPT"); err != nil {
+		return err
+	}
+	return ensureRule(bridgeHostChain, "-j", "DROP")
 }
 
 // Teardown removes per-sandbox iptables rules and chains.
@@ -126,6 +158,9 @@ func teardownLocked(containerID string) error {
 		return nil
 	}
 
+	// The egress and host chains are no longer per container. They are still
+	// torn down here so a runner upgraded in place drops the ones its previous
+	// version left behind.
 	if err := removeJumpReferences("DOCKER-USER", ChainName(containerID)); err != nil {
 		return err
 	}
@@ -141,6 +176,41 @@ func teardownLocked(containerID string) error {
 		_ = run("iptables", "-X", chain)
 	}
 
+	return nil
+}
+
+// ensureChain creates a chain unless it already exists.
+func ensureChain(chain string) error {
+	if err := run("iptables", "-n", "-L", chain); err == nil {
+		return nil
+	}
+	if err := run("iptables", "-N", chain); err != nil {
+		return fmt.Errorf("create chain %s: %w", chain, err)
+	}
+	return nil
+}
+
+// ensureRule appends a rule unless an identical one is already present, so that
+// rebuilding the shared policy never leaves a window in which it is absent for
+// the sandboxes already running under it.
+func ensureRule(chain string, rule ...string) error {
+	if err := run("iptables", append([]string{"-C", chain}, rule...)...); err == nil {
+		return nil
+	}
+	if err := run("iptables", append([]string{"-A", chain}, rule...)...); err != nil {
+		return fmt.Errorf("append rule to %s: %w", chain, err)
+	}
+	return nil
+}
+
+// ensureJump inserts a jump at the top of parent unless it is already present.
+func ensureJump(parent string, rule ...string) error {
+	if err := run("iptables", append([]string{"-C", parent}, rule...)...); err == nil {
+		return nil
+	}
+	if err := run("iptables", append([]string{"-I", parent, "1"}, rule...)...); err != nil {
+		return fmt.Errorf("insert jump into %s: %w", parent, err)
+	}
 	return nil
 }
 

--- a/internal/runner/runtime/docker/runtime.go
+++ b/internal/runner/runtime/docker/runtime.go
@@ -48,9 +48,10 @@ type Runtime struct {
 	runnerConfig  *config.Config
 	config        Config
 	gatewayIP     string
+	bridgeIface   string
 	wakeGroup     singleflight.Group
 	docker        dockerBackend
-	applyPolicy   func(containerID, sourceIP, gatewayIP string, daemonPort int) error
+	applyPolicy   func(bridgeIface, containerID, sourceIP, gatewayIP string, daemonPort int) error
 	teardownRules func(containerID string) error
 	waitForDaemon func(ctx context.Context, baseURL string) error
 	imageReady    atomic.Bool
@@ -71,11 +72,15 @@ func New(runnerConfig *config.Config, cfg Config) (*Runtime, error) {
 		return nil, fmt.Errorf("reconcile managed containers: %w", err)
 	}
 
-	gatewayIP, err := m.ensureRunnerBridge(ctx)
+	bridge, err := m.ensureRunnerBridge(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("ensure runner bridge: %w", err)
 	}
-	m.gatewayIP = gatewayIP
+	m.gatewayIP = firstGateway(bridge)
+	m.bridgeIface = bridgeInterface(bridge)
+	if m.bridgeIface == "" {
+		return nil, fmt.Errorf("cannot determine host interface for network %s", runnerBridgeNetwork)
+	}
 
 	return m, nil
 }
@@ -230,7 +235,7 @@ func (m *Runtime) CreateContainer(ctx context.Context, sandboxID string, opts *C
 		return nil, fmt.Errorf("inspect container ip: %w", err)
 	}
 
-	if err := m.applyPolicy(containerID, containerIP, m.gatewayIP, daemonPort); err != nil {
+	if err := m.applyPolicy(m.bridgeIface, containerID, containerIP, m.gatewayIP, daemonPort); err != nil {
 		cleanupOnError()
 		return nil, fmt.Errorf("apply network rules: %w", err)
 	}
@@ -321,7 +326,7 @@ func (m *Runtime) ensureSandboxRunningOnce(ctx context.Context, sandboxID string
 		m.cleanupWakeFailure(containerID)
 		return err
 	}
-	if err := m.applyPolicy(containerID, containerIP, m.gatewayIP, daemonPort); err != nil {
+	if err := m.applyPolicy(m.bridgeIface, containerID, containerIP, m.gatewayIP, daemonPort); err != nil {
 		m.cleanupWakeFailure(containerID)
 		return fmt.Errorf("apply network rules: %w", err)
 	}
@@ -536,27 +541,26 @@ func (m *Runtime) reconcileContainers(ctx context.Context) error {
 	return nil
 }
 
-func (m *Runtime) ensureRunnerBridge(ctx context.Context) (string, error) {
+func (m *Runtime) ensureRunnerBridge(ctx context.Context) (*networkInspect, error) {
 	inspect, err := m.docker.inspectNetwork(ctx, runnerBridgeNetwork)
 	if err != nil {
 		if !isDockerNotFound(err) {
-			return "", err
+			return nil, err
 		}
 		return m.createRunnerBridge(ctx)
 	}
 
-	return firstGateway(inspect), nil
+	return inspect, nil
 }
 
-func (m *Runtime) createRunnerBridge(ctx context.Context) (string, error) {
-	if _, err := m.docker.run(ctx, "network", "create", "--driver", "bridge", "--opt", "com.docker.network.bridge.enable_icc=false", runnerBridgeNetwork); err != nil {
-		return "", err
+func (m *Runtime) createRunnerBridge(ctx context.Context) (*networkInspect, error) {
+	if _, err := m.docker.run(ctx, "network", "create", "--driver", "bridge",
+		"--opt", "com.docker.network.bridge.enable_icc=false",
+		"--opt", bridgeNameOption+"="+runnerBridgeNetwork,
+		runnerBridgeNetwork); err != nil {
+		return nil, err
 	}
-	inspect, err := m.docker.inspectNetwork(ctx, runnerBridgeNetwork)
-	if err != nil {
-		return "", err
-	}
-	return firstGateway(inspect), nil
+	return m.docker.inspectNetwork(ctx, runnerBridgeNetwork)
 }
 
 // ManagedContainerCount returns how many sandbox containers this runner is managing.

--- a/internal/runner/runtime/docker/runtime_test.go
+++ b/internal/runner/runtime/docker/runtime_test.go
@@ -242,7 +242,7 @@ func TestEnsureSandboxRunningCleansUpStartedContainerOnWakeFailures(t *testing.T
 				ip:             tc.containerIP,
 				containerIPErr: tc.ipErr,
 			})
-			m.applyPolicy = func(gotID, sourceIP, gatewayIP string, port int) error {
+			m.applyPolicy = func(bridgeIface, gotID, sourceIP, gatewayIP string, port int) error {
 				events = append(events, "applyPolicy")
 				if gotID != containerID {
 					t.Fatalf("applyPolicy containerID = %q, want %q", gotID, containerID)
@@ -288,7 +288,7 @@ func TestEnsureSandboxRunningFailedWakeAfterNetworkDetachStopsContainerAndRemove
 			runnerBridgeNetwork,
 		),
 	})
-	m.applyPolicy = func(string, string, string, int) error {
+	m.applyPolicy = func(string, string, string, string, int) error {
 		return fmt.Errorf("unexpected applyPolicy")
 	}
 	m.teardownRules = func(gotID string) error {
@@ -344,7 +344,7 @@ func TestEnsureSandboxRunningDoesNotCleanUpAfterSuccessfulWake(t *testing.T) {
 		containerID: containerID,
 		ip:          "172.18.0.2",
 	})
-	m.applyPolicy = func(string, string, string, int) error {
+	m.applyPolicy = func(string, string, string, string, int) error {
 		events = append(events, "applyPolicy")
 		return nil
 	}


### PR DESCRIPTION
## Summary

* Document security model
* Add more security-related e2e tests
* Fix rules to drop host-local traffic in sysbox setup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the security model and hardens Sysbox network policy to meet CP-2673 tenant isolation. Previously, `DOCKER-USER` only filtered forwarded traffic so sandboxes could reach runner host-local ports; now bridge-level INPUT rules block sandbox-initiated connections to the runner while allowing established traffic.

- Docker runtime: add bridge-wide egress chain in `DOCKER-USER` and a bridge-wide host block in `INPUT`, both matched on the bridge interface; keep per-container ingress chain to allow gateway→daemon only; refuse to apply rules if the bridge iface is missing. Behavior change: runner ports (e.g., 8080, 9091) are unreachable from sandboxes.
- Runner: detect bridge iface via network inspect (use `com.docker.network.bridge.name` or derive `br-<id>`); on create, set the bridge name option; teardown removes legacy per-container jumps from `DOCKER-USER` and `INPUT`.
- API tests: new `internal/api/handlers_proxy_tenant_test.go` proves tenant checks prevent proxying (404) and no request reaches a runner.
- E2E: extend isolation to two tenants with a positive control, assert guests cannot reach the runner via their gateway, expand blocked CIDRs (100.64.0.0/10, 198.18.0.0/15, 240.0.0.0/4), and verify interface-based policy cannot be bypassed by adding an IP; helpers export `BASE_URL` and use `@n8n/sandbox-client`.
- Docs: add `docs/security-model.md` and link it from `README.md` and `docs/architecture.md`, detailing trust boundaries and non-guarantees.

<sup>Written for commit 954a31fce5dca880ba2c641f7c56c3c32f91ec76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

