### PR TITLE
feat: remove root from sandbox containers

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -23,14 +23,20 @@ ARG NODE_VERSION=22.16.0
 ARG NODE_X64_SHA256=f4cb75bb036f0d0eddf6b79d9596df1aaab9ddccd6a20bf489be5abe9467e84e
 ARG NODE_ARM64_SHA256=eab80cb88f8fda1e65f5e8d0420c9809bdb320b03fd34976ab7161b6e703b910
 
+# build-essential and python3-dev are here because the sandbox has no root, so it
+# cannot apt-get a compiler later. Source builds need one.
+#
+# xz-utils only untars the Node tarball below, but it stays in the image:
+# build-essential needs it through dpkg-dev.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
-    python3-pip \
+    python3-venv \
+    python3-dev \
+    build-essential \
     ca-certificates \
     curl \
     ripgrep \
     wget \
-    sudo \
     xz-utils \
     && arch="${TARGETARCH}" \
     && if [ -z "$arch" ]; then \
@@ -52,16 +58,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm /tmp/node.tar.xz \
     && node -v && npm -v \
     && npm install -g typescript \
-    && apt-get purge -y xz-utils \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd --gid 1000 user && useradd --uid 1000 --gid 1000 --create-home --shell /bin/sh user
-RUN echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user && chmod 0440 /etc/sudoers.d/user
+
+# no-new-privileges makes setuid binaries inert on the Docker runtime. Clearing
+# the bits does the same in a Firecracker guest, which has no such flag.
+RUN find / -xdev -perm /4000 -type f -exec chmod u-s {} +
 
 COPY --from=builder /out/daemon /usr/local/bin/sandbox-daemon
 
 USER 1000:1000
 WORKDIR /home/user
+
+# Install roots owned by uid 1000, because root owns /usr/local: a global npm
+# install needs its own prefix, and pip needs a venv to get past Debian's
+# externally-managed marker. Both sit under /home/user, the only directory uid
+# 1000 owns on either runtime. internal/daemon/exec.go puts them on PATH.
+#
+# ensurepip seeds pip 23.0.1, which builds an sdist the legacy setup.py way.
+RUN python3 -m venv venv \
+    && venv/bin/pip install --no-cache-dir --quiet --upgrade pip \
+    && printf 'prefix=/home/user/.npm-global\n' > .npmrc \
+    && mkdir -p .npm-global/bin
 
 RUN mkdir -p workspace/src workspace/chunks workspace/node-types
 COPY --chown=1000:1000 sandbox-workspace/ workspace/

--- a/docs/API.md
+++ b/docs/API.md
@@ -276,6 +276,27 @@ pipes, redirects, etc.) work consistently.
 
 `env` accepts an object of key-value pairs: `{"KEY": "VALUE"}`.
 
+**Sandbox environment.** A command starts with `HOME=/home/user` and this `PATH`:
+
+```
+/home/user/venv/bin:/home/user/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+```
+
+`env` layers on top, so a supplied `PATH` replaces this one.
+
+A sandbox has no root and no `sudo`, so `apt-get` does not work. Install packages
+unprivileged instead. Each command below writes only under `/home/user`:
+
+| To install | Run |
+| --- | --- |
+| A PyPI package | `pip install <name>` — `python3` and `pip` come from the virtual environment at `/home/user/venv` |
+| A global npm package | `npm install -g <name>` — writes to `/home/user/.npm-global`, whose `bin` is on `PATH` |
+| A project npm package | `npm install <name>` in the project directory |
+
+The image carries a C and C++ compiler, `make` and the Python headers, so a
+source build works too. It carries no other library's development headers, and a
+sandbox cannot add them.
+
 `exec_id`, when provided, sets the execution identifier. If an execution with that ID
 already exists, the response follows it instead of starting a new command. This lets the
 client define the ID upfront and resume even if the initial connection drops before any

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -129,21 +129,27 @@ sandbox can be created, so an upgraded runner replacing the rules of an earlier
 version never does so with a container on the bridge. Containers are created
 with IPv6 disabled.
 
-The runner creates every sandbox container with all Linux capabilities dropped.
-It then restores only `CAP_CHOWN`, `CAP_DAC_OVERRIDE`, `CAP_FOWNER`,
-`CAP_SETGID`, and `CAP_SETUID`. This allowlist is sufficient for passwordless
-`sudo` and common `apt-get` package installation, while excluding capabilities
-for network administration, audit-log writes, raw sockets, mounts, tracing,
-device creation, and other privileged operations. Successful `sudo` commands
-may emit an audit warning because `CAP_AUDIT_WRITE` is intentionally excluded;
-granting it would allow audit-log injection and flooding in environments where
-the sandbox shares the initial user namespace. `no-new-privileges` is not
-enabled because it would prevent the supported sudo workflow.
+The runner drops all Linux capabilities from every sandbox container and
+restores none. The container runs as uid 1000, so no process holds an effective
+capability, and the empty bounding set stops one being gained.
 
-The allowlist holds in every environment. Sysbox isolation and privileged local
-DinD apply to the runner container, not to the sandbox container. A sandbox
-container is never privileged, because Docker ignores `--cap-drop` for a
-privileged container and the allowlist would then have no effect.
+That alone would not close the path to root. A setuid-root binary still makes
+its caller uid 0, and uid 0 owns `/usr/local` whatever capabilities it holds.
+Two things close it: the runner sets `no-new-privileges`, which makes every
+setuid binary inert, and the image ships no `sudo` and no setuid binary at all,
+because the Firecracker runtime has no equivalent flag.
+
+A sandbox therefore has no root and no `apt-get`. Packages install unprivileged,
+under `/home/user`: `pip` runs from a virtual environment at `/home/user/venv`,
+and `npm install -g` writes to `/home/user/.npm-global`.
+[internal/daemon/exec.go](../internal/daemon/exec.go) puts both first on the
+`PATH` every command gets. The image also carries a compiler and the Python
+headers, because a source build could not otherwise install.
+
+The policy holds in every environment. Sysbox isolation and privileged local
+DinD apply to the runner container, not the sandbox container. A sandbox
+container is never privileged, because Docker then ignores `--cap-drop` and the
+policy has no effect.
 
 Within a sandbox, the daemon runs as a non-root user, and file operations are
 path-validated to keep them inside the sandbox. The daemon authenticates
@@ -205,7 +211,8 @@ The boundaries above are covered by tests rather than asserted on paper.
 | Client-supplied ID conflicts | [internal/api/handlers_create_sandbox_test.go](../internal/api/handlers_create_sandbox_test.go) |
 | Admin route gating and key revocation | [internal/api/handlers_tenants_test.go](../internal/api/handlers_tenants_test.go) |
 | Sandbox-to-sandbox and blocked-range egress | [e2e/tests/network-isolation.spec.ts](../e2e/tests/network-isolation.spec.ts) |
-| Docker capability allowlist, sudo package installation, and denied network administration | [e2e/tests/sandbox-capabilities.spec.ts](../e2e/tests/sandbox-capabilities.spec.ts) |
+| Docker capability policy, absence of a root path, and denied network administration | [e2e/tests/sandbox-capabilities.spec.ts](../e2e/tests/sandbox-capabilities.spec.ts) |
+| Unprivileged npm and PyPI installation, and the build toolchain | [e2e/tests/sandbox-packages.spec.ts](../e2e/tests/sandbox-packages.spec.ts) |
 | Egress rule generation | [internal/runner/runtime/firecracker.ee/network/egress_test.go](../internal/runner/runtime/firecracker.ee/network/egress_test.go) |
 
 The network isolation suite is untagged, so it runs against both the Sysbox and

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -244,7 +244,11 @@ export async function crashGuest(id: string): Promise<void> {
  * Command that adds a second IPv4 address to eth0 through the legacy ioctl,
  * since iproute2 is absent from the sandbox image. The ':1' label keeps the
  * address secondary, so the sandbox's own address — and with it the daemon
- * connection carrying the exec — survives. Needs CAP_NET_ADMIN, hence sudo.
+ * connection carrying the exec — survives.
+ *
+ * It runs as the sandbox user, which has no CAP_NET_ADMIN, so the ioctl is
+ * denied. Callers expect that: sandbox-capabilities.spec.ts asserts the denial,
+ * and network-isolation.spec.ts skips on it.
  */
 export const addAddress = (ip: string) =>
   `python3 -c "import fcntl,socket,struct;` +

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -247,7 +247,7 @@ export async function crashGuest(id: string): Promise<void> {
  * connection carrying the exec — survives. Needs CAP_NET_ADMIN, hence sudo.
  */
 export const addAddress = (ip: string) =>
-  `sudo -n python3 -c "import fcntl,socket,struct;` +
+  `python3 -c "import fcntl,socket,struct;` +
   `s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);` +
   `fcntl.ioctl(s,0x8916,struct.pack('16sH2s4s16s',b'eth0:1',socket.AF_INET,` +
   `b'\\x00\\x00',socket.inet_aton('${ip}'),b'\\x00'*16))"`;

--- a/e2e/tests/network-isolation.spec.ts
+++ b/e2e/tests/network-isolation.spec.ts
@@ -207,10 +207,10 @@ test.describe('Network isolation', () => {
     }
   });
 
-  // The host and private-range rules are matched on the bridge interface rather
-  // than on the address the runner assigned. Docker sandboxes cannot obtain
-  // CAP_NET_ADMIN under the capability allowlist, but this remains a
-  // defense-in-depth check for runtimes where a secondary address is possible.
+  // The host and private-range rules match on the bridge interface, not on the
+  // address the runner assigned. No runtime lets a sandbox add an address today,
+  // so this test skips on both lanes. It stays as the check that reactivates if
+  // one ever grants CAP_NET_ADMIN.
   test('sandbox cannot escape the policy by adding an address', async () => {
     const id = await createSandbox();
     try {

--- a/e2e/tests/sandbox-capabilities.spec.ts
+++ b/e2e/tests/sandbox-capabilities.spec.ts
@@ -47,10 +47,16 @@ test.describe('Docker sandbox capability policy', DOCKER_ONLY, () => {
       expect(uid).toHaveSucceeded();
       expect(uid.stdout.trim()).not.toBe('0');
 
+      // Only the exec directories, not the whole tree: a setuid binary has to
+      // live somewhere on PATH to be reachable, and /bin and /sbin are symlinks
+      // into /usr on bookworm. Scanning / instead would stat every inode of the
+      // node_modules and venv trees, which is 8x the work and slows the specs
+      // that run after this one.
       const escalation = await exec(
         id,
-        'command -v sudo; find / -xdev -perm /4000 -type f 2>/dev/null',
-        { timeoutMs: 60_000 },
+        'command -v sudo; ' +
+          'find /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin /usr/lib ' +
+          '-xdev -perm /4000 -type f 2>/dev/null',
       );
       expect(escalation.stdout.trim(), 'expected no sudo and no setuid binary').toBe('');
 

--- a/e2e/tests/sandbox-capabilities.spec.ts
+++ b/e2e/tests/sandbox-capabilities.spec.ts
@@ -10,15 +10,12 @@ import {
 } from './helpers';
 import { DOCKER_ONLY } from './tags';
 
-// The bounding set the runner grants: CHOWN, DAC_OVERRIDE, FOWNER, SETGID,
-// and SETUID (bits 0, 1, 3, 6, 7).
-const ALLOWED_BOUNDING_SET = '00000000000000cb';
-
-// No effective capabilities, because every sandbox process starts as uid 1000.
+// Every sandbox process starts as uid 1000, so nothing is effective. The
+// bounding set is where a restored capability would show up.
 const NO_CAPABILITIES = '0000000000000000';
 
 test.describe('Docker sandbox capability policy', DOCKER_ONLY, () => {
-  test('daemon and user processes have only the allowed bounding capabilities', async () => {
+  test('daemon and user processes have no capabilities at all', async () => {
     const id = await createSandbox();
     try {
       const result = await execWithTransientRetry(
@@ -31,35 +28,35 @@ test.describe('Docker sandbox capability policy', DOCKER_ONLY, () => {
       expect(result).toHaveSucceeded();
       expect(result.stdout.trim().split(/\s+/)).toEqual([
         NO_CAPABILITIES,
-        ALLOWED_BOUNDING_SET,
         NO_CAPABILITIES,
-        ALLOWED_BOUNDING_SET,
+        NO_CAPABILITIES,
+        NO_CAPABILITIES,
       ]);
     } finally {
       await deleteSandbox(id);
     }
   });
 
-  // iputils-ping asks setcap to give /usr/bin/ping CAP_NET_RAW. The allowlist
-  // holds no CAP_SETFCAP, so setcap fails and the package installs a setuid
-  // binary instead. This is the install path the capability policy changed, so
-  // it is the one the suite pins.
-  test('passwordless sudo can install a package that sets file capabilities', async () => {
-    test.setTimeout(240_000);
+  // An empty bounding set alone leaves the path to root open: a setuid-root
+  // binary still makes the caller uid 0, and uid 0 owns /usr/local whatever its
+  // capabilities. This pins the three things that close it.
+  test('has no path to root', async () => {
     const id = await createSandbox();
     try {
-      const updated = await execWithTransientRetry(id, 'sudo -n apt-get update', {
-        timeoutMs: 60_000,
-      });
-      expect(updated).toHaveSucceeded();
+      const uid = await execWithTransientRetry(id, 'id -u');
+      expect(uid).toHaveSucceeded();
+      expect(uid.stdout.trim()).not.toBe('0');
 
-      const installed = await exec(
+      const escalation = await exec(
         id,
-        'sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y iputils-ping && ls -l /usr/bin/ping',
-        { timeoutMs: 150_000 },
+        'command -v sudo; find / -xdev -perm /4000 -type f 2>/dev/null',
+        { timeoutMs: 60_000 },
       );
-      expect(installed).toHaveSucceeded();
-      expect(installed.stdout, 'expected the setuid fallback for /usr/bin/ping').toMatch(/^-rws/m);
+      expect(escalation.stdout.trim(), 'expected no sudo and no setuid binary').toBe('');
+
+      const write = await exec(id, 'touch /usr/local/bin/escalated');
+      expect(write.exitCode, 'expected a write to /usr/local/bin to be refused').not.toBe(0);
+      expect(write.stderr).toMatch(/Permission denied/);
     } finally {
       await deleteSandbox(id);
     }
@@ -75,10 +72,9 @@ test.describe('Docker sandbox capability policy', DOCKER_ONLY, () => {
       const extraIP = siblingOf(ownIP);
 
       // Positive control. Without it the assertion below also passes when
-      // passwordless sudo or python3 fcntl is missing, which hides a
-      // capability regression instead of reporting one.
-      const plumbing = await exec(id, 'sudo -n python3 -c "import fcntl"');
-      expect(plumbing, 'expected sudo -n and python3 fcntl to be available').toHaveSucceeded();
+      // python3 fcntl is missing, hiding a capability regression.
+      const plumbing = await exec(id, 'python3 -c "import fcntl"');
+      expect(plumbing, 'expected python3 fcntl to be available').toHaveSucceeded();
 
       const added = await exec(id, addAddress(extraIP));
       expect(added.exitCode, 'expected address addition to be denied').not.toBe(0);

--- a/e2e/tests/sandbox-capabilities.spec.ts
+++ b/e2e/tests/sandbox-capabilities.spec.ts
@@ -47,16 +47,14 @@ test.describe('Docker sandbox capability policy', DOCKER_ONLY, () => {
       expect(uid).toHaveSucceeded();
       expect(uid.stdout.trim()).not.toBe('0');
 
-      // Only the exec directories, not the whole tree: a setuid binary has to
-      // live somewhere on PATH to be reachable, and /bin and /sbin are symlinks
-      // into /usr on bookworm. Scanning / instead would stat every inode of the
-      // node_modules and venv trees, which is 8x the work and slows the specs
-      // that run after this one.
+      // The whole tree, not just the exec directories: a setuid binary
+      // escalates through its absolute path, so PATH does not bound where one
+      // can hide. This is also the only check covering /home/user, which the
+      // image writes the venv and the npm prefix into after it clears the
+      // setuid bits.
       const escalation = await exec(
         id,
-        'command -v sudo; ' +
-          'find /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin /usr/lib ' +
-          '-xdev -perm /4000 -type f 2>/dev/null',
+        'command -v sudo; find / -xdev -perm /4000 -type f 2>/dev/null',
       );
       expect(escalation.stdout.trim(), 'expected no sudo and no setuid binary').toBe('');
 

--- a/e2e/tests/sandbox-packages.spec.ts
+++ b/e2e/tests/sandbox-packages.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test';
+import './matchers';
+import { createSandbox, deleteSandbox, exec, execWithTransientRetry } from './helpers';
+
+// A sandbox has no root: /usr/local is read-only to it and apt-get is gone, so
+// every install lands under /home/user. Nothing in the sandbox can add the two
+// install roots or the toolchain back, so these tests pin all three.
+test.describe('sandbox package installation', () => {
+  test('pip installs into the prebuilt venv', async () => {
+    test.setTimeout(180_000);
+    const id = await createSandbox();
+    try {
+      const prefix = await execWithTransientRetry(
+        id,
+        'command -v pip; python3 -c "import sys; print(sys.prefix)"',
+      );
+      expect(prefix).toHaveSucceeded();
+      expect(prefix.stdout.trim().split('\n')).toEqual([
+        '/home/user/venv/bin/pip',
+        '/home/user/venv',
+      ]);
+
+      // The same command against /usr/bin/python3 would be refused: Debian
+      // marks its interpreter externally-managed.
+      const installed = await exec(id, 'pip install --no-input six', { timeoutMs: 120_000 });
+      expect(installed).toHaveSucceeded();
+
+      const imported = await exec(id, 'python3 -c "import six; print(six.__file__)"');
+      expect(imported).toHaveSucceeded();
+      expect(imported.stdout).toContain('/home/user/venv');
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+
+  test('npm installs globally into the per-user prefix', async () => {
+    test.setTimeout(180_000);
+    const id = await createSandbox();
+    try {
+      const prefix = await execWithTransientRetry(id, 'npm config get prefix', {
+        timeoutMs: 60_000,
+      });
+      expect(prefix).toHaveSucceeded();
+      expect(prefix.stdout.trim()).toBe('/home/user/.npm-global');
+
+      const installed = await exec(id, 'npm install -g --ignore-scripts semver', {
+        timeoutMs: 120_000,
+      });
+      expect(installed).toHaveSucceeded();
+
+      // Resolving the name proves the prefix's bin is on PATH, not just that
+      // the files exist.
+      const ran = await exec(id, 'semver 1.2.3');
+      expect(ran).toHaveSucceeded();
+      expect(ran.stdout.trim()).toBe('1.2.3');
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+
+  test('npm installs into a project directory', async () => {
+    test.setTimeout(180_000);
+    const id = await createSandbox();
+    try {
+      await execWithTransientRetry(id, 'true');
+
+      const installed = await exec(
+        id,
+        'mkdir -p /home/user/proj && cd /home/user/proj && npm init -y >/dev/null && ' +
+          `npm install --ignore-scripts semver >/dev/null && node -e "require('semver'); console.log('ok')"`,
+        { timeoutMs: 120_000 },
+      );
+      expect(installed).toHaveSucceeded();
+      expect(installed.stdout.trim()).toBe('ok');
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+
+  // Every pip sdist and npm native addon needs a compiler, and a sandbox cannot
+  // apt-get one.
+  test('ships a toolchain for packages that build from source', async () => {
+    const id = await createSandbox();
+    try {
+      const toolchain = await execWithTransientRetry(
+        id,
+        'cc --version >/dev/null && make --version >/dev/null && ls /usr/include/python3*/Python.h',
+      );
+      expect(toolchain).toHaveSucceeded();
+      expect(toolchain.stdout).toContain('Python.h');
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+});

--- a/internal/daemon/exec.go
+++ b/internal/daemon/exec.go
@@ -27,9 +27,17 @@ func HandleExec(ctx context.Context, command string, env []string, workdir strin
 
 	// Start with sensible defaults so common tools work out of the box, then
 	// layer caller-supplied env vars on top (later values win).
+	//
+	// This replaces the environment rather than extending it, so it is the only
+	// one a user command sees on either runtime: image ENV and the runner's
+	// --env reach the daemon, not the commands it runs.
+	//
+	// The first two PATH entries are the install roots a sandbox without root
+	// can write: ~/.npm-global for a global npm install, and the prebuilt venv
+	// for pip.
 	cmd.Env = append([]string{
 		"HOME=/home/user",
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"PATH=/home/user/venv/bin:/home/user/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	}, env...)
 
 	if workdir != "" {

--- a/internal/runner/runtime/docker/README.md
+++ b/internal/runner/runtime/docker/README.md
@@ -20,15 +20,14 @@ containers direct access to the host Docker daemon.
   reachable.
 - Reports capacity from the current managed container count.
 - Applies default memory, CPU, PID, and optional disk quota limits on create.
-- Drops every Linux capability, then restores only `CAP_CHOWN`,
-  `CAP_DAC_OVERRIDE`, `CAP_FOWNER`, `CAP_SETGID`, and `CAP_SETUID`. This keeps
-  passwordless `sudo` usable for common package installation while preventing
-  network administration, audit-log writes, mounts, tracing, device creation,
-  raw sockets, and other privileged operations. Successful `sudo` commands may
-  emit an audit warning because `CAP_AUDIT_WRITE` is intentionally excluded.
+- Drops every Linux capability, restores none, and sets `no-new-privileges`.
+  The container runs as uid 1000, so it holds nothing effective; the empty
+  bounding set stops it gaining anything, and `no-new-privileges` makes any
+  setuid binary inert. With an image that ships no `sudo`, that leaves no path
+  to root and so no `apt-get`; packages install unprivileged under `/home/user`.
   Sysbox isolation and privileged local DinD apply to the runner container, so
   every sandbox container gets the same policy. Never create a sandbox container
-  with `--privileged`: Docker then ignores `--cap-drop` and the allowlist has no
+  with `--privileged`: Docker then ignores `--cap-drop` and the policy has no
   effect.
 - Applies Docker-specific network isolation rules through `netrules`.
 - Waits for daemon `/healthz` and a tiny `/executions` round trip before

--- a/internal/runner/runtime/docker/docker_client.go
+++ b/internal/runner/runtime/docker/docker_client.go
@@ -141,10 +141,12 @@ func dockerContainerCreateArgs(sandboxID, containerName, image string, limits *R
 		"--label", containerLabelManaged + "=" + containerLabelManagedVal,
 		"--label", containerLabelSandboxID + "=" + sandboxID,
 		"--user", "1000:1000",
+		// The daemon process only. internal/daemon/exec.go sets the environment
+		// user commands see.
 		"--env", "HOME=/home/user",
 		"--env", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	}
-	args = append(args, dockerSandboxCapabilityArgs()...)
+	args = append(args, dockerSandboxSecurityArgs()...)
 	args = append(args,
 		// netrules only filter IPv4; disable v6 in the container so sandboxes
 		// can't bypass the policy via link-local/ULA or v6 metadata addresses.
@@ -160,20 +162,21 @@ func dockerContainerCreateArgs(sandboxID, containerName, image string, limits *R
 	return args
 }
 
-// dockerSandboxCapabilityArgs is the single capability policy for every
-// Docker-backed sandbox. Keep the allowlist minimal while preserving
-// passwordless sudo for common package installation workflows.
+// dockerSandboxSecurityArgs is the single security policy for every Docker-backed
+// sandbox. The container runs as uid 1000, so it holds no effective capability
+// anyway; the empty bounding set stops a setuid binary gaining one.
 //
-// Never create a sandbox container with --privileged. Docker ignores --cap-drop
-// for a privileged container, so that flag would void this policy silently.
-func dockerSandboxCapabilityArgs() []string {
+// no-new-privileges is what closes the path to root. Without it a setuid-root
+// binary still makes the caller uid 0, and uid 0 owns /usr/local whatever its
+// capabilities. The image ships no sudo and no setuid binary; this flag holds
+// even if one returns.
+//
+// Never create a sandbox container with --privileged. Docker then ignores
+// --cap-drop and voids this policy silently.
+func dockerSandboxSecurityArgs() []string {
 	return []string{
 		"--cap-drop", "ALL",
-		"--cap-add", "CHOWN",
-		"--cap-add", "DAC_OVERRIDE",
-		"--cap-add", "FOWNER",
-		"--cap-add", "SETGID",
-		"--cap-add", "SETUID",
+		"--security-opt", "no-new-privileges",
 	}
 }
 

--- a/internal/runner/runtime/docker/runtime_test.go
+++ b/internal/runner/runtime/docker/runtime_test.go
@@ -131,11 +131,7 @@ func TestDockerContainerCreateArgs(t *testing.T) {
 		"--env", "HOME=/home/user",
 		"--env", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"--cap-drop", "ALL",
-		"--cap-add", "CHOWN",
-		"--cap-add", "DAC_OVERRIDE",
-		"--cap-add", "FOWNER",
-		"--cap-add", "SETGID",
-		"--cap-add", "SETUID",
+		"--security-opt", "no-new-privileges",
 		"--sysctl", "net.ipv6.conf.all.disable_ipv6=1",
 		"--sysctl", "net.ipv6.conf.default.disable_ipv6=1",
 		"--sysctl", "net.ipv6.conf.lo.disable_ipv6=1",
@@ -150,31 +146,29 @@ func TestDockerContainerCreateArgs(t *testing.T) {
 	}
 }
 
-func TestDockerContainerCreateArgsAlwaysApplyCapabilityPolicy(t *testing.T) {
+// Comparing every extracted flag against the whole policy is what catches a
+// --cap-add creeping back in: it shows up as an extra pair.
+func TestDockerContainerCreateArgsAlwaysApplySecurityPolicy(t *testing.T) {
 	want := []string{
 		"--cap-drop", "ALL",
-		"--cap-add", "CHOWN",
-		"--cap-add", "DAC_OVERRIDE",
-		"--cap-add", "FOWNER",
-		"--cap-add", "SETGID",
-		"--cap-add", "SETUID",
+		"--security-opt", "no-new-privileges",
 	}
 
 	for _, enableCgroups := range []bool{false, true} {
 		gotArgs := dockerContainerCreateArgs("sandbox-id", "sandbox-name", "sandbox-image", nil, enableCgroups)
 		var got []string
 		for i := 0; i < len(gotArgs); i++ {
-			if gotArgs[i] != "--cap-drop" && gotArgs[i] != "--cap-add" {
+			if gotArgs[i] != "--cap-drop" && gotArgs[i] != "--cap-add" && gotArgs[i] != "--security-opt" {
 				continue
 			}
 			if i+1 >= len(gotArgs) {
-				t.Fatalf("capability flag %q has no value", gotArgs[i])
+				t.Fatalf("security flag %q has no value", gotArgs[i])
 			}
 			got = append(got, gotArgs[i], gotArgs[i+1])
 			i++
 		}
 		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("capability args with enableCgroups=%v = %#v, want %#v", enableCgroups, got, want)
+			t.Fatalf("security args with enableCgroups=%v = %#v, want %#v", enableCgroups, got, want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Remove root and privileges from sandbox containers:

- The runner drops all capabilities and sets `no-new-privileges`.
- The image ships no `sudo` and no setuid binary.

`apt-get` needs root, so it stops working. Packages install under `/home/user`
instead:

- `pip install <name>` → `/home/user/venv`
- `npm install -g <name>` → `/home/user/.npm-global`

`internal/daemon/exec.go` puts both first on `PATH`. The image adds a compiler
for source builds. It grows from 630MB to 940MB.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4301

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.
