### PR TITLE
CAT-4207: Minimize sandbox container capabilities

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -100,13 +100,15 @@ version never does so with a container on the bridge. Containers are created
 with IPv6 disabled.
 
 The runner creates every sandbox container with all Linux capabilities dropped.
-It then restores only `CAP_AUDIT_WRITE`, `CAP_CHOWN`, `CAP_DAC_OVERRIDE`,
-`CAP_FOWNER`, `CAP_SETGID`, and `CAP_SETUID`. This allowlist is sufficient for
-passwordless `sudo` and common `apt-get` package installation, while excluding
-capabilities for network administration, raw sockets, mounts, tracing, device
-creation, and other privileged operations. `CAP_AUDIT_WRITE` avoids audit
-warnings from successful `sudo` commands. `no-new-privileges` is not enabled
-because it would prevent the supported sudo workflow.
+It then restores only `CAP_CHOWN`, `CAP_DAC_OVERRIDE`, `CAP_FOWNER`,
+`CAP_SETGID`, and `CAP_SETUID`. This allowlist is sufficient for passwordless
+`sudo` and common `apt-get` package installation, while excluding capabilities
+for network administration, audit-log writes, raw sockets, mounts, tracing,
+device creation, and other privileged operations. Successful `sudo` commands
+may emit an audit warning because `CAP_AUDIT_WRITE` is intentionally excluded;
+granting it would allow audit-log injection and flooding in environments where
+the sandbox shares the initial user namespace. `no-new-privileges` is not
+enabled because it would prevent the supported sudo workflow.
 
 The allowlist holds in every environment. Sysbox isolation and privileged local
 DinD apply to the runner container, not to the sandbox container. A sandbox

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -99,15 +99,19 @@ sandbox can be created, so an upgraded runner replacing the rules of an earlier
 version never does so with a container on the bridge. Containers are created
 with IPv6 disabled.
 
-Every Docker-backed sandbox, including privileged local DinD, is created with
-all Linux capabilities dropped and only `CAP_AUDIT_WRITE`, `CAP_CHOWN`,
-`CAP_DAC_OVERRIDE`, `CAP_FOWNER`, `CAP_SETGID`, and `CAP_SETUID` restored. This
-allowlist is sufficient for passwordless `sudo` and common `apt-get` package
-installation, while excluding capabilities for network administration, raw
-sockets, mounts, tracing, device creation, and other privileged operations.
-`CAP_AUDIT_WRITE` avoids audit warnings from successful `sudo` commands.
-`no-new-privileges` is not enabled because it would prevent the supported sudo
-workflow.
+The runner creates every sandbox container with all Linux capabilities dropped.
+It then restores only `CAP_AUDIT_WRITE`, `CAP_CHOWN`, `CAP_DAC_OVERRIDE`,
+`CAP_FOWNER`, `CAP_SETGID`, and `CAP_SETUID`. This allowlist is sufficient for
+passwordless `sudo` and common `apt-get` package installation, while excluding
+capabilities for network administration, raw sockets, mounts, tracing, device
+creation, and other privileged operations. `CAP_AUDIT_WRITE` avoids audit
+warnings from successful `sudo` commands. `no-new-privileges` is not enabled
+because it would prevent the supported sudo workflow.
+
+The allowlist holds in every environment. Sysbox isolation and privileged local
+DinD apply to the runner container, not to the sandbox container. A sandbox
+container is never privileged, because Docker ignores `--cap-drop` for a
+privileged container and the allowlist would then have no effect.
 
 Within a sandbox, the daemon runs as a non-root user, and file operations are
 path-validated to keep them inside the sandbox. The daemon authenticates

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -85,18 +85,29 @@ ranges, and a chain in `INPUT` dropping the connections a container opens to the
 runner host itself. The second is needed because `DOCKER-USER` is only consulted
 for forwarded packets, while anything addressed to a host-local address is
 delivered locally and never reaches the egress chain. Both match on the bridge
-interface rather than on the address the runner assigned, because a sandbox can
-add addresses to its own interface and would otherwise only have to send from a
-different one. A per-container chain, keyed on the container's address as a
-destination, drops connections to its daemon port. The runner's own connections
-are unaffected, being locally generated and so never subject to a chain that
-only sees forwarded packets; the exception for the gateway address applies only
-to packets that did not arrive on the bridge, for the same reason the rules
-above avoid matching on addresses. The two shared chains are rebuilt from empty
-at runner startup, after stale containers are removed and before any sandbox can
-be created, so an upgraded runner replacing the rules of an earlier version
-never does so with a container on the bridge. Containers are created with IPv6
-disabled.
+interface rather than on the address the runner assigned. Sandboxes cannot
+normally change their interface configuration without `CAP_NET_ADMIN`, but
+interface matching keeps the network policy independent of that capability
+boundary as defense in depth. A per-container chain, keyed on the container's
+address as a destination, drops connections to its daemon port. The runner's
+own connections are unaffected, being locally generated and so never subject to
+a chain that only sees forwarded packets; the exception for the gateway address
+applies only to packets that did not arrive on the bridge, for the same reason
+the rules above avoid matching on addresses. The two shared chains are rebuilt
+from empty at runner startup, after stale containers are removed and before any
+sandbox can be created, so an upgraded runner replacing the rules of an earlier
+version never does so with a container on the bridge. Containers are created
+with IPv6 disabled.
+
+Every Docker-backed sandbox, including privileged local DinD, is created with
+all Linux capabilities dropped and only `CAP_AUDIT_WRITE`, `CAP_CHOWN`,
+`CAP_DAC_OVERRIDE`, `CAP_FOWNER`, `CAP_SETGID`, and `CAP_SETUID` restored. This
+allowlist is sufficient for passwordless `sudo` and common `apt-get` package
+installation, while excluding capabilities for network administration, raw
+sockets, mounts, tracing, device creation, and other privileged operations.
+`CAP_AUDIT_WRITE` avoids audit warnings from successful `sudo` commands.
+`no-new-privileges` is not enabled because it would prevent the supported sudo
+workflow.
 
 Within a sandbox, the daemon runs as a non-root user, and file operations are
 path-validated to keep them inside the sandbox. The daemon authenticates
@@ -157,6 +168,7 @@ The boundaries above are covered by tests rather than asserted on paper.
 | Client-supplied ID conflicts | [internal/api/handlers_create_sandbox_test.go](../internal/api/handlers_create_sandbox_test.go) |
 | Admin route gating and key revocation | [internal/api/handlers_tenants_test.go](../internal/api/handlers_tenants_test.go) |
 | Sandbox-to-sandbox and blocked-range egress | [e2e/tests/network-isolation.spec.ts](../e2e/tests/network-isolation.spec.ts) |
+| Docker capability allowlist, sudo package installation, and denied network administration | [e2e/tests/sandbox-capabilities.spec.ts](../e2e/tests/sandbox-capabilities.spec.ts) |
 | Egress rule generation | [internal/runner/runtime/firecracker.ee/network/egress_test.go](../internal/runner/runtime/firecracker.ee/network/egress_test.go) |
 
 The network isolation suite is untagged, so it runs against both the Sysbox and

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,7 +15,8 @@ Multi-pod failover: `e2e/run-postgres-multi-pod.sh` fronts both API pods with an
 Specs run on every runner lane by default. Apply a marker
 from `tests/tags.ts` only to a spec (or `describe`) that is backend-specific:
 
-- `DOCKER_ONLY` (`@docker-only`) — e.g. inner-container recovery, xfs disk quota.
+- `DOCKER_ONLY` (`@docker-only`) — e.g. inner-container recovery, capability
+  policy, and xfs disk quota.
 - `FIRECRACKER_ONLY` (`@firecracker-only`) — e.g. rootfs capacity checks.
 
 Each lane excludes the other lane's marker via `--grep-invert`: the Docker lane

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -190,6 +190,21 @@ export async function execWithTransientRetry(
   throw new Error(`exec did not recover within ${deadlineMs}ms: ${String(lastErr)}`);
 }
 
+/**
+ * Command that adds a second IPv4 address to eth0 through the legacy ioctl,
+ * since iproute2 is absent from the sandbox image. The ':1' label keeps the
+ * address secondary, so the sandbox's own address — and with it the daemon
+ * connection carrying the exec — survives. Needs CAP_NET_ADMIN, hence sudo.
+ */
+export const addAddress = (ip: string) =>
+  `sudo -n python3 -c "import fcntl,socket,struct;` +
+  `s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);` +
+  `fcntl.ioctl(s,0x8916,struct.pack('16sH2s4s16s',b'eth0:1',socket.AF_INET,` +
+  `b'\\x00\\x00',socket.inet_aton('${ip}'),b'\\x00'*16))"`;
+
+/** An unused address in the same /24 as ip. */
+export const siblingOf = (ip: string) => ip.split('.').slice(0, 3).concat('250').join('.');
+
 export async function uploadFile(
   id: string,
   path: string,

--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -38,10 +38,10 @@ const gatewayOf = (ip: string) => ip.split('.').slice(0, 3).concat('1').join('.'
 
 const siblingOf = (ip: string) => ip.split('.').slice(0, 3).concat('250').join('.');
 
-// Adds a second IPv4 address to eth0 through the legacy ioctl, since iproute2 is
-// absent from the sandbox image. The ':1' label keeps the address secondary, so
-// the sandbox's own address — and with it the daemon connection carrying this
-// exec — survives. Needs CAP_NET_ADMIN, hence sudo.
+// Attempts to add a second IPv4 address to eth0 through the legacy ioctl, since
+// iproute2 is absent from the sandbox image. This needs CAP_NET_ADMIN. The
+// Docker capability policy blocks it; the helper remains a defense-in-depth
+// network-policy test for any runtime where the operation is available.
 const addAddress = (ip: string) =>
   `sudo -n python3 -c "import fcntl,socket,struct;` +
   `s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);` +
@@ -218,11 +218,9 @@ test.describe('Network isolation', () => {
   });
 
   // The host and private-range rules are matched on the bridge interface rather
-  // than on the address the runner assigned, because a sandbox that reaches
-  // CAP_NET_ADMIN can give itself another address and a source-matched rule
-  // would no longer apply to it. Passwordless sudo in the image plus Sysbox's
-  // full capability bounding set are enough to do that, so this asserts the
-  // policy still holds for traffic the runner never handed out an address for.
+  // than on the address the runner assigned. Docker sandboxes cannot obtain
+  // CAP_NET_ADMIN under the capability allowlist, but this remains a
+  // defense-in-depth check for runtimes where a secondary address is possible.
   test('sandbox cannot escape the policy by adding an address', async () => {
     const id = await createSandbox();
     try {

--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -3,12 +3,14 @@ import './matchers';
 import {
   ADMIN_API_KEY,
   BASE_URL,
+  addAddress,
   apiClient,
   createSandbox,
   deleteSandbox,
   docker,
   exec,
   execWithTransientRetry,
+  siblingOf,
 } from './helpers';
 import { DOCKER_ONLY } from './tags';
 import type { SandboxClient } from '@n8n/sandbox-client';
@@ -35,18 +37,6 @@ const resolve = (host: string) =>
 // since iproute2 is absent from the image and the Firecracker guest has no
 // /proc/net/route either — the daemon runs as PID 1, so nothing mounts /proc.
 const gatewayOf = (ip: string) => ip.split('.').slice(0, 3).concat('1').join('.');
-
-const siblingOf = (ip: string) => ip.split('.').slice(0, 3).concat('250').join('.');
-
-// Attempts to add a second IPv4 address to eth0 through the legacy ioctl, since
-// iproute2 is absent from the sandbox image. This needs CAP_NET_ADMIN. The
-// Docker capability policy blocks it; the helper remains a defense-in-depth
-// network-policy test for any runtime where the operation is available.
-const addAddress = (ip: string) =>
-  `sudo -n python3 -c "import fcntl,socket,struct;` +
-  `s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);` +
-  `fcntl.ioctl(s,0x8916,struct.pack('16sH2s4s16s',b'eth0:1',socket.AF_INET,` +
-  `b'\\x00\\x00',socket.inet_aton('${ip}'),b'\\x00'*16))"`;
 
 const tcpConnectFrom = (source: string, ip: string, port: number, timeout: number = 3) =>
   `curl --interface ${source} --connect-timeout ${timeout} -s -o /dev/null http://${ip}:${port}/`;

--- a/e2e/tests/sandbox-capabilities.spec.ts
+++ b/e2e/tests/sandbox-capabilities.spec.ts
@@ -1,21 +1,27 @@
 import { test, expect } from '@playwright/test';
 import './matchers';
-import { createSandbox, deleteSandbox, exec, execWithTransientRetry } from './helpers';
+import {
+  addAddress,
+  createSandbox,
+  deleteSandbox,
+  exec,
+  execWithTransientRetry,
+  siblingOf,
+} from './helpers';
 import { DOCKER_ONLY } from './tags';
 
-const addAddress = (ip: string) =>
-  `sudo -n python3 -c "import fcntl,socket,struct;` +
-  `s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);` +
-  `fcntl.ioctl(s,0x8916,struct.pack('16sH2s4s16s',b'eth0:1',socket.AF_INET,` +
-  `b'\\x00\\x00',socket.inet_aton('${ip}'),b'\\x00'*16))"`;
+// The bounding set the runner grants: CHOWN, DAC_OVERRIDE, FOWNER, SETGID,
+// SETUID (bits 0, 1, 3, 6, 7) and AUDIT_WRITE (bit 29).
+const ALLOWED_BOUNDING_SET = '00000000200000cb';
 
-const siblingOf = (ip: string) => ip.split('.').slice(0, 3).concat('250').join('.');
+// No effective capabilities, because every sandbox process starts as uid 1000.
+const NO_CAPABILITIES = '0000000000000000';
 
 test.describe('Docker sandbox capability policy', DOCKER_ONLY, () => {
   test('daemon and user processes have only the allowed bounding capabilities', async () => {
     const id = await createSandbox();
     try {
-      const result = await exec(
+      const result = await execWithTransientRetry(
         id,
         `for pid in 1 self; do ` +
           `awk '$1 == "CapEff:" { print $2 }' /proc/$pid/status; ` +
@@ -24,27 +30,36 @@ test.describe('Docker sandbox capability policy', DOCKER_ONLY, () => {
       );
       expect(result).toHaveSucceeded();
       expect(result.stdout.trim().split(/\s+/)).toEqual([
-        '0000000000000000',
-        '00000000200000cb',
-        '0000000000000000',
-        '00000000200000cb',
+        NO_CAPABILITIES,
+        ALLOWED_BOUNDING_SET,
+        NO_CAPABILITIES,
+        ALLOWED_BOUNDING_SET,
       ]);
     } finally {
       await deleteSandbox(id);
     }
   });
 
-  test('passwordless sudo can install a package', async () => {
-    test.setTimeout(180_000);
+  // iputils-ping asks setcap to give /usr/bin/ping CAP_NET_RAW. The allowlist
+  // holds no CAP_SETFCAP, so setcap fails and the package installs a setuid
+  // binary instead. This is the install path the capability policy changed, so
+  // it is the one the suite pins.
+  test('passwordless sudo can install a package that sets file capabilities', async () => {
+    test.setTimeout(240_000);
     const id = await createSandbox();
     try {
-      const result = await exec(
+      const updated = await execWithTransientRetry(id, 'sudo -n apt-get update', {
+        timeoutMs: 60_000,
+      });
+      expect(updated).toHaveSucceeded();
+
+      const installed = await exec(
         id,
-        'sudo -n apt-get update && sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y jq && jq --version',
+        'sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y iputils-ping && ls -l /usr/bin/ping',
         { timeoutMs: 150_000 },
       );
-      expect(result).toHaveSucceeded();
-      expect(result.stdout).toMatch(/jq-\d+/);
+      expect(installed).toHaveSucceeded();
+      expect(installed.stdout, 'expected the setuid fallback for /usr/bin/ping').toMatch(/^-rws/m);
     } finally {
       await deleteSandbox(id);
     }
@@ -59,8 +74,19 @@ test.describe('Docker sandbox capability policy', DOCKER_ONLY, () => {
       expect(ownIP).toMatch(/^\d+\.\d+\.\d+\.\d+$/);
       const extraIP = siblingOf(ownIP);
 
+      // Positive control. Without it the assertion below also passes when
+      // passwordless sudo or python3 fcntl is missing, which hides a
+      // capability regression instead of reporting one.
+      const plumbing = await exec(id, 'sudo -n python3 -c "import fcntl"');
+      expect(plumbing, 'expected sudo -n and python3 fcntl to be available').toHaveSucceeded();
+
       const added = await exec(id, addAddress(extraIP));
       expect(added.exitCode, 'expected address addition to be denied').not.toBe(0);
+      // The errno separates the missing capability from other ioctl failures,
+      // such as ENODEV when the interface is not named eth0.
+      expect(added.stderr, 'expected the denial to come from the missing capability').toMatch(
+        /PermissionError|Operation not permitted/,
+      );
 
       const addresses = await exec(id, 'hostname -I');
       expect(addresses).toHaveSucceeded();

--- a/e2e/tests/sandbox-capabilities.spec.ts
+++ b/e2e/tests/sandbox-capabilities.spec.ts
@@ -11,8 +11,8 @@ import {
 import { DOCKER_ONLY } from './tags';
 
 // The bounding set the runner grants: CHOWN, DAC_OVERRIDE, FOWNER, SETGID,
-// SETUID (bits 0, 1, 3, 6, 7) and AUDIT_WRITE (bit 29).
-const ALLOWED_BOUNDING_SET = '00000000200000cb';
+// and SETUID (bits 0, 1, 3, 6, 7).
+const ALLOWED_BOUNDING_SET = '00000000000000cb';
 
 // No effective capabilities, because every sandbox process starts as uid 1000.
 const NO_CAPABILITIES = '0000000000000000';

--- a/e2e/tests/sandbox-capabilities.spec.ts
+++ b/e2e/tests/sandbox-capabilities.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import './matchers';
+import { createSandbox, deleteSandbox, exec, execWithTransientRetry } from './helpers';
+import { DOCKER_ONLY } from './tags';
+
+const addAddress = (ip: string) =>
+  `sudo -n python3 -c "import fcntl,socket,struct;` +
+  `s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);` +
+  `fcntl.ioctl(s,0x8916,struct.pack('16sH2s4s16s',b'eth0:1',socket.AF_INET,` +
+  `b'\\x00\\x00',socket.inet_aton('${ip}'),b'\\x00'*16))"`;
+
+const siblingOf = (ip: string) => ip.split('.').slice(0, 3).concat('250').join('.');
+
+test.describe('Docker sandbox capability policy', DOCKER_ONLY, () => {
+  test('daemon and user processes have only the allowed bounding capabilities', async () => {
+    const id = await createSandbox();
+    try {
+      const result = await exec(
+        id,
+        `for pid in 1 self; do ` +
+          `awk '$1 == "CapEff:" { print $2 }' /proc/$pid/status; ` +
+          `awk '$1 == "CapBnd:" { print $2 }' /proc/$pid/status; ` +
+          `done`,
+      );
+      expect(result).toHaveSucceeded();
+      expect(result.stdout.trim().split(/\s+/)).toEqual([
+        '0000000000000000',
+        '00000000200000cb',
+        '0000000000000000',
+        '00000000200000cb',
+      ]);
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+
+  test('passwordless sudo can install a package', async () => {
+    test.setTimeout(180_000);
+    const id = await createSandbox();
+    try {
+      const result = await exec(
+        id,
+        'sudo -n apt-get update && sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y jq && jq --version',
+        { timeoutMs: 150_000 },
+      );
+      expect(result).toHaveSucceeded();
+      expect(result.stdout).toMatch(/jq-\d+/);
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+
+  test('cannot add a secondary address without CAP_NET_ADMIN', async () => {
+    const id = await createSandbox();
+    try {
+      const ipResult = await execWithTransientRetry(id, 'hostname -I', { timeoutMs: 5_000 });
+      expect(ipResult).toHaveSucceeded();
+      const ownIP = ipResult.stdout.trim().split(/\s+/)[0];
+      expect(ownIP).toMatch(/^\d+\.\d+\.\d+\.\d+$/);
+      const extraIP = siblingOf(ownIP);
+
+      const added = await exec(id, addAddress(extraIP));
+      expect(added.exitCode, 'expected address addition to be denied').not.toBe(0);
+
+      const addresses = await exec(id, 'hostname -I');
+      expect(addresses).toHaveSucceeded();
+      expect(addresses.stdout.split(/\s+/)).not.toContain(extraIP);
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+});

--- a/internal/runner/runtime/docker/README.md
+++ b/internal/runner/runtime/docker/README.md
@@ -24,8 +24,10 @@ containers direct access to the host Docker daemon.
   `CAP_CHOWN`, `CAP_DAC_OVERRIDE`, `CAP_FOWNER`, `CAP_SETGID`, and `CAP_SETUID`.
   This keeps passwordless `sudo` usable for common package installation while
   preventing network administration, mounts, tracing, device creation, raw
-  sockets, and other privileged operations. The policy applies to every Docker
-  sandbox in both Sysbox and privileged local DinD environments.
+  sockets, and other privileged operations. Sysbox isolation and privileged
+  local DinD apply to the runner container, so every sandbox container gets the
+  same policy. Never create a sandbox container with `--privileged`: Docker then
+  ignores `--cap-drop` and the allowlist has no effect.
 - Applies Docker-specific network isolation rules through `netrules`.
 - Waits for daemon `/healthz` and a tiny `/executions` round trip before
   returning a sandbox as ready.

--- a/internal/runner/runtime/docker/README.md
+++ b/internal/runner/runtime/docker/README.md
@@ -20,6 +20,12 @@ containers direct access to the host Docker daemon.
   reachable.
 - Reports capacity from the current managed container count.
 - Applies default memory, CPU, PID, and optional disk quota limits on create.
+- Drops every Linux capability, then restores only `CAP_AUDIT_WRITE`,
+  `CAP_CHOWN`, `CAP_DAC_OVERRIDE`, `CAP_FOWNER`, `CAP_SETGID`, and `CAP_SETUID`.
+  This keeps passwordless `sudo` usable for common package installation while
+  preventing network administration, mounts, tracing, device creation, raw
+  sockets, and other privileged operations. The policy applies to every Docker
+  sandbox in both Sysbox and privileged local DinD environments.
 - Applies Docker-specific network isolation rules through `netrules`.
 - Waits for daemon `/healthz` and a tiny `/executions` round trip before
   returning a sandbox as ready.

--- a/internal/runner/runtime/docker/README.md
+++ b/internal/runner/runtime/docker/README.md
@@ -20,14 +20,16 @@ containers direct access to the host Docker daemon.
   reachable.
 - Reports capacity from the current managed container count.
 - Applies default memory, CPU, PID, and optional disk quota limits on create.
-- Drops every Linux capability, then restores only `CAP_AUDIT_WRITE`,
-  `CAP_CHOWN`, `CAP_DAC_OVERRIDE`, `CAP_FOWNER`, `CAP_SETGID`, and `CAP_SETUID`.
-  This keeps passwordless `sudo` usable for common package installation while
-  preventing network administration, mounts, tracing, device creation, raw
-  sockets, and other privileged operations. Sysbox isolation and privileged
-  local DinD apply to the runner container, so every sandbox container gets the
-  same policy. Never create a sandbox container with `--privileged`: Docker then
-  ignores `--cap-drop` and the allowlist has no effect.
+- Drops every Linux capability, then restores only `CAP_CHOWN`,
+  `CAP_DAC_OVERRIDE`, `CAP_FOWNER`, `CAP_SETGID`, and `CAP_SETUID`. This keeps
+  passwordless `sudo` usable for common package installation while preventing
+  network administration, audit-log writes, mounts, tracing, device creation,
+  raw sockets, and other privileged operations. Successful `sudo` commands may
+  emit an audit warning because `CAP_AUDIT_WRITE` is intentionally excluded.
+  Sysbox isolation and privileged local DinD apply to the runner container, so
+  every sandbox container gets the same policy. Never create a sandbox container
+  with `--privileged`: Docker then ignores `--cap-drop` and the allowlist has no
+  effect.
 - Applies Docker-specific network isolation rules through `netrules`.
 - Waits for daemon `/healthz` and a tiny `/executions` round trip before
   returning a sandbox as ready.

--- a/internal/runner/runtime/docker/docker_client.go
+++ b/internal/runner/runtime/docker/docker_client.go
@@ -106,6 +106,16 @@ func (dc *dockerClient) ping(ctx context.Context) error {
 }
 
 func (dc *dockerClient) createContainer(ctx context.Context, sandboxID, containerName, image string, limits *ResourceLimits, enableCgroups bool) (string, error) {
+	args := dockerContainerCreateArgs(sandboxID, containerName, image, limits, enableCgroups)
+
+	out, err := dc.run(ctx, args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func dockerContainerCreateArgs(sandboxID, containerName, image string, limits *ResourceLimits, enableCgroups bool) []string {
 	args := []string{
 		"container", "create",
 		"--name", containerName,
@@ -117,23 +127,36 @@ func (dc *dockerClient) createContainer(ctx context.Context, sandboxID, containe
 		"--user", "1000:1000",
 		"--env", "HOME=/home/user",
 		"--env", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	}
+	args = append(args, dockerSandboxCapabilityArgs()...)
+	args = append(args,
 		// netrules only filter IPv4; disable v6 in the container so sandboxes
 		// can't bypass the policy via link-local/ULA or v6 metadata addresses.
 		"--sysctl", "net.ipv6.conf.all.disable_ipv6=1",
 		"--sysctl", "net.ipv6.conf.default.disable_ipv6=1",
 		"--sysctl", "net.ipv6.conf.lo.disable_ipv6=1",
-	}
+	)
 	if enableCgroups {
 		args = append(args, dockerLimitArgs(limits)...)
 	}
 	args = append(args, dockerDiskQuotaArgs(limits)...)
 	args = append(args, image)
+	return args
+}
 
-	out, err := dc.run(ctx, args...)
-	if err != nil {
-		return "", err
+// dockerSandboxCapabilityArgs is the single capability policy for every
+// Docker-backed sandbox. Keep the allowlist minimal while preserving
+// passwordless sudo for common package installation workflows.
+func dockerSandboxCapabilityArgs() []string {
+	return []string{
+		"--cap-drop", "ALL",
+		"--cap-add", "AUDIT_WRITE",
+		"--cap-add", "CHOWN",
+		"--cap-add", "DAC_OVERRIDE",
+		"--cap-add", "FOWNER",
+		"--cap-add", "SETGID",
+		"--cap-add", "SETUID",
 	}
-	return strings.TrimSpace(out), nil
 }
 
 func (dc *dockerClient) startContainer(ctx context.Context, containerID string) error {

--- a/internal/runner/runtime/docker/docker_client.go
+++ b/internal/runner/runtime/docker/docker_client.go
@@ -147,6 +147,9 @@ func dockerContainerCreateArgs(sandboxID, containerName, image string, limits *R
 // dockerSandboxCapabilityArgs is the single capability policy for every
 // Docker-backed sandbox. Keep the allowlist minimal while preserving
 // passwordless sudo for common package installation workflows.
+//
+// Never create a sandbox container with --privileged. Docker ignores --cap-drop
+// for a privileged container, so that flag would void this policy silently.
 func dockerSandboxCapabilityArgs() []string {
 	return []string{
 		"--cap-drop", "ALL",

--- a/internal/runner/runtime/docker/docker_client.go
+++ b/internal/runner/runtime/docker/docker_client.go
@@ -153,7 +153,6 @@ func dockerContainerCreateArgs(sandboxID, containerName, image string, limits *R
 func dockerSandboxCapabilityArgs() []string {
 	return []string{
 		"--cap-drop", "ALL",
-		"--cap-add", "AUDIT_WRITE",
 		"--cap-add", "CHOWN",
 		"--cap-add", "DAC_OVERRIDE",
 		"--cap-add", "FOWNER",

--- a/internal/runner/runtime/docker/netrules/netrules.go
+++ b/internal/runner/runtime/docker/netrules/netrules.go
@@ -113,12 +113,11 @@ func ApplyPolicy(bridgeIface, containerID, sourceIP, gatewayIP string, daemonPor
 // the runner host itself.
 //
 // Both match on the bridge interface rather than on a container address,
-// because a sandbox controls which address it sends from and would otherwise
-// only have to pick a different one to fall outside the rule. Under Sysbox the
-// capability bounding set is full even for a non-root container process, so the
-// sandbox image's passwordless sudo yields CAP_NET_ADMIN inside the container's
-// own netns, which is enough to add an address to its interface. The interface
-// a packet arrives on is not something the container can choose.
+// so the policy does not depend on an address remaining fixed. Docker-backed
+// sandboxes are created without CAP_NET_ADMIN and cannot normally change their
+// interface addresses; interface matching remains defense in depth if that
+// capability boundary or another networking assumption regresses. The
+// interface a packet arrives on is not something the container can choose.
 //
 // The host block lives in INPUT because DOCKER-USER is only consulted for
 // forwarded packets: anything addressed to a host-local address (the bridge

--- a/internal/runner/runtime/docker/runtime_test.go
+++ b/internal/runner/runtime/docker/runtime_test.go
@@ -96,6 +96,77 @@ func TestDockerLimitArgs(t *testing.T) {
 	}
 }
 
+func TestDockerContainerCreateArgs(t *testing.T) {
+	limits := &ResourceLimits{
+		MemoryMB:   512,
+		CPUPercent: 150,
+		PidsMax:    128,
+		DiskMB:     1024,
+	}
+
+	got := dockerContainerCreateArgs("sandbox-id", "sandbox-name", "sandbox-image", limits, true)
+	want := []string{
+		"container", "create",
+		"--name", "sandbox-name",
+		"--hostname", "sandbox",
+		"--restart", "unless-stopped",
+		"--network", runnerBridgeNetwork,
+		"--label", containerLabelManaged + "=" + containerLabelManagedVal,
+		"--label", containerLabelSandboxID + "=sandbox-id",
+		"--user", "1000:1000",
+		"--env", "HOME=/home/user",
+		"--env", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"--cap-drop", "ALL",
+		"--cap-add", "AUDIT_WRITE",
+		"--cap-add", "CHOWN",
+		"--cap-add", "DAC_OVERRIDE",
+		"--cap-add", "FOWNER",
+		"--cap-add", "SETGID",
+		"--cap-add", "SETUID",
+		"--sysctl", "net.ipv6.conf.all.disable_ipv6=1",
+		"--sysctl", "net.ipv6.conf.default.disable_ipv6=1",
+		"--sysctl", "net.ipv6.conf.lo.disable_ipv6=1",
+		"--memory", "512m",
+		"--cpus", "1.50",
+		"--pids-limit", "128",
+		"--storage-opt", "size=1024m",
+		"sandbox-image",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("dockerContainerCreateArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDockerContainerCreateArgsAlwaysApplyCapabilityPolicy(t *testing.T) {
+	want := []string{
+		"--cap-drop", "ALL",
+		"--cap-add", "AUDIT_WRITE",
+		"--cap-add", "CHOWN",
+		"--cap-add", "DAC_OVERRIDE",
+		"--cap-add", "FOWNER",
+		"--cap-add", "SETGID",
+		"--cap-add", "SETUID",
+	}
+
+	for _, enableCgroups := range []bool{false, true} {
+		gotArgs := dockerContainerCreateArgs("sandbox-id", "sandbox-name", "sandbox-image", nil, enableCgroups)
+		var got []string
+		for i := 0; i < len(gotArgs); i++ {
+			if gotArgs[i] != "--cap-drop" && gotArgs[i] != "--cap-add" {
+				continue
+			}
+			if i+1 >= len(gotArgs) {
+				t.Fatalf("capability flag %q has no value", gotArgs[i])
+			}
+			got = append(got, gotArgs[i], gotArgs[i+1])
+			i++
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("capability args with enableCgroups=%v = %#v, want %#v", enableCgroups, got, want)
+		}
+	}
+}
+
 func TestDockerDiskQuotaArgs(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/runner/runtime/docker/runtime_test.go
+++ b/internal/runner/runtime/docker/runtime_test.go
@@ -117,7 +117,6 @@ func TestDockerContainerCreateArgs(t *testing.T) {
 		"--env", "HOME=/home/user",
 		"--env", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"--cap-drop", "ALL",
-		"--cap-add", "AUDIT_WRITE",
 		"--cap-add", "CHOWN",
 		"--cap-add", "DAC_OVERRIDE",
 		"--cap-add", "FOWNER",
@@ -140,7 +139,6 @@ func TestDockerContainerCreateArgs(t *testing.T) {
 func TestDockerContainerCreateArgsAlwaysApplyCapabilityPolicy(t *testing.T) {
 	want := []string{
 		"--cap-drop", "ALL",
-		"--cap-add", "AUDIT_WRITE",
 		"--cap-add", "CHOWN",
 		"--cap-add", "DAC_OVERRIDE",
 		"--cap-add", "FOWNER",


### PR DESCRIPTION
## Summary

- drop all Linux capabilities from every Docker-backed sandbox
- restore only AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, SETGID, and SETUID
- retain passwordless sudo for common package installation workflows
- document the capability boundary and keep interface-based network rules as defense in depth
- add unit and Docker-only end-to-end coverage

## Testing

- make test
- make fmt-check
- make vet
- privileged-DinD capability suite: 3 passed
  - daemon and user processes have zero effective capabilities and the exact allowlisted bounding set
  - sudo apt-get update and jq installation succeed
  - adding a secondary address fails without NET_ADMIN

The full local privileged-DinD suite passed its first 12 executed tests, then stopped in the existing public-internet network test because nested Docker on Docker Desktop could not resolve example.com.

## Acceptance

Run the labeled Linux Sysbox end-to-end workflow before merge as the production-runtime acceptance gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts Docker-backed sandbox containers to a minimal capability allowlist and removes `CAP_AUDIT_WRITE`, closing paths to privileged ops while keeping passwordless sudo/apt usable. Previously some environments exposed broader capabilities (e.g., `CAP_NET_ADMIN`); now all capabilities are dropped and only `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETGID`, and `SETUID` are restored, with the policy applied unconditionally and `no-new-privileges` left disabled to preserve the sudo workflow. Addresses Linear CAT-4207.

**Migration**
- Workflows needing `NET_ADMIN`, `NET_RAW`, mounts, tracing, or device creation will fail; remove those needs or run them outside the sandbox.
- Packages that use `setcap` will install via setuid fallbacks; successful sudo may emit audit warnings because `CAP_AUDIT_WRITE` is excluded.
- Do not start sandbox containers with `--privileged`; Docker ignores `--cap-drop` and the allowlist will not apply.
- Run the labeled Linux Sysbox end-to-end workflow before merge as the acceptance gate.

<sup>Written for commit 16607a761155e7c54e29bdce2ab98609bf2ece3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

