### PR TITLE
 feat: detect firecracker guest death and free its slot 

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,7 +176,7 @@ Series exposed today:
 - `sandbox_http_requests_total{role,route,method,status}` and `sandbox_http_request_duration_seconds{role,route,method}` (both binaries).
 - API: `sandbox_sandbox_operations_total{operation,result}`, `sandbox_sandboxes_active`, `sandbox_runners_registered`.
 - Runner: `sandbox_container_operations_total{operation,result}`, `sandbox_container_operation_duration_seconds{operation}`, `sandbox_containers_active`.
-- Firecracker runner: `sandbox_lifecycle_step_duration_seconds{operation,step}`, the per-step breakdown of a create or wake, and `sandbox_guest_deaths_total{backend}`, sandbox guests that died on their own. See [observability.md](observability.md).
+- Firecracker runner: `sandbox_lifecycle_step_duration_seconds{operation,step}`, the per-step breakdown of a create or wake, and `sandbox_guest_deaths_total`, sandbox guests that died on their own. See [observability.md](observability.md).
 - Plus the standard `go_*` and `process_*` collectors.
 
 ## Disk quotas

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,7 +176,7 @@ Series exposed today:
 - `sandbox_http_requests_total{role,route,method,status}` and `sandbox_http_request_duration_seconds{role,route,method}` (both binaries).
 - API: `sandbox_sandbox_operations_total{operation,result}`, `sandbox_sandboxes_active`, `sandbox_runners_registered`.
 - Runner: `sandbox_container_operations_total{operation,result}`, `sandbox_container_operation_duration_seconds{operation}`, `sandbox_containers_active`.
-- Firecracker runner: `sandbox_lifecycle_step_duration_seconds{operation,step}`, the per-step breakdown of a create or wake. See [observability.md](observability.md).
+- Firecracker runner: `sandbox_lifecycle_step_duration_seconds{operation,step}`, the per-step breakdown of a create or wake, and `sandbox_guest_deaths_total{backend}`, sandbox guests that died on their own. See [observability.md](observability.md).
 - Plus the standard `go_*` and `process_*` collectors.
 
 ## Disk quotas

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -40,6 +40,7 @@ and what the queries below select on.
 | `request` | Runner | A request proxied from the API (exec, files) finishes |
 | `firecracker sandbox created` | Runner | A sandbox is created and its guest daemon answers |
 | `firecracker sandbox woke` | Runner | A stopped sandbox is restored and its guest daemon answers |
+| `firecracker guest died` | Runner | A microVM exited without the runner stopping it |
 
 The runner's `request` event only records `trace_id`, `method`, `path`, and
 `duration_ms`; the API's is the wide one, and the runner's lifecycle events hold
@@ -99,6 +100,22 @@ Steps, in order:
 
 A wake skips the two clone steps, since the sandbox's disk already exists.
 
+### Runner: guest deaths
+
+`firecracker guest died` is emitted once when a microVM's process exits without
+the runner having killed it — a guest kernel panic, a host `SIGKILL` of the VMM,
+or a reboot from inside the guest. It has no `trace_id`: nothing requested it.
+
+| Field | Notes |
+| --- | --- |
+| `sandbox_id`, `vm_id`, `slot` | Identity of the sandbox and the slot it was on |
+| `err` | The wait error of the exited process, or null on a clean exit |
+
+The runner then tears the dead microVM down and hands its slot back, so the
+sandbox goes on to report as stopped with its files intact. It is not restored
+from its snapshot afterwards: the guest kept writing to the rootfs past the point
+that snapshot was taken. A request for it fails, and the sandbox stays deletable.
+
 ## Metrics
 
 The step timings also go to `sandbox_lifecycle_step_duration_seconds{operation,step}`
@@ -107,6 +124,9 @@ single slow operation, the histogram to see whether it is representative.
 
 Related series:
 
+- `sandbox_guest_deaths_total{backend}` — one increment per
+  `firecracker guest died` event, for alerting on a crash rate the events alone
+  would not surface.
 - `sandbox_container_operation_duration_seconds{operation}` — the totals the
   steps add up to.
 - `sandbox_http_request_duration_seconds{role,route,method}` — end-to-end per

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -124,9 +124,8 @@ single slow operation, the histogram to see whether it is representative.
 
 Related series:
 
-- `sandbox_guest_deaths_total{backend}` — one increment per
-  `firecracker guest died` event, for alerting on a crash rate the events alone
-  would not surface.
+- `sandbox_guest_deaths_total` — one increment per `firecracker guest died`
+  event, for alerting on a crash rate the events alone would not surface.
 - `sandbox_container_operation_duration_seconds{operation}` — the totals the
   steps add up to.
 - `sandbox_http_request_duration_seconds{role,route,method}` — end-to-end per

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -190,6 +190,31 @@ export async function execWithTransientRetry(
   throw new Error(`exec did not recover within ${deadlineMs}ms: ${String(lastErr)}`);
 }
 
+/**
+ * Kills a sandbox's guest from the inside, with no host access.
+ *
+ * `kill -9 1` does not work and fails silently: the kernel drops any signal that
+ * init has installed no handler for, and SIGKILL can never be handled, so the
+ * signal is discarded and the killer still exits 0. SIGTERM is the opposite —
+ * the daemon calls `signal.Notify` for it, so it is delivered, the daemon shuts
+ * down and returns from `main`, and a PID 1 that exits panics the kernel. The
+ * golden boot args carry `panic=1 reboot=k`, so the panic resets the CPU about a
+ * second later and the VM is gone. Signalling PID 1 is permitted because the
+ * daemon drops to uid 1000 at startup and runs execs as that same user.
+ *
+ * On Firecracker the VMM process exits, which is what the runner detects. On
+ * Docker the container exits and its restart policy brings it back.
+ */
+export async function crashGuest(id: string): Promise<void> {
+  await ensureTenantAuth();
+  try {
+    await exec(id, 'kill -TERM 1');
+  } catch {
+    // Shutdown is graceful, so this call normally returns before the guest goes
+    // down — but a dropped connection is the requested outcome, not a failure.
+  }
+}
+
 export async function uploadFile(
   id: string,
   path: string,

--- a/e2e/tests/sandbox-crash-recovery.spec.ts
+++ b/e2e/tests/sandbox-crash-recovery.spec.ts
@@ -32,8 +32,7 @@ function crashHandled(body: string, want: CrashState): boolean {
 
 /**
  * Waits for the runner to notice the guest is gone and finish reacting to it, and
- * returns the scrape it settled on — or the last one taken, so that a caller's own
- * assertions report the real values rather than a bare timeout.
+ * returns the scrape it settled on so a caller can assert further on those values.
  *
  * The death counter is deliberately not the only gate. It is incremented before the
  * handler has even taken the sandbox's transition claim, and the sandbox is marked
@@ -41,6 +40,12 @@ function crashHandled(body: string, want: CrashState): boolean {
  * gate on the counter alone can return while active/stopped still hold their
  * pre-crash values. Both gauges are evaluated at scrape time, which makes them the
  * first honest sign that the crash is fully handled.
+ *
+ * Every condition throws here rather than being left to the caller. Callers treat
+ * this as a precondition, so returning with the crash half-handled would let a test
+ * run on against a sandbox the runner never finished stopping and fail later on
+ * something unrelated — which is the regression these tests exist to catch, reported
+ * as a puzzle. Each condition names what the runner failed to do.
  */
 async function waitForCrashHandled(want: CrashState, timeoutMs = 60_000): Promise<string> {
   const deadline = Date.now() + timeoutMs;
@@ -55,6 +60,16 @@ async function waitForCrashHandled(want: CrashState, timeoutMs = 60_000): Promis
     throw new Error(
       `${GUEST_DEATHS} reached ${deaths}, want >= ${want.deaths} within ${timeoutMs}ms — ` +
         'the guest may not have died, or the runner did not detect it',
+    );
+  }
+  const active = parseGauge(body, ACTIVE);
+  const stopped = parseGauge(body, STOPPED);
+  if (active !== want.active || stopped !== want.stopped) {
+    throw new Error(
+      `${ACTIVE} = ${active} (want ${want.active}) and ${STOPPED} = ${stopped} ` +
+        `(want ${want.stopped}) within ${timeoutMs}ms — the runner counted the death but ` +
+        'never finished handling it: the sandbox was not marked stopped, or its slot was ' +
+        'not released',
     );
   }
   return body;

--- a/e2e/tests/sandbox-crash-recovery.spec.ts
+++ b/e2e/tests/sandbox-crash-recovery.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+import './matchers';
+import {
+  apiRequest,
+  crashGuest,
+  createSandboxWithRetry,
+  deleteSandbox,
+  exec,
+  scrapeRunnerMetrics,
+} from './helpers';
+import { parseCounter, parseGauge } from './metrics-helpers';
+import { FIRECRACKER_ONLY } from './tags';
+
+const GUEST_DEATHS = 'sandbox_guest_deaths_total';
+const ACTIVE = 'sandbox_containers_active';
+const STOPPED = 'sandbox_containers_stopped';
+const RUNNER_LABELS = { role: 'runner' };
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function guestDeaths(): number {
+  return parseCounter(scrapeRunnerMetrics(), GUEST_DEATHS, RUNNER_LABELS);
+}
+
+/**
+ * Waits for the runner to notice the guest is gone. The guest panics a second
+ * after the daemon exits, and the runner then tears the microVM down, so this is
+ * the point from which the sandbox's state is settled.
+ */
+async function waitForGuestDeaths(want: number, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let last = 0;
+  while (Date.now() < deadline) {
+    last = guestDeaths();
+    if (last >= want) return;
+    await sleep(500);
+  }
+  throw new Error(
+    `${GUEST_DEATHS} reached ${last}, want >= ${want} within ${timeoutMs}ms — ` +
+      'the guest may not have died, or the runner did not detect it',
+  );
+}
+
+// Docker detects a dead guest through its own event stream and heals it via the
+// container restart policy, so these assertions are Firecracker-specific until
+// that lands.
+test.describe('Guest crash detection', FIRECRACKER_ONLY, () => {
+  test('a dead guest gives its slot back and leaves the sandbox stopped', async () => {
+    test.skip(
+      !process.env.E2E_RUNNER_HTTP_ADDR && !process.env.E2E_RUNNER_CONTAINER_NAME,
+      'needs runner metrics (E2E_RUNNER_HTTP_ADDR from e2e/run-firecracker.sh)',
+    );
+    test.setTimeout(150_000);
+
+    const before = scrapeRunnerMetrics();
+    const deathsBefore = parseCounter(before, GUEST_DEATHS, RUNNER_LABELS);
+    const activeBefore = parseGauge(before, ACTIVE);
+    const stoppedBefore = parseGauge(before, STOPPED);
+
+    const id = await createSandboxWithRetry();
+    try {
+      expect(await exec(id, `printf '%s' alive`)).toHaveSucceeded();
+      expect(parseGauge(scrapeRunnerMetrics(), ACTIVE)).toBe(activeBefore + 1);
+
+      await crashGuest(id);
+      await waitForGuestDeaths(deathsBefore + 1);
+
+      // The point of tearing down eagerly: a crashed sandbox costs disk and
+      // nothing else, so a client retrying cannot accumulate slots.
+      const after = scrapeRunnerMetrics();
+      expect(parseGauge(after, ACTIVE)).toBe(activeBefore);
+      expect(parseGauge(after, STOPPED)).toBe(stoppedBefore + 1);
+    } finally {
+      // Deleting a crashed sandbox has to succeed: it is already torn down, so a
+      // delete that tried to pause a dead microVM would fail on every attempt.
+      await deleteSandbox(id);
+    }
+  });
+
+  test('a crashed sandbox is refused rather than restored from its stale snapshot', async ({
+    request,
+  }) => {
+    test.skip(
+      !process.env.E2E_RUNNER_HTTP_ADDR && !process.env.E2E_RUNNER_CONTAINER_NAME,
+      'needs runner metrics (E2E_RUNNER_HTTP_ADDR from e2e/run-firecracker.sh)',
+    );
+    test.setTimeout(150_000);
+
+    const deathsBefore = guestDeaths();
+    const id = await createSandboxWithRetry();
+    try {
+      await exec(id, `printf '%s' marker > /tmp/crash-marker`);
+
+      await crashGuest(id);
+      await waitForGuestDeaths(deathsBefore + 1);
+
+      // Restoring the snapshot here would corrupt the rootfs the guest kept
+      // writing to, so the request must fail loudly instead of appearing to
+      // succeed against a stale disk. PR 4 turns this into a 409 once the
+      // sandbox can be cold-booted back.
+      const resp = await apiRequest(request, 'POST', `/sandboxes/${id}/executions`, {
+        data: { command: 'true' },
+      });
+      expect(resp.status).toBe(503);
+      expect(resp.body.toLowerCase()).toContain('crashed');
+
+      // A 503 must not look like a missing sandbox to the API, or it would reap
+      // the store row and the sandbox would vanish instead of being recoverable.
+      const still = await apiRequest(request, 'GET', `/sandboxes/${id}`);
+      expect(still.status).toBe(200);
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+});

--- a/e2e/tests/sandbox-crash-recovery.spec.ts
+++ b/e2e/tests/sandbox-crash-recovery.spec.ts
@@ -20,27 +20,44 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function guestDeaths(): number {
-  return parseCounter(scrapeRunnerMetrics(), GUEST_DEATHS, RUNNER_LABELS);
+type CrashState = { deaths: number; active: number; stopped: number };
+
+function crashHandled(body: string, want: CrashState): boolean {
+  return (
+    parseCounter(body, GUEST_DEATHS, RUNNER_LABELS) >= want.deaths &&
+    parseGauge(body, ACTIVE) === want.active &&
+    parseGauge(body, STOPPED) === want.stopped
+  );
 }
 
 /**
- * Waits for the runner to notice the guest is gone. The guest panics a second
- * after the daemon exits, and the runner then tears the microVM down, so this is
- * the point from which the sandbox's state is settled.
+ * Waits for the runner to notice the guest is gone and finish reacting to it, and
+ * returns the scrape it settled on — or the last one taken, so that a caller's own
+ * assertions report the real values rather than a bare timeout.
+ *
+ * The death counter is deliberately not the only gate. It is incremented before the
+ * handler has even taken the sandbox's transition claim, and the sandbox is marked
+ * stopped and its slot handed back only after the microVM has been torn down, so a
+ * gate on the counter alone can return while active/stopped still hold their
+ * pre-crash values. Both gauges are evaluated at scrape time, which makes them the
+ * first honest sign that the crash is fully handled.
  */
-async function waitForGuestDeaths(want: number, timeoutMs = 60_000): Promise<void> {
+async function waitForCrashHandled(want: CrashState, timeoutMs = 60_000): Promise<string> {
   const deadline = Date.now() + timeoutMs;
-  let last = 0;
-  while (Date.now() < deadline) {
-    last = guestDeaths();
-    if (last >= want) return;
+  let body = scrapeRunnerMetrics();
+  while (!crashHandled(body, want) && Date.now() < deadline) {
     await sleep(500);
+    body = scrapeRunnerMetrics();
   }
-  throw new Error(
-    `${GUEST_DEATHS} reached ${last}, want >= ${want} within ${timeoutMs}ms — ` +
-      'the guest may not have died, or the runner did not detect it',
-  );
+
+  const deaths = parseCounter(body, GUEST_DEATHS, RUNNER_LABELS);
+  if (deaths < want.deaths) {
+    throw new Error(
+      `${GUEST_DEATHS} reached ${deaths}, want >= ${want.deaths} within ${timeoutMs}ms — ` +
+        'the guest may not have died, or the runner did not detect it',
+    );
+  }
+  return body;
 }
 
 // Docker detects a dead guest through its own event stream and heals it via the
@@ -65,11 +82,14 @@ test.describe('Guest crash detection', FIRECRACKER_ONLY, () => {
       expect(parseGauge(scrapeRunnerMetrics(), ACTIVE)).toBe(activeBefore + 1);
 
       await crashGuest(id);
-      await waitForGuestDeaths(deathsBefore + 1);
 
       // The point of tearing down eagerly: a crashed sandbox costs disk and
       // nothing else, so a client retrying cannot accumulate slots.
-      const after = scrapeRunnerMetrics();
+      const after = await waitForCrashHandled({
+        deaths: deathsBefore + 1,
+        active: activeBefore,
+        stopped: stoppedBefore + 1,
+      });
       expect(parseGauge(after, ACTIVE)).toBe(activeBefore);
       expect(parseGauge(after, STOPPED)).toBe(stoppedBefore + 1);
     } finally {
@@ -88,13 +108,24 @@ test.describe('Guest crash detection', FIRECRACKER_ONLY, () => {
     );
     test.setTimeout(150_000);
 
-    const deathsBefore = guestDeaths();
+    const before = scrapeRunnerMetrics();
+    const deathsBefore = parseCounter(before, GUEST_DEATHS, RUNNER_LABELS);
+    const activeBefore = parseGauge(before, ACTIVE);
+    const stoppedBefore = parseGauge(before, STOPPED);
+
     const id = await createSandboxWithRetry();
     try {
       await exec(id, `printf '%s' marker > /tmp/crash-marker`);
 
       await crashGuest(id);
-      await waitForGuestDeaths(deathsBefore + 1);
+      // The refusal below is only reachable once the sandbox is marked stopped,
+      // which is the last thing the crash handler does. Until then the runner still
+      // reports it running and the request fails against a proxy nothing is behind.
+      await waitForCrashHandled({
+        deaths: deathsBefore + 1,
+        active: activeBefore,
+        stopped: stoppedBefore + 1,
+      });
 
       // Restoring the snapshot here would corrupt the rootfs the guest kept
       // writing to, so the request must fail loudly instead of appearing to

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -33,6 +33,11 @@ const (
 	OpEvict         = "evict"
 )
 
+// Backend label values used with ObserveGuestDeath. Which runtime a runner is
+// built on is not visible in any other series, and the two detect a dead guest
+// by different means, so a crash rate has to be readable per backend.
+const BackendFirecracker = "firecracker"
+
 // Handler returns the http.Handler that serves the registry's metrics in
 // Prometheus exposition format.
 func Handler(reg *prometheus.Registry) http.Handler {
@@ -190,6 +195,7 @@ type RunnerRecorder struct {
 	containerOps        *prometheus.CounterVec
 	containerOpDuration *prometheus.HistogramVec
 	lifecycleSteps      *prometheus.HistogramVec
+	guestDeaths         *prometheus.CounterVec
 }
 
 // NewRunnerRecorder builds the runner recorder. If enabled is false, the
@@ -229,7 +235,16 @@ func NewRunnerRecorder(enabled bool) *RunnerRecorder {
 		},
 		[]string{"operation", "step"},
 	)
-	reg.MustRegister(containerOps, containerOpDuration, lifecycleSteps)
+	guestDeaths := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   Namespace,
+			Name:        "guest_deaths_total",
+			Help:        "Sandbox guests that died without the runner stopping them, labeled by backend.",
+			ConstLabels: prometheus.Labels{"role": RoleRunner},
+		},
+		[]string{"backend"},
+	)
+	reg.MustRegister(containerOps, containerOpDuration, lifecycleSteps, guestDeaths)
 	return &RunnerRecorder{
 		reg:                 reg,
 		httpRequests:        httpReq,
@@ -237,6 +252,7 @@ func NewRunnerRecorder(enabled bool) *RunnerRecorder {
 		containerOps:        containerOps,
 		containerOpDuration: containerOpDuration,
 		lifecycleSteps:      lifecycleSteps,
+		guestDeaths:         guestDeaths,
 	}
 }
 
@@ -273,6 +289,16 @@ func (r *RunnerRecorder) ObserveLifecycleStep(operation, step string, dur time.D
 		return
 	}
 	r.lifecycleSteps.WithLabelValues(operation, step).Observe(dur.Seconds())
+}
+
+// ObserveGuestDeath records a sandbox guest that exited without the runner
+// stopping it. There is no result label: a death has no outcome of its own, and
+// what became of the sandbox afterwards is a separate series.
+func (r *RunnerRecorder) ObserveGuestDeath(backend string) {
+	if r == nil || r.reg == nil {
+		return
+	}
+	r.guestDeaths.WithLabelValues(backend).Inc()
 }
 
 // SetActiveContainers registers a scrape-time gauge that calls f to read the
@@ -315,6 +341,15 @@ func (r *RunnerRecorder) ContainerOpCount(operation string, success bool) float6
 		return 0
 	}
 	return testutil.ToFloat64(r.containerOps.WithLabelValues(operation, resultLabel(success)))
+}
+
+// GuestDeathCount returns the counter value for guest deaths on a backend.
+// Intended for tests in other packages.
+func (r *RunnerRecorder) GuestDeathCount(backend string) float64 {
+	if r.reg == nil {
+		return 0
+	}
+	return testutil.ToFloat64(r.guestDeaths.WithLabelValues(backend))
 }
 
 func resultLabel(success bool) string {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -33,11 +33,6 @@ const (
 	OpEvict         = "evict"
 )
 
-// Backend label values used with ObserveGuestDeath. Which runtime a runner is
-// built on is not visible in any other series, and the two detect a dead guest
-// by different means, so a crash rate has to be readable per backend.
-const BackendFirecracker = "firecracker"
-
 // Handler returns the http.Handler that serves the registry's metrics in
 // Prometheus exposition format.
 func Handler(reg *prometheus.Registry) http.Handler {
@@ -195,7 +190,7 @@ type RunnerRecorder struct {
 	containerOps        *prometheus.CounterVec
 	containerOpDuration *prometheus.HistogramVec
 	lifecycleSteps      *prometheus.HistogramVec
-	guestDeaths         *prometheus.CounterVec
+	guestDeaths         prometheus.Counter
 }
 
 // NewRunnerRecorder builds the runner recorder. If enabled is false, the
@@ -235,14 +230,13 @@ func NewRunnerRecorder(enabled bool) *RunnerRecorder {
 		},
 		[]string{"operation", "step"},
 	)
-	guestDeaths := prometheus.NewCounterVec(
+	guestDeaths := prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace:   Namespace,
 			Name:        "guest_deaths_total",
-			Help:        "Sandbox guests that died without the runner stopping them, labeled by backend.",
+			Help:        "Sandbox guests that died without the runner stopping them.",
 			ConstLabels: prometheus.Labels{"role": RoleRunner},
 		},
-		[]string{"backend"},
 	)
 	reg.MustRegister(containerOps, containerOpDuration, lifecycleSteps, guestDeaths)
 	return &RunnerRecorder{
@@ -292,13 +286,14 @@ func (r *RunnerRecorder) ObserveLifecycleStep(operation, step string, dur time.D
 }
 
 // ObserveGuestDeath records a sandbox guest that exited without the runner
-// stopping it. There is no result label: a death has no outcome of its own, and
-// what became of the sandbox afterwards is a separate series.
-func (r *RunnerRecorder) ObserveGuestDeath(backend string) {
+// stopping it. Unlabeled: a death has no outcome of its own, and a runner
+// process serves exactly one runtime, so which backend detected it is a property
+// of the scrape target rather than of the series.
+func (r *RunnerRecorder) ObserveGuestDeath() {
 	if r == nil || r.reg == nil {
 		return
 	}
-	r.guestDeaths.WithLabelValues(backend).Inc()
+	r.guestDeaths.Inc()
 }
 
 // SetActiveContainers registers a scrape-time gauge that calls f to read the
@@ -343,13 +338,13 @@ func (r *RunnerRecorder) ContainerOpCount(operation string, success bool) float6
 	return testutil.ToFloat64(r.containerOps.WithLabelValues(operation, resultLabel(success)))
 }
 
-// GuestDeathCount returns the counter value for guest deaths on a backend.
+// GuestDeathCount returns the counter value for guest deaths.
 // Intended for tests in other packages.
-func (r *RunnerRecorder) GuestDeathCount(backend string) float64 {
+func (r *RunnerRecorder) GuestDeathCount() float64 {
 	if r.reg == nil {
 		return 0
 	}
-	return testutil.ToFloat64(r.guestDeaths.WithLabelValues(backend))
+	return testutil.ToFloat64(r.guestDeaths)
 }
 
 func resultLabel(success bool) string {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -134,6 +134,27 @@ func TestRunnerRecorderLifecycleSteps(t *testing.T) {
 	}
 }
 
+func TestRunnerRecorderGuestDeaths(t *testing.T) {
+	r := NewRunnerRecorder(true)
+
+	r.ObserveGuestDeath(BackendFirecracker)
+	r.ObserveGuestDeath(BackendFirecracker)
+
+	if got := r.GuestDeathCount(BackendFirecracker); got != 2 {
+		t.Errorf("guest_deaths_total{firecracker} = %v, want 2", got)
+	}
+
+	body := scrape(t, r.Registry())
+	for _, want := range []string{
+		"sandbox_guest_deaths_total",
+		`backend="firecracker",role="runner"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("scrape body missing %q", want)
+		}
+	}
+}
+
 func TestRunnerRecorderDisabled(t *testing.T) {
 	r := NewRunnerRecorder(false)
 	if r.Enabled() {
@@ -142,6 +163,7 @@ func TestRunnerRecorderDisabled(t *testing.T) {
 	r.ObserveHTTP("/x", http.MethodGet, http.StatusOK, time.Millisecond)
 	r.ObserveContainerOp(OpCreate, true, time.Second)
 	r.ObserveLifecycleStep(OpCreate, "clone_rootfs", time.Millisecond)
+	r.ObserveGuestDeath(BackendFirecracker)
 	r.SetActiveContainers(func() float64 { return 1 })
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -137,17 +137,17 @@ func TestRunnerRecorderLifecycleSteps(t *testing.T) {
 func TestRunnerRecorderGuestDeaths(t *testing.T) {
 	r := NewRunnerRecorder(true)
 
-	r.ObserveGuestDeath(BackendFirecracker)
-	r.ObserveGuestDeath(BackendFirecracker)
+	r.ObserveGuestDeath()
+	r.ObserveGuestDeath()
 
-	if got := r.GuestDeathCount(BackendFirecracker); got != 2 {
-		t.Errorf("guest_deaths_total{firecracker} = %v, want 2", got)
+	if got := r.GuestDeathCount(); got != 2 {
+		t.Errorf("guest_deaths_total = %v, want 2", got)
 	}
 
 	body := scrape(t, r.Registry())
 	for _, want := range []string{
 		"sandbox_guest_deaths_total",
-		`backend="firecracker",role="runner"`,
+		`role="runner"`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("scrape body missing %q", want)
@@ -163,7 +163,7 @@ func TestRunnerRecorderDisabled(t *testing.T) {
 	r.ObserveHTTP("/x", http.MethodGet, http.StatusOK, time.Millisecond)
 	r.ObserveContainerOp(OpCreate, true, time.Second)
 	r.ObserveLifecycleStep(OpCreate, "clone_rootfs", time.Millisecond)
-	r.ObserveGuestDeath(BackendFirecracker)
+	r.ObserveGuestDeath()
 	r.SetActiveContainers(func() float64 { return 1 })
 }
 

--- a/internal/runner/runtime/firecracker.ee/README.md
+++ b/internal/runner/runtime/firecracker.ee/README.md
@@ -194,6 +194,39 @@ is set, and otherwise fails naming the script to re-run. Bump `schema_version`
 when the layout changes; the runner rejects versions it does not know rather
 than guessing.
 
+## Guest death
+
+A microVM can die on its own: the guest daemon runs as PID 1 with `panic=1
+reboot=k` in the boot args, so killing it panics the kernel, which resets the CPU
+and exits the VMM. A host `SIGKILL` of the VMM and a `reboot` from inside the
+guest end the same way. Because jailer execs Firecracker in place, the process
+the runner starts lives exactly as long as the guest, so waiting on it is the
+detection: `startCommand` reports the exit and `handleGuestDeath` reacts.
+
+Telling that apart from the runner's own kills is what `sandboxState.generation`
+is for. `teardownRunningVM` bumps it before killing the process, and each exit
+callback carries the generation of the microVM it was registered for, so a stop,
+delete, wake rollback or shutdown is not read as a crash — and an old
+incarnation's exit arriving late cannot mark a freshly woken one dead. The
+handler takes the sandbox's transition claim like any other lifecycle operation,
+so a stop already in flight finishes first and then invalidates it.
+
+A dead guest is torn down immediately and **hands its slot back**, which is what
+bounds the damage: a crashed sandbox costs disk and nothing else, so a client
+retrying cannot accumulate slots. What is left behind is what an idle stop leaves
+behind, minus a usable snapshot — stopped, no slot, files intact — so the
+existing paths need no special case: `StopSandbox` is idempotent instead of
+looping on a dead API socket, the idle sweeper can delete it, and `DaemonURL`
+reports it not running.
+
+It is **not** restored from its snapshot afterwards. The guest kept writing to
+the rootfs after that snapshot was taken, and restoring a memory image whose
+cached filesystem metadata no longer matches the disk corrupts it silently —
+nothing detects the mismatch. So the sandbox is pinned (`mustColdBoot`) and
+`EnsureSandboxRunning` refuses it. Bringing it back needs a boot of its existing
+rootfs, which this runtime does not do yet; until then a request for a crashed
+sandbox fails and the sandbox stays deletable.
+
 ## Current Limitations
 
 - Slots are allocated in memory and are not pre-created or persisted.

--- a/internal/runner/runtime/firecracker.ee/README.md
+++ b/internal/runner/runtime/firecracker.ee/README.md
@@ -90,6 +90,13 @@ and releases the slot. The admission canary is built on this — a canary whose
 cleanup fails keeps its slot and fails admission, so a capacity-1 runner is never
 marked healthy while one of its slots is unaccounted for.
 
+The cleanup a **failed create** runs is the exception to that: it releases the slot,
+because it is the one delete with nothing behind it. The create returns an error, so
+the API stores no record for the sandbox, and without a record neither an explicit
+delete nor the idle sweeper can ever name it again. Keeping the slot would strand
+runner capacity until the process restarts, so this path follows stop rather than
+delete and hands it back.
+
 Because slot ownership moves like that, create, stop, wake, and delete are
 mutually exclusive per sandbox: each claims the sandbox for the duration of the
 transition and the others wait. Without that, a delete overlapping a create or

--- a/internal/runner/runtime/firecracker.ee/README.md
+++ b/internal/runner/runtime/firecracker.ee/README.md
@@ -98,8 +98,18 @@ it removes last — an expired context, a `sudo` that never ran — leaves it un
 whether the netns is really gone. Delete can afford that caution where stop cannot,
 because a delete retry does arrive: the API keeps the sandbox row when the runner
 reports a delete failure, and the idle sweeper retries every sweep interval. The
-retry skips the teardown it no longer has handles for, removes the data directory,
-and releases the slot. The admission canary is built on this — a canary whose
+retry repeats host cleanup, removes the data directory, and releases the slot.
+
+Host cleanup on delete runs whether or not the sandbox still has process and proxy
+handles, which matters because a stop or crash whose cleanup failed marks the sandbox
+stopped and drops those handles anyway. Skipping cleanup on the strength of them
+would leave the jail's bind mounts in place while the delete removes the data
+directory beneath them, so the snapshot files would stay allocated with no way left
+to reclaim them: startup reconcile cannot help either, since its `rm -rf` fails on a
+directory holding an active mount. Repeating cleanup is safe because every step is
+guarded and what it removes is keyed to the `vmID`.
+
+The admission canary is built on this — a canary whose
 cleanup fails keeps its slot and fails admission, so a capacity-1 runner is never
 marked healthy while one of its slots is unaccounted for.
 
@@ -297,14 +307,24 @@ nothing detects the mismatch. So `EnsureSandboxRunning` refuses a pinned
 which this runtime does not do yet; until then a request for a crashed sandbox
 fails and the sandbox stays deletable.
 
-The pin is set by the restore, not by the death: `snapshot/load` resumes the guest,
-so the mismatch begins the moment a wake or create succeeds at that step, and only
-the snapshot `StopSandbox` takes of the paused guest clears it. Tying it to the
-restore is what makes it hold for a guest that dies mid-wake, where the death
-cannot be told apart from the rollback's own kill. It also covers a wake that
-failed after the restore for a reason of its own: that guest ran too, so its
-snapshot is just as stale. Such a sandbox is refused until cold boot exists, which
-is the deliberate trade — a loud failure instead of a silently corrupted disk.
+The pin is set by the restore, not by the death, and specifically *before* the
+restore is asked for rather than after it reports success. `snapshot/load` carries
+`resume_vm: true`, so one request both loads the snapshot and lets the guest start
+writing to a rootfs that snapshot no longer describes. Its failures are therefore
+ambiguous — a deadline that expires while the response is read leaves no way to know
+whether the guest ran — and the ambiguous case is resolved as if it did. Only the
+snapshot `StopSandbox` takes of the paused guest clears the pin.
+
+Tying it to the restore is what makes it hold for a guest that dies mid-wake, where
+the death cannot be told apart from the rollback's own kill, and for a wake that
+failed after the restore for a reason of its own: that guest ran too, so its snapshot
+is just as stale. The cost of pinning first is that a load which failed without
+resuming anything is pinned as well, which costs a cold boot instead of a restore.
+Placing the pin immediately before the request rather than earlier is what keeps that
+cost small — every step ahead of it fails unambiguously with no guest having run, so
+those failures leave the sandbox wakeable. Until cold boot exists a pinned sandbox is
+refused, which is the deliberate trade: a loud failure instead of a silently
+corrupted disk.
 
 ## Current Limitations
 

--- a/internal/runner/runtime/firecracker.ee/README.md
+++ b/internal/runner/runtime/firecracker.ee/README.md
@@ -75,9 +75,22 @@ stopped — and a sandbox left marked running would hold its slot for a microVM
 nothing can reach, hand out a daemon URL nothing listens on, and fail every later
 stop against an API socket that died with its guest. Nothing would ever reclaim it.
 The snapshot is written by then, so the sandbox becomes an ordinary stopped one and
-wakes on the next request instead; a slot handed back with jail mounts still on it
-comes up clean anyway, since the setup script deletes and recreates the netns
-before using it, and what survives is keyed to the `vmID` rather than the slot.
+wakes on the next request instead; a slot handed back with leftovers on it comes up
+clean anyway, because the next sandbox clears the slot before building it.
+
+That last part is load-bearing for every path that releases a slot after a failed
+teardown, so it is worth being precise about which resources are per-slot. The netns
+`fc-sb-{slot}` and the host veth `fc-veth-{slot}` are, and the setup script deletes
+both before creating them — including the veth, without which a single leftover
+would fail `ip link add` under `set -eu` and strand the slot until the runner
+restarts. Deleting a netns by name works even while a stale microVM still runs
+inside it: the kernel keeps that namespace alive for the process while freeing the
+name, so the new sandbox gets an empty namespace and the stale guest is isolated in
+an unnamed one with its uplink gone. The proxy port is per-slot too, and is freed by
+the `Stop` that teardown performs on every handle it claims; were it ever left
+bound, the next create on the slot would fail loudly on bind rather than share it.
+The jail directory is keyed to the `vmID`, so it collides with nothing and startup
+reconcile sweeps it.
 
 A failed **delete** keeps its slot, which looks inconsistent with that but is not.
 Cleanup runs as a single shell command, so a failure that is not the jail directory
@@ -117,6 +130,20 @@ state in the same critical section that bumps the generation, and every other
 read and write of them holds `r.mu` too. Whoever takes the handles owns the stop
 and the kill, and the loser finds nil and repeats only `cleanupHost`, which is
 written to be repeatable.
+
+An activation is the other side of that: `Shutdown` decides whether to kill a
+microVM by reading handles a create or wake has not published yet, so it can find
+nothing to tear down, delete the sandbox and hand the slot back while the guest is
+still coming up. `activateSandboxVM` therefore rechecks after publishing each
+handle whether the sandbox is still its own, and fails with `errActivationAbandoned`
+if not. The recheck comes *after* the publication on purpose: the caller's rollback
+is what kills the microVM, and a rollback only tears down handles it can see.
+Carrying on instead would finish building a guest nothing tracks, holding the netns
+and jail mounts of a slot already handed to someone else — and outliving the runner,
+since jailer's children are their own process group. Today a stale `loadSnapshot`
+usually fails that activation anyway, because `Shutdown` deletes the data directory
+out from under it, but cold-boot recovery boots the rootfs and reads no snapshot
+files, so that accident stops covering it.
 
 A claim comes with a budget: `beginTransition` returns the context its operation
 must run under, which is the caller's detached from cancellation and capped at two

--- a/internal/runner/runtime/firecracker.ee/README.md
+++ b/internal/runner/runtime/firecracker.ee/README.md
@@ -270,6 +270,17 @@ is set, and otherwise fails naming the script to re-run. Bump `schema_version`
 when the layout changes; the runner rejects versions it does not know rather
 than guessing.
 
+A set that is already complete is verified rather than trusted, because the
+sidecar only certifies the snapshot the runner actually restores if the configured
+paths lead to it. Regeneration replaces `snapshot_mem` and `snapshot_state` inside
+the `--out` directory, so a configured path that is an independent copy or a
+symlink out of it keeps serving the previous snapshot under a `boot.json`
+describing the new one, and survives every restart in that state. So whenever the
+runner owns snapshot creation and its outputs are present, admission resolves both
+configured paths and fails if either does not land on the generated file. Hosts
+without a create script, or whose `--out` directory holds no generated files, have
+nothing to compare against and are left alone.
+
 ## Guest death
 
 A microVM can die on its own: the guest daemon runs as PID 1 with `panic=1

--- a/internal/runner/runtime/firecracker.ee/README.md
+++ b/internal/runner/runtime/firecracker.ee/README.md
@@ -67,6 +67,29 @@ part of the public API, and not a promise that the same sandbox ID will always
 get the same slot after restart. A sandbox that stops releases its slot and may
 wake onto a different one.
 
+A stop releases its slot even when the host cleanup that follows fails. The
+failure is logged and returned, but the state moves on to stopped, because that is
+the only outcome that leaves the sandbox usable. `teardownRunningVM` drops the
+process and proxy handles whatever it returns, so no retry can resume where it
+stopped — and a sandbox left marked running would hold its slot for a microVM
+nothing can reach, hand out a daemon URL nothing listens on, and fail every later
+stop against an API socket that died with its guest. Nothing would ever reclaim it.
+The snapshot is written by then, so the sandbox becomes an ordinary stopped one and
+wakes on the next request instead; a slot handed back with jail mounts still on it
+comes up clean anyway, since the setup script deletes and recreates the netns
+before using it, and what survives is keyed to the `vmID` rather than the slot.
+
+A failed **delete** keeps its slot, which looks inconsistent with that but is not.
+Cleanup runs as a single shell command, so a failure that is not the jail directory
+it removes last — an expired context, a `sudo` that never ran — leaves it unknown
+whether the netns is really gone. Delete can afford that caution where stop cannot,
+because a delete retry does arrive: the API keeps the sandbox row when the runner
+reports a delete failure, and the idle sweeper retries every sweep interval. The
+retry skips the teardown it no longer has handles for, removes the data directory,
+and releases the slot. The admission canary is built on this — a canary whose
+cleanup fails keeps its slot and fails admission, so a capacity-1 runner is never
+marked healthy while one of its slots is unaccounted for.
+
 Because slot ownership moves like that, create, stop, wake, and delete are
 mutually exclusive per sandbox: each claims the sandbox for the duration of the
 transition and the others wait. Without that, a delete overlapping a create or
@@ -75,9 +98,18 @@ skip teardown, and leave an orphaned microVM holding host resources on a slot th
 runner had already handed back. The delete claim is terminal and doubles as the
 tombstone that hides the sandbox from lookups, so a single flag decides both
 mutual exclusion and visibility. `Shutdown` is the one exception to waiting — it
-sweeps sandboxes mid-stop or mid-wake, since the process is exiting and startup
-reconcile removes whatever leaks, but it still skips sandboxes a delete already
-claimed so teardown never runs twice.
+sweeps sandboxes mid-stop, mid-wake or mid-guest-death, since a claim it waited for
+could outlive the process and leave a microVM running past the runner (jailer's
+children are their own process group, so they do not die with it). It still skips
+sandboxes a delete already claimed, so a delete never runs twice.
+
+Because of that exception, the claim cannot be the only thing protecting a
+sandbox's `process` and `proxy` handles: `Shutdown` can be tearing down the same
+microVM as the claim holder. So `teardownRunningVM` takes both handles off the
+state in the same critical section that bumps the generation, and every other
+read and write of them holds `r.mu` too. Whoever takes the handles owns the stop
+and the kill, and the loser finds nil and repeats only `cleanupHost`, which is
+written to be repeatable.
 
 A claim comes with a budget: `beginTransition` returns the context its operation
 must run under, which is the caller's detached from cancellation and capped at two
@@ -207,9 +239,13 @@ Telling that apart from the runner's own kills is what `sandboxState.generation`
 is for. `teardownRunningVM` bumps it before killing the process, and each exit
 callback carries the generation of the microVM it was registered for, so a stop,
 delete, wake rollback or shutdown is not read as a crash — and an old
-incarnation's exit arriving late cannot mark a freshly woken one dead. The
-handler takes the sandbox's transition claim like any other lifecycle operation,
-so a stop already in flight finishes first and then invalidates it.
+incarnation's exit arriving late cannot mark a freshly woken one dead. The death
+is recorded straight away, before the handler queues for the sandbox's transition
+claim: an exit that arrives while another operation holds the sandbox is only
+looked at once that operation has released it, by which point its teardown has
+bumped the generation past the one the exit carries. A wake that fails *because*
+its guest just died goes exactly that way. The teardown that follows is still
+gated on the generation, so it cannot run twice on the same microVM.
 
 A dead guest is torn down immediately and **hands its slot back**, which is what
 bounds the damage: a crashed sandbox costs disk and nothing else, so a client
@@ -222,10 +258,19 @@ reports it not running.
 It is **not** restored from its snapshot afterwards. The guest kept writing to
 the rootfs after that snapshot was taken, and restoring a memory image whose
 cached filesystem metadata no longer matches the disk corrupts it silently —
-nothing detects the mismatch. So the sandbox is pinned (`mustColdBoot`) and
-`EnsureSandboxRunning` refuses it. Bringing it back needs a boot of its existing
-rootfs, which this runtime does not do yet; until then a request for a crashed
-sandbox fails and the sandbox stays deletable.
+nothing detects the mismatch. So `EnsureSandboxRunning` refuses a pinned
+(`mustColdBoot`) sandbox. Bringing it back needs a boot of its existing rootfs,
+which this runtime does not do yet; until then a request for a crashed sandbox
+fails and the sandbox stays deletable.
+
+The pin is set by the restore, not by the death: `snapshot/load` resumes the guest,
+so the mismatch begins the moment a wake or create succeeds at that step, and only
+the snapshot `StopSandbox` takes of the paused guest clears it. Tying it to the
+restore is what makes it hold for a guest that dies mid-wake, where the death
+cannot be told apart from the rollback's own kill. It also covers a wake that
+failed after the restore for a reason of its own: that guest ran too, so its
+snapshot is just as stale. Such a sandbox is refused until cold boot exists, which
+is the deliberate trade — a loud failure instead of a silently corrupted disk.
 
 ## Current Limitations
 

--- a/internal/runner/runtime/firecracker.ee/admission.go
+++ b/internal/runner/runtime/firecracker.ee/admission.go
@@ -203,11 +203,12 @@ func fileSHA256(path string) (string, error) {
 // boot parameter sidecar counts as part of the snapshot: a runner upgraded onto
 // a host whose snapshot predates it has mem and state but no boot.json, and the
 // three have to describe the same build, so the whole set is rewritten rather
-// than the sidecar reconstructed from current config.
+// than the sidecar reconstructed from current config. A set that is already complete
+// is verified rather than trusted, see verifyGoldenSnapshotSet.
 func (r *Runtime) ensureGoldenSnapshot(ctx context.Context) error {
 	bootPath := bootParamsPath(r.config)
 	if r.deps.pathExists(r.config.SnapshotMemPath) && r.deps.pathExists(r.config.SnapshotStatePath) && r.deps.pathExists(bootPath) {
-		return nil
+		return r.verifyGoldenSnapshotSet()
 	}
 	if strings.TrimSpace(r.config.CreateSnapshotScript) == "" {
 		return fmt.Errorf("golden snapshot incomplete (need %s, %s and %s) and create script is not configured; re-run create-golden-snapshot.sh with --out %s",
@@ -279,8 +280,33 @@ DAEMON_PORT=%s \
 	)
 }
 
+// verifyGoldenSnapshotSet re-checks the snapshot/sidecar linkage of a set that is
+// already complete, which is every ordinary restart. Regeneration is otherwise the
+// only thing that checks it, and that is the moment it is least needed — the runner
+// has just written all three files itself — while the mismatch it catches survives
+// from one run to the next: a configured path aiming outside the output directory
+// keeps serving the snapshot from before the last regeneration while boot.json
+// describes the one after, and admission would certify it on every restart.
+//
+// Limited to hosts where the runner owns snapshot creation and its outputs are still
+// there. Without a create script nothing generated exists to compare against, and a
+// set assembled by hand is the operator's to name, so failing those over a missing
+// comparison target would refuse admission for no reason. Where the script is
+// configured, config validation has already required both configured paths to share
+// a directory, so one outDir covers them.
+func (r *Runtime) verifyGoldenSnapshotSet() error {
+	if strings.TrimSpace(r.config.CreateSnapshotScript) == "" {
+		return nil
+	}
+	outDir := filepath.Dir(r.config.SnapshotMemPath)
+	if !r.deps.pathExists(filepath.Join(outDir, "snapshot_mem")) || !r.deps.pathExists(filepath.Join(outDir, "snapshot_state")) {
+		return nil
+	}
+	return verifySnapshotPathsResolveToOutputs(outDir, r.config.SnapshotMemPath, r.config.SnapshotStatePath)
+}
+
 // verifySnapshotPathsResolveToOutputs rejects configured mem/state paths that do
-// not resolve to the files the create script just wrote. Regeneration only
+// not resolve to the files the create script wrote. Regeneration only
 // replaces snapshot_mem and snapshot_state inside outDir, so a configured path
 // that is an independent copy, a hard link, or a symlink out of outDir survives
 // untouched and still holds the previous snapshot while the fresh boot.json

--- a/internal/runner/runtime/firecracker.ee/admission_test.go
+++ b/internal/runner/runtime/firecracker.ee/admission_test.go
@@ -88,6 +88,87 @@ func TestEnsureGoldenSnapshotSkipsWhenPresent(t *testing.T) {
 	}
 }
 
+// A complete set is checked on every admission, not only in the moment after the
+// runner regenerated it: a configured path aiming away from the generated file
+// outlives regeneration, and every restart in between would certify it.
+func TestEnsureGoldenSnapshotVerifiesACompleteSet(t *testing.T) {
+	writeFile := func(t *testing.T, path string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte{1}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeGenerated := func(t *testing.T, outDir string) {
+		t.Helper()
+		writeFile(t, filepath.Join(outDir, "snapshot_mem"))
+		writeFile(t, filepath.Join(outDir, "snapshot_state"))
+	}
+	symlink := func(t *testing.T, target, path string) {
+		t.Helper()
+		if err := os.Symlink(target, path); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, outDir, memPath, statePath string)
+		wantErr string
+	}{
+		{
+			name: "configured paths symlinked to the generated files",
+			setup: func(t *testing.T, outDir, memPath, statePath string) {
+				writeGenerated(t, outDir)
+				symlink(t, "snapshot_mem", memPath)
+				symlink(t, "snapshot_state", statePath)
+			},
+		},
+		{
+			name: "configured memory path is an independent copy beside the generated file",
+			setup: func(t *testing.T, outDir, memPath, statePath string) {
+				writeGenerated(t, outDir)
+				writeFile(t, memPath)
+				symlink(t, "snapshot_state", statePath)
+			},
+			wantErr: "resolves to",
+		},
+		{
+			name: "snapshot assembled by hand, with nothing generated to compare against",
+			setup: func(t *testing.T, _, memPath, statePath string) {
+				writeFile(t, memPath)
+				writeFile(t, statePath)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			outDir := t.TempDir()
+			script := filepath.Join(t.TempDir(), "create.sh")
+			writeFile(t, script)
+
+			rt := testRuntime(1)
+			rt.config.CreateSnapshotScript = script
+			rt.config.SnapshotMemPath = filepath.Join(outDir, "mem")
+			rt.config.SnapshotStatePath = filepath.Join(outDir, "state")
+			rt.deps.pathExists = pathExists
+			rt.deps.run = func(context.Context, string, ...string) error {
+				t.Fatal("create script ran for a snapshot set that is already complete")
+				return nil
+			}
+			tc.setup(t, outDir, rt.config.SnapshotMemPath, rt.config.SnapshotStatePath)
+			writeBootParams(t, bootParamsPath(rt.config), testBootParams(rt.config))
+
+			err := rt.ensureGoldenSnapshot(context.Background())
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("ensureGoldenSnapshot() failed: %v", err)
+			case tc.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tc.wantErr)):
+				t.Fatalf("ensureGoldenSnapshot() error = %v, want one containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestEnsureGoldenSnapshotRequiresScriptWhenMissing(t *testing.T) {
 	rt := testRuntime(1)
 	rt.config.CreateSnapshotScript = ""

--- a/internal/runner/runtime/firecracker.ee/crash.go
+++ b/internal/runner/runtime/firecracker.ee/crash.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"log/slog"
 	"time"
-
-	"github.com/n8n-io/sandbox-service/internal/metrics"
 )
 
 // errGuestCrashed is what the wake path returns for a sandbox pinned to cold
@@ -58,7 +56,7 @@ func (r *Runtime) handleGuestDeath(died *sandboxState, generation uint64, waitEr
 		"slot", slot,
 		"err", waitErr,
 	)
-	r.metrics.ObserveGuestDeath(metrics.BackendFirecracker)
+	r.metrics.ObserveGuestDeath()
 
 	if err := r.teardownRunningVM(ctx, state); err != nil {
 		// Reported, not returned: the slot has to go back even when host cleanup

--- a/internal/runner/runtime/firecracker.ee/crash.go
+++ b/internal/runner/runtime/firecracker.ee/crash.go
@@ -1,0 +1,79 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/n8n-io/sandbox-service/internal/metrics"
+)
+
+// errGuestCrashed is what the wake path returns for a sandbox pinned to cold
+// boot. Its files are intact and it is meant to come back, but only through a
+// boot of its rootfs, which this runner cannot do yet; restoring the snapshot
+// instead would corrupt the disk. Waking it is therefore refused rather than
+// attempted, and the sandbox stays deletable.
+var errGuestCrashed = errors.New("sandbox guest crashed and cannot be restored from its snapshot")
+
+// handleGuestDeath reacts to a Firecracker process that exited without the
+// runner killing it. It runs on the goroutine watching that process, so it takes
+// the sandbox's transition claim like any other lifecycle operation: a stop or
+// delete already in flight finishes first, and its own teardown then bumps the
+// generation this call is checked against, which is how the two cannot both tear
+// the same microVM down.
+//
+// What it leaves behind is exactly what an idle stop leaves behind, minus a
+// usable snapshot: stopped, holding no slot, pinned to mustColdBoot. Every path
+// that already handles a stopped sandbox then behaves without knowing a crash
+// happened — StopSandbox is idempotent instead of looping on a dead API socket,
+// the idle sweeper can delete it, and DaemonURL reports it not running so a
+// request drives the wake path, which refuses it with errGuestCrashed. Freeing
+// the slot here is what bounds the damage: a crashed sandbox costs nothing but
+// disk, so a client retrying cannot accumulate slots.
+func (r *Runtime) handleGuestDeath(died *sandboxState, generation uint64, waitErr error) {
+	// Detached from any request: the process this reacts to has already exited,
+	// and beginTransition caps both the wait for the claim and the teardown.
+	state, ctx, cancel, err := r.beginTransition(context.Background(), died.id, transitionStopping)
+	if err != nil {
+		// Either the sandbox is gone, which needs nothing, or an operation held it
+		// past the wait budget, which is long enough that something else is wrong.
+		slog.Debug("firecracker guest death not claimable", "sandbox_id", died.id, "err", err)
+		return
+	}
+	defer cancel()
+	defer r.endTransition(state)
+
+	r.mu.Lock()
+	stale := state != died || state.generation != generation
+	slot, vmID := state.slot, state.vmID
+	r.mu.Unlock()
+	if stale {
+		return
+	}
+
+	slog.Error("firecracker guest died",
+		"sandbox_id", state.id,
+		"vm_id", vmID,
+		"slot", slot,
+		"err", waitErr,
+	)
+	r.metrics.ObserveGuestDeath(metrics.BackendFirecracker)
+
+	if err := r.teardownRunningVM(ctx, state); err != nil {
+		// Reported, not returned: the slot has to go back even when host cleanup
+		// leaves a mount or a netns behind, and startup reconcile removes those.
+		slog.Warn("firecracker crashed sandbox teardown failed", "sandbox_id", state.id, "err", err)
+	}
+
+	r.mu.Lock()
+	state.running = false
+	state.stopped = true
+	state.mustColdBoot = true
+	state.stoppedAt = time.Now()
+	if state.slot >= 0 && r.slotOwnedByLocked(state.slot, state.id) {
+		r.releaseSlotLocked(state.slot)
+	}
+	state.slot = -1
+	r.mu.Unlock()
+}

--- a/internal/runner/runtime/firecracker.ee/crash.go
+++ b/internal/runner/runtime/firecracker.ee/crash.go
@@ -22,14 +22,19 @@ var errGuestCrashed = errors.New("sandbox guest crashed and cannot be restored f
 // the same microVM down.
 //
 // What it leaves behind is exactly what an idle stop leaves behind, minus a
-// usable snapshot: stopped, holding no slot, pinned to mustColdBoot. Every path
-// that already handles a stopped sandbox then behaves without knowing a crash
-// happened — StopSandbox is idempotent instead of looping on a dead API socket,
-// the idle sweeper can delete it, and DaemonURL reports it not running so a
-// request drives the wake path, which refuses it with errGuestCrashed. Freeing
-// the slot here is what bounds the damage: a crashed sandbox costs nothing but
-// disk, so a client retrying cannot accumulate slots.
+// usable snapshot: stopped, holding no slot, and still pinned to mustColdBoot by
+// the restore that resumed this guest. Every path that already handles a stopped
+// sandbox then behaves without knowing a crash happened — StopSandbox is
+// idempotent instead of looping on a dead API socket, the idle sweeper can delete
+// it, and DaemonURL reports it not running so a request drives the wake path,
+// which refuses it with errGuestCrashed. Freeing the slot here is what bounds the
+// damage: a crashed sandbox costs nothing but disk, so a client retrying cannot
+// accumulate slots.
 func (r *Runtime) handleGuestDeath(died *sandboxState, generation uint64, waitErr error) {
+	if !r.recordGuestDeath(died, generation, waitErr) {
+		return
+	}
+
 	// Detached from any request: the process this reacts to has already exited,
 	// and beginTransition caps both the wait for the claim and the teardown.
 	state, ctx, cancel, err := r.beginTransition(context.Background(), died.id, transitionStopping)
@@ -42,21 +47,16 @@ func (r *Runtime) handleGuestDeath(died *sandboxState, generation uint64, waitEr
 	defer cancel()
 	defer r.endTransition(state)
 
+	// Stale means something tore this incarnation down while this call waited for
+	// the claim. The case that matters is a wake that failed because of this very
+	// death: its rollback has already stopped the sandbox and freed the slot, and
+	// the restore pinned it, so nothing is left to do here.
 	r.mu.Lock()
 	stale := state != died || state.generation != generation
-	slot, vmID := state.slot, state.vmID
 	r.mu.Unlock()
 	if stale {
 		return
 	}
-
-	slog.Error("firecracker guest died",
-		"sandbox_id", state.id,
-		"vm_id", vmID,
-		"slot", slot,
-		"err", waitErr,
-	)
-	r.metrics.ObserveGuestDeath()
 
 	if err := r.teardownRunningVM(ctx, state); err != nil {
 		// Reported, not returned: the slot has to go back even when host cleanup
@@ -67,11 +67,41 @@ func (r *Runtime) handleGuestDeath(died *sandboxState, generation uint64, waitEr
 	r.mu.Lock()
 	state.running = false
 	state.stopped = true
-	state.mustColdBoot = true
 	state.stoppedAt = time.Now()
 	if state.slot >= 0 && r.slotOwnedByLocked(state.slot, state.id) {
 		r.releaseSlotLocked(state.slot)
 	}
 	state.slot = -1
 	r.mu.Unlock()
+}
+
+// recordGuestDeath logs and counts a guest that died on its own, reporting
+// whether this exit was one the runner did not ask for.
+//
+// It runs before the transition claim is contended for, because the claim is what
+// makes the generation unreliable: an exit that arrives while a lifecycle
+// operation holds the sandbox is only checked once that operation has released it,
+// by which point its own teardown has bumped the generation past the one the exit
+// carries. A wake that fails because its guest just died goes exactly that way, so
+// checking after the claim would drop the death that caused it.
+//
+// False for an exit the runner caused: teardownRunningVM bumps the generation
+// before killing, so a stop, delete, wake rollback or shutdown of a live guest
+// reaches here with a generation that no longer matches.
+func (r *Runtime) recordGuestDeath(state *sandboxState, generation uint64, waitErr error) bool {
+	r.mu.Lock()
+	current, slot, vmID := state.generation, state.slot, state.vmID
+	r.mu.Unlock()
+	if current != generation {
+		return false
+	}
+
+	slog.Error("firecracker guest died",
+		"sandbox_id", state.id,
+		"vm_id", vmID,
+		"slot", slot,
+		"err", waitErr,
+	)
+	r.metrics.ObserveGuestDeath()
+	return true
 }

--- a/internal/runner/runtime/firecracker.ee/crash_test.go
+++ b/internal/runner/runtime/firecracker.ee/crash_test.go
@@ -153,6 +153,66 @@ func TestShutdownRacingGuestDeathTearsDownTheMicroVMOnce(t *testing.T) {
 	}
 }
 
+// Shutdown decides whether to kill a sandbox's microVM by reading handles that an
+// activation has not published yet, and it hands the slot back without waiting for
+// the activation's claim. So an activation still running afterwards must not go on
+// to finish a guest nothing tracks: jailer's children survive the runner.
+func TestShutdownDuringActivationDoesNotLeaveTheMicroVMRunning(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+
+	proc := &countingProcess{}
+	rt.deps.start = func(context.Context, func(error), string, ...string) (process, error) {
+		return proc, nil
+	}
+	proxy := &countingProxy{}
+	rt.deps.newProxy = func(context.Context, string, string, string) (daemonProxy, error) { return proxy, nil }
+
+	// Parks the create before it starts the microVM, so shutdown runs while both
+	// handles are still nil — the case where shutdown finds nothing to tear down.
+	cloneStarted := make(chan struct{})
+	allowClone := make(chan struct{})
+	rt.deps.cloneGoldenSnapshot = func(context.Context, string, string, string) error {
+		close(cloneStarted)
+		<-allowClone
+		return nil
+	}
+
+	const sandboxID = "sandbox-id-123456"
+	createErr := make(chan error, 1)
+	go func() {
+		_, err := rt.CreateSandbox(context.Background(), sandboxID, nil)
+		createErr <- err
+	}()
+
+	select {
+	case <-cloneStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("CreateSandbox never reached the golden snapshot clone")
+	}
+	rt.Shutdown(context.Background())
+	close(allowClone)
+
+	var err error
+	select {
+	case err = <-createErr:
+	case <-time.After(10 * time.Second):
+		t.Fatal("CreateSandbox never returned after shutdown")
+	}
+	if !errors.Is(err, errActivationAbandoned) {
+		t.Fatalf("CreateSandbox() error = %v, want errActivationAbandoned", err)
+	}
+	if got := proc.kills.Load(); got != 1 {
+		t.Errorf("microVM process killed %d times, want 1 — a guest nothing tracks was left running", got)
+	}
+	if got := capacityOf(t, rt); got.Used != 0 {
+		t.Errorf("capacity used = %d, want 0 after shutdown", got.Used)
+	}
+	if _, err := rt.GetSandboxInfo(context.Background(), sandboxID); !errors.Is(err, runnerruntime.ErrSandboxNotFound) {
+		t.Errorf("GetSandboxInfo() error = %v, want ErrSandboxNotFound", err)
+	}
+}
+
 func capacityOf(t *testing.T, rt *Runtime) runnerruntime.Capacity {
 	t.Helper()
 	capacity, err := rt.Capacity(context.Background())

--- a/internal/runner/runtime/firecracker.ee/crash_test.go
+++ b/internal/runner/runtime/firecracker.ee/crash_test.go
@@ -358,6 +358,43 @@ func TestWakeFailureAfterRestorePinsSandboxToColdBoot(t *testing.T) {
 	}
 }
 
+// The ambiguous case, and the reason the pin is set before the restore is asked for
+// rather than after it reports success: one request both loads the snapshot and
+// resumes the guest, so a load that fails may still have let the guest write to the
+// rootfs. Restoring the same snapshot again would corrupt it with nothing able to
+// tell.
+func TestWakeFailureAtRestorePinsSandboxToColdBoot(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+	if err := rt.StopSandbox(context.Background(), sandboxID); err != nil {
+		t.Fatalf("StopSandbox() failed: %v", err)
+	}
+
+	rt.deps.loadSnapshot = func(context.Context, string, Config) error {
+		return errors.New("context deadline exceeded awaiting response headers")
+	}
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); err == nil {
+		t.Fatal("EnsureSandboxRunning() succeeded, want the load failure")
+	}
+
+	restores := 0
+	rt.deps.loadSnapshot = func(context.Context, string, Config) error {
+		restores++
+		return nil
+	}
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); !errors.Is(err, errGuestCrashed) {
+		t.Fatalf("EnsureSandboxRunning() error = %v, want errGuestCrashed", err)
+	}
+	if restores != 0 {
+		t.Fatalf("wake after an ambiguous load restored the snapshot %d times", restores)
+	}
+}
+
 // The other side of that invariant: a wake that never got as far as restoring left
 // the snapshot matching the rootfs, so it has to stay wakeable.
 func TestWakeFailureBeforeRestoreLeavesSandboxWakeable(t *testing.T) {

--- a/internal/runner/runtime/firecracker.ee/crash_test.go
+++ b/internal/runner/runtime/firecracker.ee/crash_test.go
@@ -1,0 +1,187 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/n8n-io/sandbox-service/internal/metrics"
+	runnerruntime "github.com/n8n-io/sandbox-service/internal/runner/runtime"
+)
+
+// guestExitStub records the exit callback the runtime registers for each microVM
+// it starts, so a test can report that incarnation's process as gone. Firing a
+// specific one is the point: it is how "an old incarnation died" is told apart
+// from "the current one died" without a real Firecracker process.
+type guestExitStub struct {
+	mu    sync.Mutex
+	exits []func(error)
+}
+
+func (s *guestExitStub) install(rt *Runtime, proc process) {
+	rt.deps.start = func(_ context.Context, onExit func(error), _ string, _ ...string) (process, error) {
+		s.mu.Lock()
+		s.exits = append(s.exits, onExit)
+		s.mu.Unlock()
+		return proc, nil
+	}
+}
+
+// fire reports the exit of the nth microVM this runtime started, counting from 0.
+func (s *guestExitStub) fire(t *testing.T, n int) {
+	t.Helper()
+	s.mu.Lock()
+	count := len(s.exits)
+	var onExit func(error)
+	if n < count {
+		onExit = s.exits[n]
+	}
+	s.mu.Unlock()
+	if onExit == nil {
+		t.Fatalf("microVM %d was never started (%d starts recorded)", n, count)
+	}
+	onExit(errors.New("signal: killed"))
+}
+
+func capacityOf(t *testing.T, rt *Runtime) runnerruntime.Capacity {
+	t.Helper()
+	capacity, err := rt.Capacity(context.Background())
+	if err != nil {
+		t.Fatalf("Capacity() failed: %v", err)
+	}
+	return capacity
+}
+
+func TestGuestDeathFreesSlotAndPinsSandboxToColdBoot(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+	rec := metrics.NewRunnerRecorder(true)
+	rt.SetMetricsRecorder(rec)
+
+	proc := &fakeProcess{}
+	proxy := &fakeProxy{}
+	exits := &guestExitStub{}
+	exits.install(rt, proc)
+	rt.deps.newProxy = func(context.Context, string, string, string) (daemonProxy, error) { return proxy, nil }
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+	if got := capacityOf(t, rt); got.Used != 1 {
+		t.Fatalf("capacity used before crash = %d, want 1", got.Used)
+	}
+
+	exits.fire(t, 0)
+
+	if got := capacityOf(t, rt); got.Used != 0 || got.Stopped != 1 {
+		t.Fatalf("capacity after crash = %+v, want used 0 and stopped 1", got)
+	}
+	if !proc.killed {
+		t.Fatal("crashed sandbox left its process group unkilled")
+	}
+	if !proxy.stopped {
+		t.Fatal("crashed sandbox left its daemon proxy running")
+	}
+	if got := rec.GuestDeathCount(metrics.BackendFirecracker); got != 1 {
+		t.Fatalf("guest death metric = %v, want 1", got)
+	}
+
+	// The crash has to reach a client as "not running" so a request drives the
+	// wake path, and the wake path has to refuse rather than restore the snapshot
+	// the guest wrote past.
+	if _, err := rt.DaemonURL(context.Background(), sandboxID); !errors.Is(err, runnerruntime.ErrSandboxNotRunning) {
+		t.Fatalf("DaemonURL() error = %v, want ErrSandboxNotRunning", err)
+	}
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); !errors.Is(err, errGuestCrashed) {
+		t.Fatalf("EnsureSandboxRunning() error = %v, want errGuestCrashed", err)
+	}
+
+	// A crashed sandbox is already torn down, so the idle sweeper's stop must
+	// succeed instead of failing against a dead API socket on every pass.
+	rt.deps.pauseVM = func(context.Context, string) error {
+		t.Fatal("StopSandbox paused a crashed sandbox")
+		return nil
+	}
+	if err := rt.StopSandbox(context.Background(), sandboxID); err != nil {
+		t.Fatalf("StopSandbox() after crash failed: %v", err)
+	}
+	if err := rt.DeleteSandbox(context.Background(), sandboxID); err != nil {
+		t.Fatalf("DeleteSandbox() after crash failed: %v", err)
+	}
+}
+
+func TestIntentionalStopIsNotReportedAsGuestDeath(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+	rec := metrics.NewRunnerRecorder(true)
+	rt.SetMetricsRecorder(rec)
+
+	exits := &guestExitStub{}
+	exits.install(rt, &fakeProcess{})
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+	if err := rt.StopSandbox(context.Background(), sandboxID); err != nil {
+		t.Fatalf("StopSandbox() failed: %v", err)
+	}
+
+	// The stop killed the microVM, so its exit callback fires afterwards. Taking
+	// that for a crash would pin every idle-stopped sandbox to cold boot.
+	exits.fire(t, 0)
+
+	if got := rec.GuestDeathCount(metrics.BackendFirecracker); got != 0 {
+		t.Fatalf("guest death metric = %v, want 0 after an intentional stop", got)
+	}
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); err != nil {
+		t.Fatalf("EnsureSandboxRunning() after stop failed: %v", err)
+	}
+}
+
+func TestStaleGuestExitDoesNotCrashTheCurrentMicroVM(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+	rec := metrics.NewRunnerRecorder(true)
+	rt.SetMetricsRecorder(rec)
+
+	exits := &guestExitStub{}
+	exits.install(rt, &fakeProcess{})
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+	if err := rt.StopSandbox(context.Background(), sandboxID); err != nil {
+		t.Fatalf("StopSandbox() failed: %v", err)
+	}
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); err != nil {
+		t.Fatalf("EnsureSandboxRunning() failed: %v", err)
+	}
+
+	// The first incarnation's exit can arrive at any time, including after the
+	// sandbox is back up on a new one.
+	exits.fire(t, 0)
+
+	if got := capacityOf(t, rt); got.Used != 1 {
+		t.Fatalf("capacity after stale exit = %+v, want the woken sandbox still on its slot", got)
+	}
+	if _, err := rt.DaemonURL(context.Background(), sandboxID); err != nil {
+		t.Fatalf("DaemonURL() after stale exit failed: %v", err)
+	}
+	if got := rec.GuestDeathCount(metrics.BackendFirecracker); got != 0 {
+		t.Fatalf("guest death metric = %v, want 0 for a stale exit", got)
+	}
+
+	// The incarnation that is actually running still gets detected.
+	exits.fire(t, 1)
+
+	if got := rec.GuestDeathCount(metrics.BackendFirecracker); got != 1 {
+		t.Fatalf("guest death metric = %v, want 1 after the current microVM died", got)
+	}
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); !errors.Is(err, errGuestCrashed) {
+		t.Fatalf("EnsureSandboxRunning() error = %v, want errGuestCrashed", err)
+	}
+}

--- a/internal/runner/runtime/firecracker.ee/crash_test.go
+++ b/internal/runner/runtime/firecracker.ee/crash_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/n8n-io/sandbox-service/internal/metrics"
 	runnerruntime "github.com/n8n-io/sandbox-service/internal/runner/runtime"
@@ -31,17 +33,124 @@ func (s *guestExitStub) install(rt *Runtime, proc process) {
 // fire reports the exit of the nth microVM this runtime started, counting from 0.
 func (s *guestExitStub) fire(t *testing.T, n int) {
 	t.Helper()
+	s.at(t, n)(errors.New("signal: killed"))
+}
+
+// fireAsync reports the exit from a goroutine of its own, the way the real process
+// watcher does. Needed when the exit is injected from inside a lifecycle
+// operation, since handling it waits for that operation's transition claim.
+func (s *guestExitStub) fireAsync(t *testing.T, n int) {
+	t.Helper()
+	onExit := s.at(t, n)
+	go onExit(errors.New("signal: killed"))
+}
+
+func (s *guestExitStub) at(t *testing.T, n int) func(error) {
+	t.Helper()
 	s.mu.Lock()
-	count := len(s.exits)
-	var onExit func(error)
-	if n < count {
-		onExit = s.exits[n]
+	defer s.mu.Unlock()
+	if n >= len(s.exits) {
+		t.Fatalf("microVM %d was never started (%d starts recorded)", n, len(s.exits))
 	}
-	s.mu.Unlock()
-	if onExit == nil {
-		t.Fatalf("microVM %d was never started (%d starts recorded)", n, count)
+	return s.exits[n]
+}
+
+// waitForGuestDeaths blocks until the death handler has counted want deaths. The
+// handler runs on the watcher goroutine, so it is not ordered against the caller.
+func waitForGuestDeaths(t *testing.T, rec *metrics.RunnerRecorder, want float64) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		got := rec.GuestDeathCount()
+		if got >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("guest death metric = %v, want %v", got, want)
+		}
+		time.Sleep(time.Millisecond)
 	}
-	onExit(errors.New("signal: killed"))
+}
+
+// countingProcess and countingProxy are the concurrency-safe counterparts of
+// fakeProcess and fakeProxy, for the one test that drives two teardowns of the
+// same microVM at once. blockFirstStop holds the first Stop until released, which
+// is what parks a guest-death teardown mid-flight.
+type countingProcess struct {
+	kills atomic.Int32
+}
+
+func (p *countingProcess) Kill() error {
+	p.kills.Add(1)
+	return nil
+}
+
+type countingProxy struct {
+	stops          atomic.Int32
+	blockFirstStop chan struct{}
+	firstStop      chan struct{}
+}
+
+func (p *countingProxy) Stop() error {
+	if p.stops.Add(1) == 1 && p.blockFirstStop != nil {
+		close(p.firstStop)
+		<-p.blockFirstStop
+	}
+	return nil
+}
+
+// Shutdown will not wait for a transition claim it finds held, so it can tear down
+// the same microVM a guest-death handler is already tearing down. Both must not
+// stop the proxy or kill the process twice, and -race must stay quiet on the
+// handles they share.
+func TestShutdownRacingGuestDeathTearsDownTheMicroVMOnce(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+
+	proc := &countingProcess{}
+	proxy := &countingProxy{blockFirstStop: make(chan struct{}), firstStop: make(chan struct{})}
+	exits := &guestExitStub{}
+	exits.install(rt, proc)
+	rt.deps.newProxy = func(context.Context, string, string, string) (daemonProxy, error) { return proxy, nil }
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+
+	// The guest dies, and its handler is parked inside its own teardown holding the
+	// sandbox's claim.
+	exits.fireAsync(t, 0)
+	select {
+	case <-proxy.firstStop:
+	case <-time.After(5 * time.Second):
+		t.Fatal("guest death handler never reached its teardown")
+	}
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		rt.Shutdown(context.Background())
+	}()
+
+	// Shutdown has to finish rather than block on the held claim, and the parked
+	// teardown then has to finish against a state Shutdown has already deleted.
+	close(proxy.blockFirstStop)
+	select {
+	case <-shutdownDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Shutdown blocked on the guest death handler's claim")
+	}
+
+	if got := proxy.stops.Load(); got != 1 {
+		t.Errorf("daemon proxy stopped %d times, want 1", got)
+	}
+	if got := proc.kills.Load(); got != 1 {
+		t.Errorf("microVM process killed %d times, want 1", got)
+	}
+	if got := capacityOf(t, rt); got.Used != 0 {
+		t.Errorf("capacity used = %d, want the slot back after shutdown", got.Used)
+	}
 }
 
 func capacityOf(t *testing.T, rt *Runtime) runnerruntime.Capacity {
@@ -109,6 +218,112 @@ func TestGuestDeathFreesSlotAndPinsSandboxToColdBoot(t *testing.T) {
 	}
 	if err := rt.DeleteSandbox(context.Background(), sandboxID); err != nil {
 		t.Fatalf("DeleteSandbox() after crash failed: %v", err)
+	}
+}
+
+// A guest that dies mid-wake is the case the generation counter cannot see: the
+// wake's rollback bumps the generation before the exit is handled, so the death
+// looks like one the runner asked for.
+func TestGuestDeathDuringWakePinsSandboxToColdBoot(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+	rec := metrics.NewRunnerRecorder(true)
+	rt.SetMetricsRecorder(rec)
+
+	exits := &guestExitStub{}
+	exits.install(rt, &fakeProcess{})
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+	if err := rt.StopSandbox(context.Background(), sandboxID); err != nil {
+		t.Fatalf("StopSandbox() failed: %v", err)
+	}
+
+	// The restored guest dies while the wake is still in flight, which is why the
+	// wake then fails: the probe only gives up once the guest is gone.
+	rt.deps.probeDaemon = func(context.Context, string) error {
+		exits.fireAsync(t, 1)
+		waitForGuestDeaths(t, rec, 1)
+		return errors.New("connection refused")
+	}
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); err == nil {
+		t.Fatal("EnsureSandboxRunning() succeeded, want a failure with the guest gone")
+	}
+
+	// The guest ran against the rootfs after that snapshot was restored, so waking
+	// again has to be refused rather than restore the same snapshot a second time.
+	restores := 0
+	rt.deps.loadSnapshot = func(context.Context, string, Config) error {
+		restores++
+		return nil
+	}
+	rt.deps.probeDaemon = func(context.Context, string) error { return nil }
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); !errors.Is(err, errGuestCrashed) {
+		t.Fatalf("EnsureSandboxRunning() error = %v, want errGuestCrashed", err)
+	}
+	if restores != 0 {
+		t.Fatalf("second wake restored the stale snapshot %d times", restores)
+	}
+}
+
+// Same hazard without a death: the wake failed for a reason of its own and killed
+// a guest that had been running since the restore.
+func TestWakeFailureAfterRestorePinsSandboxToColdBoot(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+	rec := metrics.NewRunnerRecorder(true)
+	rt.SetMetricsRecorder(rec)
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+	if err := rt.StopSandbox(context.Background(), sandboxID); err != nil {
+		t.Fatalf("StopSandbox() failed: %v", err)
+	}
+
+	rt.deps.probeDaemon = func(context.Context, string) error { return errors.New("connection refused") }
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); err == nil {
+		t.Fatal("EnsureSandboxRunning() succeeded, want the probe failure")
+	}
+	if got := rec.GuestDeathCount(); got != 0 {
+		t.Fatalf("guest death metric = %v, want 0 for a guest the runner killed itself", got)
+	}
+
+	rt.deps.probeDaemon = func(context.Context, string) error { return nil }
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); !errors.Is(err, errGuestCrashed) {
+		t.Fatalf("EnsureSandboxRunning() error = %v, want errGuestCrashed", err)
+	}
+}
+
+// The other side of that invariant: a wake that never got as far as restoring left
+// the snapshot matching the rootfs, so it has to stay wakeable.
+func TestWakeFailureBeforeRestoreLeavesSandboxWakeable(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+	if err := rt.StopSandbox(context.Background(), sandboxID); err != nil {
+		t.Fatalf("StopSandbox() failed: %v", err)
+	}
+
+	rt.deps.start = func(context.Context, func(error), string, ...string) (process, error) {
+		return nil, errors.New("jailer refused to start")
+	}
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); err == nil {
+		t.Fatal("EnsureSandboxRunning() succeeded, want the jailer failure")
+	}
+
+	rt.deps.start = func(context.Context, func(error), string, ...string) (process, error) {
+		return &fakeProcess{}, nil
+	}
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); err != nil {
+		t.Fatalf("EnsureSandboxRunning() after a failure before the restore: %v", err)
 	}
 }
 

--- a/internal/runner/runtime/firecracker.ee/crash_test.go
+++ b/internal/runner/runtime/firecracker.ee/crash_test.go
@@ -84,7 +84,7 @@ func TestGuestDeathFreesSlotAndPinsSandboxToColdBoot(t *testing.T) {
 	if !proxy.stopped {
 		t.Fatal("crashed sandbox left its daemon proxy running")
 	}
-	if got := rec.GuestDeathCount(metrics.BackendFirecracker); got != 1 {
+	if got := rec.GuestDeathCount(); got != 1 {
 		t.Fatalf("guest death metric = %v, want 1", got)
 	}
 
@@ -133,7 +133,7 @@ func TestIntentionalStopIsNotReportedAsGuestDeath(t *testing.T) {
 	// that for a crash would pin every idle-stopped sandbox to cold boot.
 	exits.fire(t, 0)
 
-	if got := rec.GuestDeathCount(metrics.BackendFirecracker); got != 0 {
+	if got := rec.GuestDeathCount(); got != 0 {
 		t.Fatalf("guest death metric = %v, want 0 after an intentional stop", got)
 	}
 	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); err != nil {
@@ -171,14 +171,14 @@ func TestStaleGuestExitDoesNotCrashTheCurrentMicroVM(t *testing.T) {
 	if _, err := rt.DaemonURL(context.Background(), sandboxID); err != nil {
 		t.Fatalf("DaemonURL() after stale exit failed: %v", err)
 	}
-	if got := rec.GuestDeathCount(metrics.BackendFirecracker); got != 0 {
+	if got := rec.GuestDeathCount(); got != 0 {
 		t.Fatalf("guest death metric = %v, want 0 for a stale exit", got)
 	}
 
 	// The incarnation that is actually running still gets detected.
 	exits.fire(t, 1)
 
-	if got := rec.GuestDeathCount(metrics.BackendFirecracker); got != 1 {
+	if got := rec.GuestDeathCount(); got != 1 {
 		t.Fatalf("guest death metric = %v, want 1 after the current microVM died", got)
 	}
 	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); !errors.Is(err, errGuestCrashed) {

--- a/internal/runner/runtime/firecracker.ee/network/network.go
+++ b/internal/runner/runtime/firecracker.ee/network/network.go
@@ -46,6 +46,16 @@ iptables -C FORWARD -i fc-veth+ -j ACCEPT 2>/dev/null \
 
 // SetupScript builds a shell script that creates a per-slot netns, TAP, veth
 // uplink, routing, NAT, and egress policy.
+//
+// It clears the slot before building it, which is what lets a slot be handed back
+// for reuse even when the teardown that released it failed. Both names it creates
+// on the host are per-slot, so both have to be cleared: a leftover veth would
+// otherwise fail `ip link add` under `set -eu`, and the leftover survives precisely
+// when cleanup never ran at all — a cleanup budget that expired before its script
+// started, say. Deleting the netns by name also succeeds while a stale microVM is
+// still running inside it, because the kernel keeps that namespace alive for the
+// process while the name is freed, so the new sandbox gets an empty namespace and
+// the stale guest is left isolated in an unnamed one.
 func SetupScript(slot int, netnsName, tapDevice, tapCIDR string) string {
 	q := shellquote.Quote
 	if tapDevice == "" {
@@ -56,6 +66,7 @@ func SetupScript(slot int, netnsName, tapDevice, tapCIDR string) string {
 
 	var b strings.Builder
 	b.WriteString("set -eu\n")
+	fmt.Fprintf(&b, "ip link delete %s 2>/dev/null || true\n", q(hostVeth))
 	fmt.Fprintf(&b, "ip netns delete %s 2>/dev/null || true\n", q(netnsName))
 	fmt.Fprintf(&b, "ip netns add %s\n", q(netnsName))
 	fmt.Fprintf(&b, "ip link add %s type veth peer name %s netns %s\n",

--- a/internal/runner/runtime/firecracker.ee/network/network_test.go
+++ b/internal/runner/runtime/firecracker.ee/network/network_test.go
@@ -26,3 +26,21 @@ func TestSetupScriptIncludesTopologyAndPolicy(t *testing.T) {
 		}
 	}
 }
+
+// A slot can be reused after a teardown that failed before removing anything, so
+// setup has to clear both of the per-slot host names it goes on to create. Missing
+// either one fails the whole script under `set -eu` and strands the slot.
+func TestSetupScriptClearsSlotBeforeCreatingIt(t *testing.T) {
+	script := SetupScript(3, "fc-sb-3", "fc-tap-0", "172.16.0.1/24")
+	for _, want := range []string{
+		"ip link delete 'fc-veth-3' 2>/dev/null || true",
+		"ip netns delete 'fc-sb-3' 2>/dev/null || true",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("setup script missing %q, so a leftover from a failed teardown breaks slot reuse", want)
+		}
+	}
+	if strings.Index(script, "ip link delete 'fc-veth-3'") > strings.Index(script, "ip link add 'fc-veth-3'") {
+		t.Error("setup script deletes the host veth after creating it")
+	}
+}

--- a/internal/runner/runtime/firecracker.ee/runtime.go
+++ b/internal/runner/runtime/firecracker.ee/runtime.go
@@ -160,6 +160,7 @@ type sandboxState struct {
 	slot              int
 	info              *runnerruntime.SandboxInfo
 	netnsName         string
+	hostVeth          string
 	socketPath        string
 	daemonURL         string
 	dataDir           string
@@ -205,9 +206,20 @@ type process interface {
 // processGroup kills Firecracker and any children started in its process group.
 type processGroup struct {
 	process *os.Process
+	// reaped is set once wait has collected the process, after which its pid is no
+	// longer ours to signal.
+	reaped atomic.Bool
 }
 
 func (p *processGroup) Kill() error {
+	// The pid identifies this process group only until it is reaped; the kernel is
+	// then free to hand it to something else, and signalling a whole group by a
+	// recycled id could kill unrelated processes. Crash handling reaches here after
+	// the exit it reacts to, having waited for the sandbox's claim, so this is the
+	// ordinary case rather than a corner of one.
+	if p.reaped.Load() {
+		return os.ErrProcessDone
+	}
 	if err := syscall.Kill(-p.process.Pid, syscall.SIGKILL); err != nil {
 		if err == syscall.ESRCH {
 			return os.ErrProcessDone
@@ -500,6 +512,7 @@ func (r *Runtime) reserveSandbox(sandboxID string) (*sandboxState, error) {
 		vmID:              vmID,
 		slot:              slot,
 		netnsName:         netnsName,
+		hostVeth:          fcnetwork.HostVethName(slot),
 		socketPath:        socketPath,
 		daemonURL:         daemonURL,
 		dataDir:           dataDir,
@@ -529,19 +542,24 @@ func (r *Runtime) deleteSandbox(ctx context.Context, state *sandboxState) error 
 	}
 	// Read under the lock, once, and used for the rest of this call: on the Shutdown
 	// path this delete may not hold the sandbox's claim, so another teardown can be
-	// clearing the handles and releasing the slot while it runs.
-	hasVM := state.process != nil || state.proxy != nil
+	// releasing the slot while it runs.
 	slot := state.slot
 	r.mu.Unlock()
 
 	slog.Debug("firecracker sandbox cleanup started", "sandbox_id", state.id, "vm_id", state.vmID, "slot", slot)
 
 	var errs []error
-	if hasVM {
-		if err := r.teardownRunningVM(ctx, state); err != nil {
-			slog.Warn("firecracker host cleanup failed", "sandbox_id", state.id, "err", err)
-			errs = append(errs, err)
-		}
+	// Run unconditionally, including for a sandbox whose handles are already gone. A
+	// stop or crash whose host cleanup failed still marks the sandbox stopped and
+	// drops those handles, so skipping cleanup here on the strength of them would
+	// leave the jail's bind mounts in place and the data dir removed below out from
+	// under them — the snapshot files stay allocated, unreclaimable, and startup
+	// reconcile cannot free them either, because its rm -rf fails on a directory
+	// holding an active mount. Repeating cleanup is safe: every step is guarded, and
+	// what it removes is keyed to this vmID.
+	if err := r.teardownRunningVM(ctx, state); err != nil {
+		slog.Warn("firecracker host cleanup failed", "sandbox_id", state.id, "err", err)
+		errs = append(errs, err)
 	}
 	if err := removeSandboxDataDir(ctx, state.dataDir); err != nil {
 		slog.Warn("firecracker sandbox data cleanup failed", "sandbox_id", state.id, "data_dir", state.dataDir, "err", err)
@@ -694,6 +712,12 @@ func (r *Runtime) waitForSocket(ctx context.Context, socketPath string) error {
 
 // cleanupHost removes the bind mounts, network namespace, and jail directory
 // created for a sandbox. It is intentionally best-effort at the shell level.
+//
+// Every name it needs is one the slot reservation wrote and no teardown touches,
+// which is why hostVeth is carried on the state rather than derived from the slot
+// here: two teardowns can run this concurrently — a guest death racing shutdown —
+// and the one that arrives second would otherwise read a slot the first has already
+// released and set to -1, naming a device that does not exist.
 func (r *Runtime) cleanupHost(ctx context.Context, state *sandboxState) error {
 	jailDir := filepath.Join(r.config.JailerBaseDir, "firecracker", state.vmID)
 	rootfsTarget := filepath.Join(jailDir, "root", strings.TrimPrefix(r.config.SnapshotVirtioBlockPath, "/"))
@@ -705,7 +729,7 @@ umount -l %[3]s 2>/dev/null || true
 %[4]s
 rm -rf %[1]s
 `, shellquote.Quote(jailDir), shellquote.Quote(state.netnsName), shellquote.Quote(rootfsTarget),
-		strings.TrimSpace(fcnetwork.CleanupScript(state.netnsName, fcnetwork.HostVethName(state.slot))))
+		strings.TrimSpace(fcnetwork.CleanupScript(state.netnsName, state.hostVeth)))
 	return r.deps.run(ctx, "sudo", "/bin/sh", "-c", script)
 }
 
@@ -734,13 +758,17 @@ func startCommand(ctx context.Context, onExit func(error), name string, args ...
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("%s failed: %w", commandString(name, args), err)
 	}
+	group := &processGroup{process: cmd.Process}
 	go func() {
 		err := cmd.Wait()
+		// Marked before the exit is reported, so the crash handling that follows
+		// cannot signal a pid the kernel has already taken back.
+		group.reaped.Store(true)
 		if onExit != nil {
 			onExit(err)
 		}
 	}()
-	return &processGroup{process: cmd.Process}, nil
+	return group, nil
 }
 
 func pathExists(path string) bool {

--- a/internal/runner/runtime/firecracker.ee/runtime.go
+++ b/internal/runner/runtime/firecracker.ee/runtime.go
@@ -172,6 +172,20 @@ type sandboxState struct {
 	stopped           bool
 	transition        sandboxTransition
 	stoppedAt         time.Time
+
+	// generation counts the microVM incarnations this sandbox has had. It is
+	// bumped in teardownRunningVM, before the process is killed, and captured by
+	// the exit callback of the process being started, so an exit the runner
+	// caused is told apart from a guest that died on its own. One counter covers
+	// stop, delete, wake rollback and shutdown, and it also stops a dying old
+	// incarnation from marking a freshly started one dead.
+	generation uint64
+
+	// mustColdBoot pins a crashed sandbox away from its snapshot. The guest kept
+	// writing to the rootfs after that snapshot was taken, and restoring a memory
+	// image whose cached filesystem metadata no longer matches the disk corrupts
+	// it silently, with nothing to detect the mismatch.
+	mustColdBoot bool
 }
 
 // deleting reports whether the sandbox has been claimed for teardown. r.mu must
@@ -208,7 +222,7 @@ type daemonProxy interface {
 // dependencies groups host operations so tests can replace shell, process, and network calls.
 type dependencies struct {
 	run                 func(ctx context.Context, name string, args ...string) error
-	start               func(ctx context.Context, name string, args ...string) (process, error)
+	start               func(ctx context.Context, onExit func(error), name string, args ...string) (process, error)
 	pathExists          func(path string) bool
 	cloneRootfs         func(ctx context.Context, templatePath, destPath string) error
 	cloneGoldenSnapshot func(ctx context.Context, goldenMemPath, goldenStatePath, dataDir string) error
@@ -603,11 +617,14 @@ func (r *Runtime) setupNetwork(ctx context.Context, state *sandboxState) error {
 }
 
 // startJailer starts Firecracker through jailer inside the sandbox netns.
-func (r *Runtime) startJailer(ctx context.Context, state *sandboxState) (process, error) {
+// onExit fires once the microVM is gone: jailer execs Firecracker in place, so
+// the process started here lives exactly as long as the guest does.
+func (r *Runtime) startJailer(ctx context.Context, state *sandboxState, onExit func(error)) (process, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	return r.deps.start(ctx,
+		onExit,
 		"sudo",
 		r.config.JailerBin,
 		"--id", state.vmID,
@@ -667,8 +684,10 @@ func runCommand(ctx context.Context, name string, args ...string) error {
 	return nil
 }
 
-// startCommand starts a long-running host process without waiting for it.
-func startCommand(ctx context.Context, name string, args ...string) (process, error) {
+// startCommand starts a long-running host process without waiting for it, and
+// reports its exit to onExit. The wait has to happen regardless, to reap the
+// child; handing its error to the caller is what turns it into crash detection.
+func startCommand(ctx context.Context, onExit func(error), name string, args ...string) (process, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -680,7 +699,10 @@ func startCommand(ctx context.Context, name string, args ...string) (process, er
 		return nil, fmt.Errorf("%s failed: %w", commandString(name, args), err)
 	}
 	go func() {
-		_ = cmd.Wait()
+		err := cmd.Wait()
+		if onExit != nil {
+			onExit(err)
+		}
 	}()
 	return &processGroup{process: cmd.Process}, nil
 }

--- a/internal/runner/runtime/firecracker.ee/runtime.go
+++ b/internal/runner/runtime/firecracker.ee/runtime.go
@@ -352,10 +352,16 @@ func (r *Runtime) CreateSandbox(ctx context.Context, sandboxID string, _ *runner
 			// reclaim it, but no retry can arrive here: this create is about to return
 			// an error, so the API stores no record for the sandbox and neither an
 			// explicit delete nor the idle sweeper can name it again. Holding the slot
-			// would strand runner capacity until the process restarts. So it goes back
-			// on the same terms a failed stop hands its slot back: the next sandbox
-			// here recreates the netns, the rest of the leftovers are keyed to this
-			// vmID, and startup reconcile removes them.
+			// would strand runner capacity until the process restarts.
+			//
+			// So it goes back on the same terms a failed stop hands its slot back. What
+			// makes that safe is that the next sandbox here clears the slot before
+			// building it: setupNetwork deletes both per-slot host names, netns and
+			// veth, whatever state they were left in. The jail directory is keyed to
+			// this vmID, so it collides with nothing and startup reconcile sweeps it.
+			// The proxy port is per-slot and freed by the Stop that teardown performs on
+			// every handle it claims; if that ever left the port bound, the next create
+			// on this slot fails loudly on bind rather than sharing it.
 			slog.Warn("firecracker create cleanup failed, releasing slot anyway",
 				"sandbox_id", sandboxID, "vm_id", state.vmID, "slot", state.slot, "err", err)
 			r.untrackSandbox(state)

--- a/internal/runner/runtime/firecracker.ee/runtime.go
+++ b/internal/runner/runtime/firecracker.ee/runtime.go
@@ -347,7 +347,19 @@ func (r *Runtime) CreateSandbox(ctx context.Context, sandboxID string, _ *runner
 	cleanupOnError := func() {
 		cleanupCtx, cancelCleanup := withCleanupBudget(ctx)
 		defer cancelCleanup()
-		_ = r.deleteSandbox(cleanupCtx, state)
+		if err := r.deleteSandbox(cleanupCtx, state); err != nil {
+			// A delete that fails normally keeps its slot because a retry arrives to
+			// reclaim it, but no retry can arrive here: this create is about to return
+			// an error, so the API stores no record for the sandbox and neither an
+			// explicit delete nor the idle sweeper can name it again. Holding the slot
+			// would strand runner capacity until the process restarts. So it goes back
+			// on the same terms a failed stop hands its slot back: the next sandbox
+			// here recreates the netns, the rest of the leftovers are keyed to this
+			// vmID, and startup reconcile removes them.
+			slog.Warn("firecracker create cleanup failed, releasing slot anyway",
+				"sandbox_id", sandboxID, "vm_id", state.vmID, "slot", state.slot, "err", err)
+			r.untrackSandbox(state)
+		}
 	}
 
 	timer := newStepTimer(metrics.OpCreate, r.metrics)
@@ -539,15 +551,24 @@ func (r *Runtime) deleteSandbox(ctx context.Context, state *sandboxState) error 
 		return err
 	}
 
-	r.mu.Lock()
-	if current, ok := r.sandboxes[state.id]; ok && current == state {
-		delete(r.sandboxes, state.id)
-		if state.slot >= 0 && r.slotOwnedByLocked(state.slot, state.id) {
-			r.releaseSlotLocked(state.slot)
-		}
-	}
-	r.mu.Unlock()
+	r.untrackSandbox(state)
 	return nil
+}
+
+// untrackSandbox drops the sandbox from the runner and hands its slot back. It is
+// a no-op once another state has taken over the id or the slot, so it cannot
+// reclaim capacity a later sandbox is already using.
+func (r *Runtime) untrackSandbox(state *sandboxState) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if current, ok := r.sandboxes[state.id]; !ok || current != state {
+		return
+	}
+	delete(r.sandboxes, state.id)
+	if state.slot >= 0 && r.slotOwnedByLocked(state.slot, state.id) {
+		r.releaseSlotLocked(state.slot)
+	}
 }
 
 // reserveSlotLocked marks the first free Firecracker slot as occupied. r.mu

--- a/internal/runner/runtime/firecracker.ee/runtime.go
+++ b/internal/runner/runtime/firecracker.ee/runtime.go
@@ -212,11 +212,22 @@ type processGroup struct {
 }
 
 func (p *processGroup) Kill() error {
-	// The pid identifies this process group only until it is reaped; the kernel is
-	// then free to hand it to something else, and signalling a whole group by a
-	// recycled id could kill unrelated processes. Crash handling reaches here after
-	// the exit it reacts to, having waited for the sandbox's claim, so this is the
-	// ordinary case rather than a corner of one.
+	// The pid names this process group only until it is reaped; the kernel is then
+	// free to hand the number to something else, and signalling a whole group by a
+	// recycled one could kill unrelated processes. Crash handling reaches here after
+	// the exit it reacts to, minutes later if it waited that long for the sandbox's
+	// claim, and it runs in the goroutine that did the reaping — so it always sees
+	// this flag set, and never signals.
+	//
+	// What the flag cannot order is a stop, delete or shutdown killing a guest that
+	// happens to be exiting on its own right then: it can read false in the instant
+	// between wait reaping the pid and the watcher recording it. No lock closes that,
+	// because the kernel frees the number inside wait, ahead of any code that could
+	// hold one. It stays harmless because of what the number being reusable implies:
+	// the kernel keeps it allocated while any process still belongs to the group, so
+	// a recycled id means the group was already empty and the signal had nothing of
+	// ours to reach. Jailer execs Firecracker in place, so that group is this one
+	// process and nothing else.
 	if p.reaped.Load() {
 		return os.ErrProcessDone
 	}

--- a/internal/runner/runtime/firecracker.ee/runtime.go
+++ b/internal/runner/runtime/firecracker.ee/runtime.go
@@ -181,10 +181,13 @@ type sandboxState struct {
 	// incarnation from marking a freshly started one dead.
 	generation uint64
 
-	// mustColdBoot pins a crashed sandbox away from its snapshot. The guest kept
-	// writing to the rootfs after that snapshot was taken, and restoring a memory
-	// image whose cached filesystem metadata no longer matches the disk corrupts
-	// it silently, with nothing to detect the mismatch.
+	// mustColdBoot pins a sandbox away from its snapshot. Restoring a memory image
+	// whose cached filesystem metadata no longer matches the disk corrupts it
+	// silently, with nothing to detect the mismatch, and the guest has been writing
+	// to the rootfs ever since the restore that resumed it. So it is set once the
+	// snapshot is restored and cleared only by the snapshot a stop takes of the
+	// paused guest: anything else that ends the microVM in between — a crash, or a
+	// wake that failed after the restore — leaves the pair mismatched.
 	mustColdBoot bool
 }
 
@@ -501,16 +504,22 @@ func (r *Runtime) reserveSandbox(sandboxID string) (*sandboxState, error) {
 // is upgraded to transitionDeleting here for the create-cleanup path, which
 // deletes under its own creation claim.
 func (r *Runtime) deleteSandbox(ctx context.Context, state *sandboxState) error {
-	slog.Debug("firecracker sandbox cleanup started", "sandbox_id", state.id, "vm_id", state.vmID, "slot", state.slot)
 	r.mu.Lock()
 	if current, ok := r.sandboxes[state.id]; ok && current == state {
 		state.running = false
 		state.transition = transitionDeleting
 	}
+	// Read under the lock, once, and used for the rest of this call: on the Shutdown
+	// path this delete may not hold the sandbox's claim, so another teardown can be
+	// clearing the handles and releasing the slot while it runs.
+	hasVM := state.process != nil || state.proxy != nil
+	slot := state.slot
 	r.mu.Unlock()
 
+	slog.Debug("firecracker sandbox cleanup started", "sandbox_id", state.id, "vm_id", state.vmID, "slot", slot)
+
 	var errs []error
-	if state.process != nil || state.proxy != nil {
+	if hasVM {
 		if err := r.teardownRunningVM(ctx, state); err != nil {
 			slog.Warn("firecracker host cleanup failed", "sandbox_id", state.id, "err", err)
 			errs = append(errs, err)
@@ -520,7 +529,7 @@ func (r *Runtime) deleteSandbox(ctx context.Context, state *sandboxState) error 
 		slog.Warn("firecracker sandbox data cleanup failed", "sandbox_id", state.id, "data_dir", state.dataDir, "err", err)
 		errs = append(errs, fmt.Errorf("remove sandbox data dir: %w", err))
 	}
-	slog.Debug("firecracker sandbox cleanup finished", "sandbox_id", state.id, "vm_id", state.vmID, "slot", state.slot)
+	slog.Debug("firecracker sandbox cleanup finished", "sandbox_id", state.id, "vm_id", state.vmID, "slot", slot)
 	if err := joinErrors(errs); err != nil {
 		r.mu.Lock()
 		if current, ok := r.sandboxes[state.id]; ok && current == state {

--- a/internal/runner/runtime/firecracker.ee/runtime_test.go
+++ b/internal/runner/runtime/firecracker.ee/runtime_test.go
@@ -477,6 +477,47 @@ func TestRuntimeCreateSandboxCleansUpOnFailure(t *testing.T) {
 	}
 }
 
+// A failed delete normally keeps its slot so a delete retry can reclaim it, but a
+// failed create is the one caller with no retry behind it: it returns an error, so
+// the API stores no record and nothing can name the sandbox again. Its slot has to
+// come back here or it is stranded until the runner restarts.
+func TestRuntimeCreateSandboxReleasesSlotWhenCleanupFails(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+
+	// cleanupHost is the only script that removes the jail directory, so a busy
+	// mount under it fails the create's cleanup and nothing else.
+	rt.deps.run = func(_ context.Context, _ string, args ...string) error {
+		if len(args) > 0 && strings.Contains(args[len(args)-1], "rm -rf") {
+			return errors.New("rm: cannot remove jail dir: Device or resource busy")
+		}
+		return nil
+	}
+	rt.deps.probeDaemon = func(context.Context, string) error { return errors.New("daemon down") }
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err == nil {
+		t.Fatal("expected CreateSandbox() failure")
+	}
+
+	capacity, err := rt.Capacity(context.Background())
+	if err != nil {
+		t.Fatalf("Capacity() failed: %v", err)
+	}
+	if capacity.Used != 0 {
+		t.Fatalf("Capacity().Used = %d, want the slot back even though cleanup failed", capacity.Used)
+	}
+	if _, err := rt.GetSandboxInfo(context.Background(), sandboxID); !errors.Is(err, runnerruntime.ErrSandboxNotFound) {
+		t.Fatalf("GetSandboxInfo() error = %v, want ErrSandboxNotFound", err)
+	}
+	// The id has to be free too, or a retry of the same create is refused forever.
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err == nil {
+		t.Fatal("expected CreateSandbox() failure")
+	} else if strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("CreateSandbox() error = %v, want the id to be reusable", err)
+	}
+}
+
 func TestProbeDaemonRejectsUnhealthyStatus(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)

--- a/internal/runner/runtime/firecracker.ee/runtime_test.go
+++ b/internal/runner/runtime/firecracker.ee/runtime_test.go
@@ -49,7 +49,9 @@ func testRunnerConfig(capacity int32) *config.Config {
 
 func stubCreateDeps(rt *Runtime) {
 	rt.deps.run = func(context.Context, string, ...string) error { return nil }
-	rt.deps.start = func(context.Context, string, ...string) (process, error) { return &fakeProcess{}, nil }
+	rt.deps.start = func(context.Context, func(error), string, ...string) (process, error) {
+		return &fakeProcess{}, nil
+	}
 	rt.deps.pathExists = func(string) bool { return true }
 	rt.deps.cloneRootfs = func(context.Context, string, string) error { return nil }
 	rt.deps.cloneGoldenSnapshot = func(_ context.Context, _, _, dataDir string) error {
@@ -163,7 +165,7 @@ func TestRuntimeCreateSandboxStartsFirecrackerAndProxy(t *testing.T) {
 		commands = append(commands, recordedCommand{name: name, args: args})
 		return nil
 	}
-	rt.deps.start = func(_ context.Context, name string, args ...string) (process, error) {
+	rt.deps.start = func(_ context.Context, _ func(error), name string, args ...string) (process, error) {
 		started = append(started, recordedCommand{name: name, args: args})
 		return proc, nil
 	}
@@ -294,7 +296,7 @@ func TestRuntimeDeleteHoldsSlotUntilCleanupCompletes(t *testing.T) {
 		}
 		return nil
 	}
-	rt.deps.start = func(context.Context, string, ...string) (process, error) { return proc, nil }
+	rt.deps.start = func(context.Context, func(error), string, ...string) (process, error) { return proc, nil }
 	rt.deps.pathExists = func(string) bool { return true }
 	rt.deps.cloneRootfs = func(context.Context, string, string) error { return nil }
 	rt.deps.cloneGoldenSnapshot = func(context.Context, string, string, string) error { return nil }
@@ -342,7 +344,7 @@ func TestRuntimeDeleteSandboxWaitsForCreate(t *testing.T) {
 
 	proc := &fakeProcess{}
 	proxy := &fakeProxy{}
-	rt.deps.start = func(context.Context, string, ...string) (process, error) { return proc, nil }
+	rt.deps.start = func(context.Context, func(error), string, ...string) (process, error) { return proc, nil }
 	rt.deps.newProxy = func(context.Context, string, string, string) (daemonProxy, error) { return proxy, nil }
 
 	createReachedSnapshot := make(chan struct{})
@@ -442,7 +444,7 @@ func TestRuntimeCreateSandboxCleansUpOnFailure(t *testing.T) {
 		runCount++
 		return nil
 	}
-	rt.deps.start = func(context.Context, string, ...string) (process, error) { return proc, nil }
+	rt.deps.start = func(context.Context, func(error), string, ...string) (process, error) { return proc, nil }
 	rt.deps.pathExists = func(string) bool { return true }
 	rt.deps.cloneRootfs = func(context.Context, string, string) error { return nil }
 	rt.deps.cloneGoldenSnapshot = func(context.Context, string, string, string) error { return nil }
@@ -489,7 +491,7 @@ func TestProbeDaemonRejectsUnhealthyStatus(t *testing.T) {
 }
 
 func TestStartCommandRunsInOwnProcessGroup(t *testing.T) {
-	proc, err := startCommand(context.Background(), "sh", "-c", "sleep 10")
+	proc, err := startCommand(context.Background(), nil, "sh", "-c", "sleep 10")
 	if err != nil {
 		t.Fatalf("startCommand() failed: %v", err)
 	}

--- a/internal/runner/runtime/firecracker.ee/runtime_test.go
+++ b/internal/runner/runtime/firecracker.ee/runtime_test.go
@@ -518,6 +518,66 @@ func TestRuntimeCreateSandboxReleasesSlotWhenCleanupFails(t *testing.T) {
 	}
 }
 
+// A stop whose host cleanup failed still marks the sandbox stopped and drops its
+// process and proxy handles. The delete that follows has to clean up regardless, or
+// the jail's bind mounts go on pinning the snapshot files the delete removes, with
+// nothing left able to free them.
+func TestRuntimeDeleteRunsHostCleanupForAStoppedSandbox(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+	if err := rt.StopSandbox(context.Background(), sandboxID); err != nil {
+		t.Fatalf("StopSandbox() failed: %v", err)
+	}
+
+	unmounts := 0
+	rt.deps.run = func(_ context.Context, _ string, args ...string) error {
+		if len(args) > 0 && strings.Contains(args[len(args)-1], "umount") {
+			unmounts++
+		}
+		return nil
+	}
+	if err := rt.DeleteSandbox(context.Background(), sandboxID); err != nil {
+		t.Fatalf("DeleteSandbox() failed: %v", err)
+	}
+	if unmounts == 0 {
+		t.Error("delete skipped host cleanup, so the jail mounts still pin the deleted snapshot files")
+	}
+}
+
+// Once a process has been reaped its pid is the kernel's to reuse, and signalling a
+// whole process group by a recycled id would kill unrelated processes. A live group
+// stands in for that here: if Kill signalled despite the reap, it would die.
+func TestProcessGroupKillSkipsAReapedPid(t *testing.T) {
+	exited := make(chan struct{})
+	proc, err := startCommand(context.Background(), func(error) { close(exited) }, "sh", "-c", "sleep 30")
+	if err != nil {
+		t.Fatalf("startCommand() failed: %v", err)
+	}
+	group, ok := proc.(*processGroup)
+	if !ok {
+		t.Fatalf("startCommand() returned %T, want *processGroup", proc)
+	}
+	t.Cleanup(func() {
+		group.reaped.Store(false)
+		_ = group.Kill()
+	})
+
+	group.reaped.Store(true)
+	if err := group.Kill(); !errors.Is(err, os.ErrProcessDone) {
+		t.Errorf("Kill() = %v, want os.ErrProcessDone", err)
+	}
+	select {
+	case <-exited:
+		t.Error("Kill signalled a process group it had already recorded as reaped")
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
 func TestProbeDaemonRejectsUnhealthyStatus(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)

--- a/internal/runner/runtime/firecracker.ee/stop_wake.go
+++ b/internal/runner/runtime/firecracker.ee/stop_wake.go
@@ -56,8 +56,27 @@ func (r *Runtime) StopSandbox(ctx context.Context, sandboxID string) error {
 	if err := r.deps.createSnapshot(ctx, state.socketPath); err != nil {
 		return fmt.Errorf("create firecracker snapshot: %w", err)
 	}
-	if err := r.teardownRunningVM(ctx, state); err != nil {
-		return err
+	// Taken from a paused guest, so this snapshot and the rootfs describe the same
+	// moment. That makes this the one point at which restoring becomes safe again.
+	r.mu.Lock()
+	state.mustColdBoot = false
+	r.mu.Unlock()
+
+	// Reported, not returned as a reason to abandon the stop. The snapshot is
+	// written and the microVM is gone whatever this leaves on the host, and
+	// teardown has already dropped the process and proxy handles, so no retry can
+	// pick up where it stopped. Keeping the sandbox marked running would hold its
+	// slot for a microVM that no longer exists, hand out a daemon URL nothing
+	// listens on, and fail every later stop against an API socket that died with
+	// its guest, so nothing would ever reclaim it. The slot is safe to hand back
+	// regardless of what cleanup left: setupNetwork deletes and recreates the netns
+	// before using it, and the rest is keyed to the vmID, which reconcile removes.
+	//
+	// A failed delete keeps its slot instead, because a delete retry does arrive to
+	// reclaim it (see the README); a stop has no such retry.
+	teardownErr := r.teardownRunningVM(ctx, state)
+	if teardownErr != nil {
+		slog.Warn("firecracker stopped sandbox teardown failed", "sandbox_id", sandboxID, "err", teardownErr)
 	}
 
 	r.mu.Lock()
@@ -73,7 +92,7 @@ func (r *Runtime) StopSandbox(ctx context.Context, sandboxID string) error {
 	r.mu.Unlock()
 
 	slog.Info("firecracker sandbox stopped", "sandbox_id", sandboxID, "vm_id", state.vmID)
-	return nil
+	return teardownErr
 }
 
 // EnsureSandboxRunning restores a stopped sandbox from its per-sandbox snapshot.
@@ -171,7 +190,12 @@ func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState, t 
 	if err != nil {
 		return fmt.Errorf("start firecracker jailer: %w", err)
 	}
+	// Published under the lock because Shutdown reads it without waiting for this
+	// activation's claim, and has to see a handle it can kill rather than a torn
+	// read that lets the microVM outlive the runner.
+	r.mu.Lock()
 	state.process = process
+	r.mu.Unlock()
 	if err := t.step(stepWaitSocket, func() error { return r.waitForSocket(ctx, state.socketPath) }); err != nil {
 		return fmt.Errorf("wait for firecracker socket: %w", err)
 	}
@@ -180,6 +204,14 @@ func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState, t 
 	}); err != nil {
 		return fmt.Errorf("load firecracker snapshot: %w", err)
 	}
+	// The restore resumes the guest, so from here on it writes to a rootfs the
+	// snapshot it came from no longer describes. Pinning at the restore rather
+	// than when a guest death is detected is what makes the pin reliable: it holds
+	// however the microVM ends, including for the deaths that arrive too late to
+	// be told apart from an exit the runner asked for.
+	r.mu.Lock()
+	state.mustColdBoot = true
+	r.mu.Unlock()
 	guestAddr := net.JoinHostPort(r.config.GuestIP, fmt.Sprintf("%d", r.config.DaemonPort))
 	var proxy daemonProxy
 	err = t.step(stepStartProxy, func() error {
@@ -190,7 +222,9 @@ func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState, t 
 	if err != nil {
 		return fmt.Errorf("start firecracker daemon proxy: %w", err)
 	}
+	r.mu.Lock()
 	state.proxy = proxy
+	r.mu.Unlock()
 	if err := t.step(stepProbeDaemon, func() error { return r.deps.probeDaemon(ctx, state.daemonURL) }); err != nil {
 		return fmt.Errorf("connect to firecracker daemon: %w", err)
 	}
@@ -202,23 +236,30 @@ func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState, t 
 // The generation bump has to come before the kill: it is what tells the exit
 // callback of the process being killed here that the runner asked for this exit,
 // so an ordinary stop, delete or wake rollback is not reported as a crash.
+//
+// The handles are taken off the state in the same critical section, which is what
+// makes two teardowns of one microVM safe. Normally the transition claim keeps
+// them apart, but Shutdown deliberately does not wait for a claim it finds held —
+// it would rather race a stop, wake or guest death than leave a microVM running
+// past the runner. Whoever takes the handles owns the stop and the kill; the other
+// caller finds nil and only repeats cleanupHost, which is written to be repeatable.
 func (r *Runtime) teardownRunningVM(ctx context.Context, state *sandboxState) error {
 	r.mu.Lock()
 	state.generation++
+	proxy, process := state.proxy, state.process
+	state.proxy, state.process = nil, nil
 	r.mu.Unlock()
 
 	var errs []error
-	if state.proxy != nil {
-		if err := state.proxy.Stop(); err != nil {
+	if proxy != nil {
+		if err := proxy.Stop(); err != nil {
 			errs = append(errs, fmt.Errorf("stop daemon proxy: %w", err))
 		}
-		state.proxy = nil
 	}
-	if state.process != nil {
-		if err := state.process.Kill(); err != nil && !containsProcessFinished(err) {
+	if process != nil {
+		if err := process.Kill(); err != nil && !containsProcessFinished(err) {
 			errs = append(errs, fmt.Errorf("kill firecracker process: %w", err))
 		}
-		state.process = nil
 	}
 	if err := r.cleanupHost(ctx, state); err != nil {
 		errs = append(errs, fmt.Errorf("cleanup firecracker host state: %w", err))

--- a/internal/runner/runtime/firecracker.ee/stop_wake.go
+++ b/internal/runner/runtime/firecracker.ee/stop_wake.go
@@ -2,6 +2,7 @@ package firecracker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -69,8 +70,9 @@ func (r *Runtime) StopSandbox(ctx context.Context, sandboxID string) error {
 	// slot for a microVM that no longer exists, hand out a daemon URL nothing
 	// listens on, and fail every later stop against an API socket that died with
 	// its guest, so nothing would ever reclaim it. The slot is safe to hand back
-	// regardless of what cleanup left: setupNetwork deletes and recreates the netns
-	// before using it, and the rest is keyed to the vmID, which reconcile removes.
+	// regardless of what cleanup left, because the next sandbox on it clears it
+	// first: setupNetwork deletes both per-slot host names, netns and veth, before
+	// creating them. What is left is keyed to the vmID, which reconcile removes.
 	//
 	// A failed delete keeps its slot instead, because a delete retry does arrive to
 	// reclaim it (see the README); a stop has no such retry.
@@ -166,9 +168,35 @@ func (r *Runtime) ensureSandboxRunningOnce(ctx context.Context, sandboxID string
 	return nil
 }
 
+// errActivationAbandoned ends an activation whose sandbox stopped being the
+// runner's own while its microVM was starting. It is returned after the handle is
+// published, never instead of publishing it, so the caller's rollback finds the
+// microVM and kills it.
+var errActivationAbandoned = errors.New("sandbox was torn down while its microVM was starting")
+
+// activationAbandonedLocked reports whether the sandbox being activated has been
+// taken away from this activation. Only Shutdown can do that: every other
+// lifecycle operation waits for the activation's claim before touching the
+// sandbox, while Shutdown overwrites the claim and deletes the sandbox rather than
+// let a microVM outlive the runner. r.mu must be held.
+func (r *Runtime) activationAbandonedLocked(state *sandboxState) bool {
+	current, ok := r.sandboxes[state.id]
+	return !ok || current != state || state.deleting()
+}
+
 // activateSandboxVM prepares jail/netns, starts Firecracker, loads snapshot, and
 // exposes the guest daemon through the host proxy. Each phase is timed through
 // t, which the caller emits once the operation finishes.
+//
+// Both handles are published before that ownership is rechecked, and a lost
+// sandbox fails the activation rather than carrying on. Shutdown does not wait for
+// the claim this runs under, so it can delete the sandbox and hand its slot back
+// while the microVM is still coming up — and it decides whether to tear the microVM
+// down by reading handles that do not exist yet. Carrying on would finish building
+// a guest nothing tracks: jailer's children are their own process group, so it
+// would outlive the runner, holding the netns and jail mounts of a slot already
+// handed to someone else. Failing routes it into the caller's rollback, which is
+// why the handle is published first — a rollback only tears down what it can see.
 func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState, t *stepTimer) error {
 	if err := t.step(stepPrepareJail, func() error { return r.prepareJail(ctx, state) }); err != nil {
 		return fmt.Errorf("prepare firecracker jail: %w", err)
@@ -195,7 +223,11 @@ func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState, t 
 	// read that lets the microVM outlive the runner.
 	r.mu.Lock()
 	state.process = process
+	abandoned := r.activationAbandonedLocked(state)
 	r.mu.Unlock()
+	if abandoned {
+		return errActivationAbandoned
+	}
 	if err := t.step(stepWaitSocket, func() error { return r.waitForSocket(ctx, state.socketPath) }); err != nil {
 		return fmt.Errorf("wait for firecracker socket: %w", err)
 	}
@@ -224,7 +256,11 @@ func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState, t 
 	}
 	r.mu.Lock()
 	state.proxy = proxy
+	abandoned = r.activationAbandonedLocked(state)
 	r.mu.Unlock()
+	if abandoned {
+		return errActivationAbandoned
+	}
 	if err := t.step(stepProbeDaemon, func() error { return r.deps.probeDaemon(ctx, state.daemonURL) }); err != nil {
 		return fmt.Errorf("connect to firecracker daemon: %w", err)
 	}

--- a/internal/runner/runtime/firecracker.ee/stop_wake.go
+++ b/internal/runner/runtime/firecracker.ee/stop_wake.go
@@ -99,13 +99,16 @@ func (r *Runtime) ensureSandboxRunningOnce(ctx context.Context, sandboxID string
 	defer r.endTransition(state)
 
 	r.mu.Lock()
-	running, stopped := state.running, state.stopped
+	running, stopped, mustColdBoot := state.running, state.stopped, state.mustColdBoot
 	r.mu.Unlock()
 	if running {
 		return nil
 	}
 	if !stopped {
 		return runnerruntime.ErrSandboxNotRunning
+	}
+	if mustColdBoot {
+		return errGuestCrashed
 	}
 
 	if err := r.reserveWakeSlot(state); err != nil {
@@ -154,10 +157,15 @@ func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState, t 
 	if err := t.step(stepSetupNetwork, func() error { return r.setupNetwork(ctx, state) }); err != nil {
 		return fmt.Errorf("setup firecracker network: %w", err)
 	}
+	r.mu.Lock()
+	generation := state.generation
+	r.mu.Unlock()
 	var process process
 	err := t.step(stepStartJailer, func() error {
 		var startErr error
-		process, startErr = r.startJailer(ctx, state)
+		process, startErr = r.startJailer(ctx, state, func(waitErr error) {
+			r.handleGuestDeath(state, generation, waitErr)
+		})
 		return startErr
 	})
 	if err != nil {
@@ -190,7 +198,15 @@ func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState, t 
 }
 
 // teardownRunningVM stops proxy, jailer, and jail state without deleting sandbox data.
+//
+// The generation bump has to come before the kill: it is what tells the exit
+// callback of the process being killed here that the runner asked for this exit,
+// so an ordinary stop, delete or wake rollback is not reported as a crash.
 func (r *Runtime) teardownRunningVM(ctx context.Context, state *sandboxState) error {
+	r.mu.Lock()
+	state.generation++
+	r.mu.Unlock()
+
 	var errs []error
 	if state.proxy != nil {
 		if err := state.proxy.Stop(); err != nil {

--- a/internal/runner/runtime/firecracker.ee/stop_wake.go
+++ b/internal/runner/runtime/firecracker.ee/stop_wake.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/n8n-io/sandbox-service/internal/metrics"
 	runnerruntime "github.com/n8n-io/sandbox-service/internal/runner/runtime"
+	fcnetwork "github.com/n8n-io/sandbox-service/internal/runner/runtime/firecracker.ee/network"
 )
 
 // stoppedSnapshotHeadroomBytes is extra free-space reserved on top of the
@@ -231,19 +232,28 @@ func (r *Runtime) activateSandboxVM(ctx context.Context, state *sandboxState, t 
 	if err := t.step(stepWaitSocket, func() error { return r.waitForSocket(ctx, state.socketPath) }); err != nil {
 		return fmt.Errorf("wait for firecracker socket: %w", err)
 	}
+	// Pinned before the request that would earn it, not after, because that request
+	// resumes the guest as it restores: one call both loads the snapshot and lets the
+	// guest start writing to a rootfs the snapshot no longer describes. A load that
+	// resumes the guest and then fails to report it — a deadline that expires while
+	// the response is read, a dropped connection — would otherwise roll back with the
+	// pin unset, and the next wake would restore that same snapshot onto the changed
+	// rootfs and corrupt it silently, which is the one outcome nothing downstream can
+	// detect. So the ambiguous case is resolved as if the guest ran.
+	//
+	// The cost is a load that failed without resuming anything being pinned too,
+	// which cold-boot recovery turns into a boot of the sandbox's own rootfs instead
+	// of a restore. Pinning here rather than earlier is what keeps that cost small:
+	// every step before this one fails unambiguously, with no guest having run, so
+	// those failures still leave the sandbox wakeable.
+	r.mu.Lock()
+	state.mustColdBoot = true
+	r.mu.Unlock()
 	if err := t.step(stepLoadSnapshot, func() error {
 		return r.deps.loadSnapshot(ctx, state.socketPath, r.config)
 	}); err != nil {
 		return fmt.Errorf("load firecracker snapshot: %w", err)
 	}
-	// The restore resumes the guest, so from here on it writes to a rootfs the
-	// snapshot it came from no longer describes. Pinning at the restore rather
-	// than when a guest death is detected is what makes the pin reliable: it holds
-	// however the microVM ends, including for the deaths that arrive too late to
-	// be told apart from an exit the runner asked for.
-	r.mu.Lock()
-	state.mustColdBoot = true
-	r.mu.Unlock()
 	guestAddr := net.JoinHostPort(r.config.GuestIP, fmt.Sprintf("%d", r.config.DaemonPort))
 	var proxy daemonProxy
 	err = t.step(stepStartProxy, func() error {
@@ -363,6 +373,7 @@ func (r *Runtime) reserveWakeSlot(state *sandboxState) error {
 	}
 	state.slot = slot
 	state.netnsName = fmt.Sprintf("fc-sb-%d", slot)
+	state.hostVeth = fcnetwork.HostVethName(slot)
 	state.socketPath = filepath.Join(r.config.JailerBaseDir, "firecracker", state.vmID, "root", "firecracker.socket")
 	state.daemonURL = fmt.Sprintf("http://%s", net.JoinHostPort(r.config.ProxyListenIP, fmt.Sprintf("%d", r.config.ProxyPortStart+slot)))
 	return nil

--- a/internal/runner/runtime/firecracker.ee/stop_wake_test.go
+++ b/internal/runner/runtime/firecracker.ee/stop_wake_test.go
@@ -123,7 +123,7 @@ func TestRuntimeDeleteSandboxWaitsForWake(t *testing.T) {
 
 	proc := &fakeProcess{}
 	proxy := &fakeProxy{}
-	rt.deps.start = func(context.Context, string, ...string) (process, error) { return proc, nil }
+	rt.deps.start = func(context.Context, func(error), string, ...string) (process, error) { return proc, nil }
 	rt.deps.newProxy = func(context.Context, string, string, string) (daemonProxy, error) { return proxy, nil }
 
 	wakeReachedSnapshot := make(chan struct{})
@@ -205,7 +205,7 @@ func TestRuntimeShutdownSkipsSandboxClaimedForDelete(t *testing.T) {
 
 	proc := &fakeProcess{}
 	proxy := &fakeProxy{}
-	rt.deps.start = func(context.Context, string, ...string) (process, error) { return proc, nil }
+	rt.deps.start = func(context.Context, func(error), string, ...string) (process, error) { return proc, nil }
 	rt.deps.newProxy = func(context.Context, string, string, string) (daemonProxy, error) { return proxy, nil }
 
 	const sandboxID = "sandbox-id-123456"
@@ -234,7 +234,7 @@ func TestRuntimeDeleteSandboxCompletesAfterCallerContextCanceled(t *testing.T) {
 
 	proc := &fakeProcess{}
 	proxy := &fakeProxy{}
-	rt.deps.start = func(context.Context, string, ...string) (process, error) { return proc, nil }
+	rt.deps.start = func(context.Context, func(error), string, ...string) (process, error) { return proc, nil }
 	rt.deps.newProxy = func(context.Context, string, string, string) (daemonProxy, error) { return proxy, nil }
 
 	const sandboxID = "sandbox-id-123456"

--- a/internal/runner/runtime/firecracker.ee/stop_wake_test.go
+++ b/internal/runner/runtime/firecracker.ee/stop_wake_test.go
@@ -59,6 +59,50 @@ func TestRuntimeStopSandboxEvictsOldestStoppedWhenDiskFull(t *testing.T) {
 	}
 }
 
+// Host cleanup is the one part of a stop that can fail after the microVM is
+// already gone. The stop has to finish anyway: teardown drops the process and
+// proxy handles, so a sandbox left marked running would hold its slot for a
+// microVM nothing can reach and fail every later stop against a dead API socket.
+func TestRuntimeStopSandboxFinishesWhenHostCleanupFails(t *testing.T) {
+	rt := testRuntimeT(t, 1)
+	stubCreateDeps(rt)
+
+	// cleanupHost is the only script that removes the jail directory, so a busy
+	// mount under it fails the stop's teardown and nothing else.
+	rt.deps.run = func(_ context.Context, _ string, args ...string) error {
+		if len(args) > 0 && strings.Contains(args[len(args)-1], "rm -rf") {
+			return errors.New("rm: cannot remove jail dir: Device or resource busy")
+		}
+		return nil
+	}
+
+	const sandboxID = "sandbox-id-123456"
+	if _, err := rt.CreateSandbox(context.Background(), sandboxID, nil); err != nil {
+		t.Fatalf("CreateSandbox() failed: %v", err)
+	}
+	if err := rt.StopSandbox(context.Background(), sandboxID); err == nil {
+		t.Fatal("StopSandbox() succeeded, want the host cleanup failure reported")
+	}
+
+	if got := capacityOf(t, rt); got.Used != 0 || got.Stopped != 1 {
+		t.Fatalf("capacity after the failed cleanup = %+v, want used 0 and stopped 1", got)
+	}
+	// Nothing is listening on the daemon URL any more, so a request has to be told
+	// the sandbox is not running instead of being proxied into a refused connection.
+	if _, err := rt.DaemonURL(context.Background(), sandboxID); !errors.Is(err, runnerruntime.ErrSandboxNotRunning) {
+		t.Fatalf("DaemonURL() error = %v, want ErrSandboxNotRunning", err)
+	}
+
+	// The snapshot was written before the cleanup failed, so the sandbox is a
+	// normal stopped one and has to wake.
+	if err := rt.EnsureSandboxRunning(context.Background(), sandboxID); err != nil {
+		t.Fatalf("EnsureSandboxRunning() after the failed cleanup: %v", err)
+	}
+	if got := capacityOf(t, rt); got.Used != 1 {
+		t.Fatalf("capacity after the wake = %+v, want the sandbox back on a slot", got)
+	}
+}
+
 func TestRuntimeEnsureSandboxRunningWaitsForStop(t *testing.T) {
 	rt := testRuntimeT(t, 2)
 	stubCreateDeps(rt)


### PR DESCRIPTION
## Summary

Detect crashed microVMs and free their slot on the runner.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects when a Firecracker microVM exits on its own, tears it down immediately, frees its slot, and marks the sandbox stopped. We refuse restoring a crashed sandbox’s snapshot (pin to cold boot) to avoid disk corruption; requests return 503 "crashed" until cold-boot recovery for CP‑2670 lands.

- Watches the jailer/Firecracker process and fires an on-exit callback guarded by a generation counter to ignore intentional teardown and stale exits.
- Emits a “firecracker guest died” event and increments `sandbox_guest_deaths_total`.
- After a death, tears the microVM down, releases the slot, and leaves the sandbox stopped and deletable.
- Pins any sandbox after a snapshot restore to cold boot; `EnsureSandboxRunning` refuses pinned sandboxes with a crash error; `StopSandbox` clears the pin only after writing a fresh snapshot.
- `StopSandbox` reports host cleanup errors but still marks stopped and returns the slot; failed creates now untrack the sandbox and release the slot when cleanup fails; deletes always rerun host cleanup even without live handles.
- Hardens shutdown/activation: avoid double teardown, abandon activation if the sandbox is deleted mid-start, and skip signaling reaped PIDs.
- Network setup clears the per-slot veth and netns before creating them so slots are reusable after failed cleanup.
- Admission verifies a complete golden snapshot set on restart (when a create script is configured) and rejects `snapshot_mem`/`snapshot_state` paths that don’t resolve to the generated outputs.
- Updates docs to include `sandbox_guest_deaths_total` and the “firecracker guest died” event; adds unit and e2e tests.

<sup>Written for commit 848c587eb9d4e96ae11ac65cbfebb1ff080b65ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

