### PR TITLE
fix: release process ACR

### DIFF
--- a/.github/workflows/release-service-publish.yml
+++ b/.github/workflows/release-service-publish.yml
@@ -21,13 +21,34 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Read version
         id: version
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          VERSION=$(cat VERSION)
+          VERSION="${BASE_REF#service/release/}"
+          FILE_VERSION=$(tr -d '[:space:]' < VERSION)
+          if [[ "$VERSION" != "$FILE_VERSION" ]]; then
+            echo "::error::Release branch ${BASE_REF} claims v${VERSION} but VERSION reads ${FILE_VERSION}. Refusing to publish under either version."
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # release-metadata only tags at the very end, long after the images are public.
+      - name: Fail if version was already released
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if ! matches=$(git ls-remote origin "refs/tags/service/v${VERSION}"); then
+            echo "::error::Could not reach origin to look up service/v${VERSION}. Refusing to publish without confirming it is unreleased; re-run once origin is reachable."
+            exit 1
+          fi
+          if [[ -n "$matches" ]]; then
+            echo "::error::service/v${VERSION} already exists, so v${VERSION} was published before. Publishing it again would overwrite its images and move latest and stable onto them."
+            exit 1
+          fi
 
       - name: Run tests
         uses: ./.github/actions/sandbox-service-test
@@ -91,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       # The golden build tarball embeds a freshly compiled cmd/daemon; without the
       # test action in this job, nothing else puts Go on the runner.
@@ -185,30 +206,52 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Import release images into ACR
+      - name: Log in to ACR
+        env:
+          ACR_NAME: ${{ secrets.AZURE_ACR_NAME }}
+        run: az acr login -n "$ACR_NAME"
+
+      - name: Copy release images into ACR
         env:
           ACR_NAME: ${{ secrets.AZURE_ACR_NAME }}
           VERSION: ${{ needs.publish-images.outputs.version }}
-          GHCR_USER: ${{ github.actor }}
-          GHCR_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          REGISTRY="${ACR_NAME}.azurecr.io"
+
+          # Sets DIGEST to the tag's digest, or to "" when the tag is absent. Every
+          # other failure returns non-zero, so a transport or auth error cannot pass
+          # as "not mirrored yet" and overwrite a manifest deployments already run.
+          read_digest() {
+            local ref=$1 out
+            DIGEST=""
+            if out=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$ref" 2>&1); then
+              DIGEST=$(jq -r '.digest' <<< "$out")
+              return 0
+            fi
+            [[ "$out" == *": not found" ]] && return 0
+            echo "::error::Could not read ${ref}: ${out}"
+            return 1
+          }
+
           for image in \
             n8n-sandbox-service-api \
             n8n-sandbox-service-runner-dind \
             n8n-sandbox-service-runner-firecracker \
             n8n-sandbox-service-sandbox; do
-            # Resolve the source to a digest: rebuilding a version moves the GHCR
-            # tag, and importing by tag would copy whatever it points at now.
-            source_digest=$(docker buildx imagetools inspect \
-              --format '{{json .Manifest}}' "ghcr.io/n8n-io/${image}:${VERSION}" | jq -r '.digest')
-            acr_digest=$(az acr repository show \
-              --name "$ACR_NAME" --image "${image}:${VERSION}" \
-              --query digest -o tsv 2>/dev/null || true)
+            read_digest "ghcr.io/n8n-io/${image}:${VERSION}"
+            source_digest="$DIGEST"
+            if [[ -z "$source_digest" ]]; then
+              echo "::error::ghcr.io/n8n-io/${image}:${VERSION} does not exist, so it was never published."
+              exit 1
+            fi
 
-            # Keeps a partially imported run re-runnable.
+            read_digest "${REGISTRY}/${image}:${VERSION}"
+            acr_digest="$DIGEST"
+
+            # Keeps a partially mirrored run re-runnable.
             if [[ "$acr_digest" == "$source_digest" ]]; then
-              echo "${image}:${VERSION} already imported as ${source_digest}"
+              echo "${image}:${VERSION} already mirrored as ${source_digest}"
               continue
             fi
 
@@ -217,12 +260,13 @@ jobs:
               exit 1
             fi
 
-            # No --force, so ACR still refuses to overwrite if the digest read above
-            # failed for a reason other than the tag being absent.
-            az acr import \
-              --name "$ACR_NAME" \
-              --source "ghcr.io/n8n-io/${image}@${source_digest}" \
-              --username "$GHCR_USER" \
-              --password "$GHCR_TOKEN" \
-              --image "${image}:${VERSION}"
+            docker buildx imagetools create \
+              --tag "${REGISTRY}/${image}:${VERSION}" \
+              "ghcr.io/n8n-io/${image}@${source_digest}"
+
+            read_digest "${REGISTRY}/${image}:${VERSION}"
+            if [[ "$DIGEST" != "$source_digest" ]]; then
+              echo "::error::${image}:${VERSION} landed in ACR as ${DIGEST}, expected ${source_digest}."
+              exit 1
+            fi
           done

--- a/.github/workflows/retag-service-image.yml
+++ b/.github/workflows/retag-service-image.yml
@@ -1,0 +1,92 @@
+name: Retag Service Image
+
+# Points published tags at a manifest that is already in the registries, for
+# recovering from a release that tagged the wrong images. It cannot build or
+# delete anything.
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: Image to retag
+        required: true
+        type: choice
+        options:
+          - n8n-sandbox-service-api
+          - n8n-sandbox-service-runner-dind
+          - n8n-sandbox-service-runner-firecracker
+          - n8n-sandbox-service-sandbox
+      digest:
+        description: "Manifest digest the tags should point at (sha256:...)"
+        required: true
+        type: string
+      tags:
+        description: Space-separated tags to move (e.g. "1.1.1 latest stable")
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: retag-service-image-${{ inputs.image }}
+  cancel-in-progress: false
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    environment: docker-release
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Move tags
+        env:
+          IMAGE: ${{ inputs.image }}
+          DIGEST: ${{ inputs.digest }}
+          TAGS: ${{ inputs.tags }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::digest must be sha256 followed by 64 hex characters, got '${DIGEST}'"
+            exit 1
+          fi
+
+          digest_of() {
+            docker buildx imagetools inspect --format '{{json .Manifest}}' "$1" 2>/dev/null \
+              | jq -r '.digest' || true
+          }
+
+          for repo in "n8nio/${IMAGE}" "ghcr.io/n8n-io/${IMAGE}"; do
+            # Both registries must already hold the manifest, so a mistyped digest
+            # fails here rather than moving one registry and not the other.
+            if [[ "$(digest_of "${repo}@${DIGEST}")" != "$DIGEST" ]]; then
+              echo "::error::${repo}@${DIGEST} does not exist. Nothing was changed."
+              exit 1
+            fi
+          done
+
+          for repo in "n8nio/${IMAGE}" "ghcr.io/n8n-io/${IMAGE}"; do
+            for tag in $TAGS; do
+              echo "${repo}:${tag} was $(digest_of "${repo}:${tag}" | grep . || echo absent)"
+              # A single index source is copied as-is, so the tag resolves to the
+              # same digest in both registries.
+              docker buildx imagetools create --tag "${repo}:${tag}" "${repo}@${DIGEST}"
+              landed=$(digest_of "${repo}:${tag}")
+              if [[ "$landed" != "$DIGEST" ]]; then
+                echo "::error::${repo}:${tag} landed as ${landed}, expected ${DIGEST}"
+                exit 1
+              fi
+              echo "${repo}:${tag} now ${landed}"
+            done
+          done

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -38,7 +38,7 @@ flowchart TD
         I --> J[Build + push multi-arch\nimages to Docker Hub]
         J --> K[Create git tag +\nGitHub Release +\ngolden-build tarball]
         K --> L[Open post-release\nversion-bump PR to main]
-        J --> S[Import :version into\nprivate registry]
+        J --> S[Copy :version into\nprivate registry]
     end
 
     subgraph sdk ["SDK Release"]
@@ -83,20 +83,26 @@ commit.
 ### Private registry mirror
 
 Cloud environments pull from the private container registry, not Docker Hub, so
-the publish workflow also imports all four images into it under `{version}`. The
-import is server-side and copies the published manifests, so the private
+the publish workflow also copies all four images into it under `{version}`. It
+copies the published manifests instead of rebuilding them, so the private
 registry's `{version}` resolves to the same digests as Docker Hub's.
 
-Each image is imported by digest rather than by tag, and an existing `{version}`
-is never replaced. If a rebuild of the same version produces a different
-manifest, the import fails instead of swapping the content behind a tag that
-deployments may already be running. Re-importing an identical manifest is a
-no-op, so a partially imported run stays re-runnable.
+The copy runs over the registry API with `docker buildx imagetools create`, after
+the same `az acr login` the alpha and staging workflows use, so it needs nothing
+beyond push access to the registry. `az acr import` is the more obvious tool but
+needs the registry readable as an ARM resource plus `importImage` on it — control
+plane access nothing else in this repository requires.
+
+Each image is copied by digest rather than by tag, and an existing `{version}` is
+never replaced. If a rebuild of the same version produces a different manifest,
+the copy fails instead of swapping the content behind a tag that deployments may
+already be running. Re-copying an identical manifest is a no-op, so a partially
+mirrored run stays re-runnable.
 
 This only makes the version deployable; it rolls nothing out. Deployments still
 move their own tags (`prod`) or pin `{version}` explicitly.
 
-The import is gated on the image publish alone, not on tagging or release creation,
+The copy is gated on the image publish alone, not on tagging or release creation,
 so a failure in those steps can never skip it — the registries cannot diverge
 because of work the mirror does not depend on.
 
@@ -138,9 +144,21 @@ unable to rebuild their snapshot.
    and the chart `appVersion` disagree.
 4. Merge the PR. This triggers the `Service Publish` workflow, whose
    `publish-images` job runs tests and then builds and pushes the multi-arch images
-   to Docker Hub, sandbox image included. Two jobs run in parallel off that push,
-   neither waiting on the other:
-   - `mirror-to-acr` imports those images into the private container registry under
+   to Docker Hub, sandbox image included.
+
+   Every job builds from the PR's merge commit rather than from the base branch by
+   name, and takes the version from the base branch name (`service/release/{version}`)
+   rather than from the `VERSION` file. Merging the release PR is what puts the new
+   version on that branch, so a job that resolves the branch name can still read the
+   pre-merge tip and publish the *previous* release's version on top of itself.
+   `VERSION` is only cross-checked against the branch name, so a release PR that
+   bumps to a different number fails before anything is pushed. As a second line of
+   defence, publishing aborts if `service/v{version}` already exists — checked up
+   front, because the tag is otherwise only created at the very end, long after the
+   images are public.
+
+   Two jobs then run in parallel off that push, neither waiting on the other:
+   - `mirror-to-acr` copies those images into the private container registry under
      `{version}`
    - `release-metadata` packages `firecracker-golden-build-{version}.tar.gz` and
      attaches it to the release, creates a git tag (`service/v{version}`) and GitHub
@@ -257,8 +275,9 @@ communicates HTTP API compatibility to consumers who do not deploy this service.
 - SDK: `sdk/v{version}` (e.g. `sdk/v0.0.4`)
 
 Release tags are immutable: publish creates them unforced, so a tag always points
-at the commit its images and release assets were built from. That is what makes
-the `git_sha` assertion in the copy-on-release contract meaningful.
+at the commit its images and release assets were built from — both jobs check out
+the release PR's merge commit, so they cannot diverge. That is what makes the
+`git_sha` assertion in the copy-on-release contract meaningful.
 
 `sandbox/v{version}` tags exist for releases made before versions were unified and
 are not created anymore.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the service release process so version bumps publish the right images and ACR mirroring no longer needs Azure control-plane access.

**Bug Fixes**
- The publish workflow now checks out the release PR's merge commit instead of the base branch, so it can't rebuild the previous release's version on top of itself.
- Version is derived from the `service/release/{version}` branch name and cross-checked against `VERSION`, failing the run on mismatch.
- Publishing aborts if `service/v{version}` already exists, checked up front because the tag is only created after images go public.
- ACR mirroring logs in via `az acr login` and copies with `docker buildx imagetools create` instead of `az acr import`, which required control-plane access nothing else in the repo uses.
- `docs/RELEASE.md` now describes the new copy step and version checks.

**New Features**
- Adds a `retag-service-image` workflow that re-points published tags at a manifest already present in Docker Hub and GHCR, as a recovery path for a mis-tagged release.

<sup>Written for commit 783cbdb4c954d715fd37319d03135a98cce4d9bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

