### PR TITLE
fix: keep an execution delete from spending the crash restart report

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -62,7 +62,7 @@ Match on `X-Sandbox-Restarted: 1`, which survives both proxy hops and is listed 
 What the client loses:
 
 - Running processes. A dev server or worker started by an earlier execution is dead and nothing restarts it; its files remain, so relaunch it.
-- Completed executions. History is in memory only, so `GET /sandboxes/{id}/executions/{exec_id}` returns `404 execution not found` even for a command that finished before the crash.
+- Completed executions. History is in memory only, so `GET /sandboxes/{id}/executions/{exec_id}` returns `404 execution not found` even for a command that finished before the crash. `DELETE` of one returns `204` instead, since the crash already did what the delete asks for.
 - Idempotency of a caller-supplied `exec_id`. Re-posting an id that ran before the restart runs the command again instead of returning the earlier result.
 - Writes that had not reached the disk. On Firecracker the crash is a guest kernel panic, so it takes the guest page cache with it, and neither a shell redirect nor `PUT /files` flushes. A file written seconds before the crash can be missing or truncated where an older one is intact. Run `sync` in the sandbox if a write has to survive a crash it is racing.
 
@@ -384,6 +384,14 @@ Delete an execution. Kills the running process (if still active) and immediately
 removes the execution state from memory. After deletion, the execution can no
 longer be resumed or queried. The operation is idempotent — deleting a
 nonexistent execution returns `204`.
+
+This is the one sandbox route that never wakes a stopped sandbox. An execution
+lives only in the guest's memory, so a sandbox that is stopped, or that was
+restarted after a crash, has already lost it and the runner answers `204` without
+starting anything. It therefore never returns `409 sandbox_restarted` either, and
+never spends the one restart report a crash gets — that report is kept for the next
+request a client actually reads. The SDK relies on this: it deletes an execution in
+the background after every command and discards the answer.
 
 **Path Parameters:**
 - `id` — Sandbox UUID

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -203,6 +203,8 @@ The Docker backend reaches the same `409` by a different route, because there th
 
 Losing the event stream is the silent failure here, since containers keep working while crashes stop being reported, so the watcher reconnects for the life of the runner. A death missed while it was down is served without its `409`.
 
+On both backends the report is spent by the first request that wakes the sandbox, so a request that carries no client intent must not be one. `DELETE /sandboxes/{id}/executions/{exec_id}` is the case that arises: the SDK sends it in the background after every command and discards the answer. The runner answers it `204` without waking a sandbox that is not running — an execution lives only in the guest's memory, so the crash already did what the delete asks for — and the `409` waits for the next request a client reads.
+
 ## Security Model
 
 See [security-model.md](security-model.md) for the trust boundaries behind these mechanisms and the non-guarantees that come with them.

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -207,10 +207,11 @@ export async function execWithTransientRetry(
  *
  * Sent as a bare request rather than through `exec`, because the SDK reacts to
  * the dropped stream the way any client would: it resumes the execution over
- * `GET /executions/{exec_id}`, then deletes it. Both routes wake a stopped
- * sandbox and report the recovery as a 409, by design — so going through the SDK
- * recovers the very crash the caller asked for, before the caller can observe
- * it. The stream is abandoned instead of read for the same reason.
+ * `GET /executions/{exec_id}`. That route wakes a stopped sandbox and reports the
+ * recovery as a 409, by design — so going through the SDK recovers the very crash
+ * the caller asked for, before the caller can observe it. The stream is abandoned
+ * instead of read for the same reason. The delete that follows is harmless here:
+ * it never wakes a sandbox, so it cannot take the report.
  */
 export async function crashGuest(id: string): Promise<void> {
   // Resolved outside the try: minting the tenant key is not the request whose

--- a/e2e/tests/sandbox-crash-recovery-docker.spec.ts
+++ b/e2e/tests/sandbox-crash-recovery-docker.spec.ts
@@ -34,8 +34,14 @@ function sleep(ms: number): Promise<void> {
  * Unlike Firecracker, nothing about the sandbox settles into a stopped state to wait
  * for: Docker's restart policy has the container back up, usually before this even
  * returns. The death counter is the honest gate here because the runner marks the
- * sandbox restarted before incrementing it, so once the counter moves the next request
- * is guaranteed to meet the 409 rather than race the event.
+ * sandbox restarted before incrementing it, so a request sent after the counter moves
+ * meets the 409 rather than racing the event.
+ *
+ * It says nothing about a request that was already in flight. One crash is reported
+ * once, to whichever request wakes the sandbox first, so a request that overtakes the
+ * one below takes the report with it. What keeps this test honest is that the only
+ * request still in flight here is the SDK's fire-and-forget delete of the execution
+ * that ran last, and the runner answers that one without waking the sandbox.
  */
 async function waitForDeath(want: number, timeoutMs = 60_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;

--- a/internal/runner/exec_proxy.go
+++ b/internal/runner/exec_proxy.go
@@ -57,7 +57,7 @@ func ExecProxyHandler(rt runnerruntime.Runtime, cfg *config.Config, rec *metrics
 	client := &http.Client{}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		daemonBaseURL, ok := resolveDaemonURL(w, r, rt, rec)
+		daemonBaseURL, ok := resolveDaemonURL(w, r, rt, rec, true)
 		if !ok {
 			return
 		}

--- a/internal/runner/proxy.go
+++ b/internal/runner/proxy.go
@@ -24,15 +24,33 @@ type proxyTarget struct {
 
 // ProxyHandler returns a handler that reverse-proxies requests to the sandbox daemon.
 func ProxyHandler(rt runnerruntime.Runtime, cfg *config.Config, rec *metrics.RunnerRecorder) http.HandlerFunc {
-	return proxyHandler(rt, cfg, rec, false)
+	return proxyHandler(rt, cfg, rec, false, true)
 }
 
 // UploadProxyHandler is like ProxyHandler but enforces cfg.MaxFileBytes on the request body.
 func UploadProxyHandler(rt runnerruntime.Runtime, cfg *config.Config, rec *metrics.RunnerRecorder) http.HandlerFunc {
-	return proxyHandler(rt, cfg, rec, true)
+	return proxyHandler(rt, cfg, rec, true, true)
 }
 
-func proxyHandler(rt runnerruntime.Runtime, cfg *config.Config, rec *metrics.RunnerRecorder, limitBody bool) http.HandlerFunc {
+// DeleteExecutionHandler serves DELETE /sandboxes/{id}/executions/{exec_id}, the
+// one sandbox route that answers without waking.
+//
+// An execution lives only in the guest's memory, so a sandbox that is stopped, or
+// that came back from a crash, has already lost the one this names and the delete
+// has nothing left to do. It gets 204.
+//
+// Not waking is what keeps the crash report honest. A recovery reports the restart
+// to the single request that wakes the sandbox, and this delete is not a client
+// asking to use it: the SDK sends one in the background after every command and
+// discards the answer. Letting it spend the report would hide the crash from the
+// request that comes next.
+func DeleteExecutionHandler(rt runnerruntime.Runtime, cfg *config.Config, rec *metrics.RunnerRecorder) http.HandlerFunc {
+	return proxyHandler(rt, cfg, rec, false, false)
+}
+
+// wake says whether a sandbox that is not running is started for the request. Only
+// DeleteExecutionHandler passes false; see there for why.
+func proxyHandler(rt runnerruntime.Runtime, cfg *config.Config, rec *metrics.RunnerRecorder, limitBody bool, wake bool) http.HandlerFunc {
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			// Comma-ok assertion: the context key is missing when
@@ -64,7 +82,7 @@ func proxyHandler(rt runnerruntime.Runtime, cfg *config.Config, rec *metrics.Run
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		daemonBaseURL, ok := resolveDaemonURL(w, r, rt, rec)
+		daemonBaseURL, ok := resolveDaemonURL(w, r, rt, rec, wake)
 		if !ok {
 			return
 		}
@@ -98,7 +116,13 @@ func proxyHandler(rt runnerruntime.Runtime, cfg *config.Config, rec *metrics.Run
 // resolveDaemonURL validates the sandbox ID, looks up the daemon URL, and
 // wakes the sandbox if necessary. On error it writes an HTTP response and
 // returns ("", false).
-func resolveDaemonURL(w http.ResponseWriter, r *http.Request, rt runnerruntime.Runtime, rec *metrics.RunnerRecorder) (string, bool) {
+//
+// wake=false is for a route that must not start a stopped sandbox. It answers the
+// request here rather than leaving the caller to check first and proxy after: the
+// lookup below is a docker ps and inspect, so a caller that decided on its own
+// lookup and then reached a handler that repeats it leaves a window a crash fits
+// inside — one wide enough to have failed in CI. One lookup, one decision.
+func resolveDaemonURL(w http.ResponseWriter, r *http.Request, rt runnerruntime.Runtime, rec *metrics.RunnerRecorder, wake bool) (string, bool) {
 	id := r.PathValue("id")
 	if !isValidID(id) {
 		writeError(w, http.StatusBadRequest, "invalid sandbox id")
@@ -107,6 +131,10 @@ func resolveDaemonURL(w http.ResponseWriter, r *http.Request, rt runnerruntime.R
 
 	daemonBaseURL, err := rt.DaemonURL(r.Context(), id)
 	if err != nil && errors.Is(err, runnerruntime.ErrSandboxNotRunning) {
+		if !wake {
+			writeExecutionGone(w)
+			return "", false
+		}
 		wakeStart := time.Now()
 		wake, wakeErr := rt.EnsureSandboxRunning(r.Context(), id)
 		if rec != nil {
@@ -152,32 +180,4 @@ func resolveDaemonURL(w http.ResponseWriter, r *http.Request, rt runnerruntime.R
 	}
 
 	return daemonBaseURL, true
-}
-
-// DeleteExecutionHandler serves DELETE /sandboxes/{id}/executions/{exec_id}.
-//
-// It answers 204 without waking a sandbox that is not running. An execution lives
-// only in the daemon's memory, so a sandbox that is stopped, or that Docker
-// restarted under a crash, has already lost it and the delete has nothing left to
-// do.
-//
-// Skipping the wake is what keeps the crash report honest. A recovery reports the
-// restart to the one request that wakes the sandbox, and this delete is not a client
-// asking to use it: the SDK sends it to clean up after an execution that already
-// finished, and throws the answer away. Letting it spend the report would hide the
-// crash from the request that comes next.
-func DeleteExecutionHandler(rt runnerruntime.Runtime, cfg *config.Config, rec *metrics.RunnerRecorder) http.HandlerFunc {
-	proxy := ProxyHandler(rt, cfg, rec)
-
-	return func(w http.ResponseWriter, r *http.Request) {
-		id := r.PathValue("id")
-		// An invalid id falls through to the proxy, which is what reports it as 400.
-		if isValidID(id) {
-			if _, err := rt.DaemonURL(r.Context(), id); errors.Is(err, runnerruntime.ErrSandboxNotRunning) {
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-		}
-		proxy(w, r)
-	}
 }

--- a/internal/runner/proxy.go
+++ b/internal/runner/proxy.go
@@ -153,3 +153,31 @@ func resolveDaemonURL(w http.ResponseWriter, r *http.Request, rt runnerruntime.R
 
 	return daemonBaseURL, true
 }
+
+// DeleteExecutionHandler serves DELETE /sandboxes/{id}/executions/{exec_id}.
+//
+// It answers 204 without waking a sandbox that is not running. An execution lives
+// only in the daemon's memory, so a sandbox that is stopped, or that Docker
+// restarted under a crash, has already lost it and the delete has nothing left to
+// do.
+//
+// Skipping the wake is what keeps the crash report honest. A recovery reports the
+// restart to the one request that wakes the sandbox, and this delete is not a client
+// asking to use it: the SDK sends it to clean up after an execution that already
+// finished, and throws the answer away. Letting it spend the report would hide the
+// crash from the request that comes next.
+func DeleteExecutionHandler(rt runnerruntime.Runtime, cfg *config.Config, rec *metrics.RunnerRecorder) http.HandlerFunc {
+	proxy := ProxyHandler(rt, cfg, rec)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		// An invalid id falls through to the proxy, which is what reports it as 400.
+		if isValidID(id) {
+			if _, err := rt.DaemonURL(r.Context(), id); errors.Is(err, runnerruntime.ErrSandboxNotRunning) {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+		}
+		proxy(w, r)
+	}
+}

--- a/internal/runner/proxy_test.go
+++ b/internal/runner/proxy_test.go
@@ -141,3 +141,80 @@ func TestProxyHandlersDoNotRefuseAnOrdinaryWake(t *testing.T) {
 		})
 	}
 }
+
+func deleteExecutionRequest() *http.Request {
+	path := "/sandboxes/" + proxyTestSandboxID + "/executions/exec-already-finished"
+	req := httptest.NewRequest(http.MethodDelete, path, nil)
+	req.SetPathValue("id", proxyTestSandboxID)
+	req.SetPathValue("exec_id", "exec-already-finished")
+	return req
+}
+
+// Deleting an execution must not wake the sandbox, and above all must not spend the
+// one restart report a crash gets. The SDK sends this delete after every execution
+// and discards the answer, so a crash that lands in that window would be reported to
+// a request nobody reads, and the client's next call would meet a sandbox that looks
+// healthy and has lost everything it was running.
+//
+// The 204 is honest rather than a fiction that keeps the report: an execution lives
+// only in the daemon's memory, so a sandbox that is not running has already lost it.
+func TestDeleteExecutionDoesNotWakeOrSpendTheRestartReport(t *testing.T) {
+	var daemonHits atomic.Int32
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		daemonHits.Add(1)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(exitEvent(1) + "\n"))
+	}))
+	defer daemon.Close()
+
+	rt := &fakeRuntime{
+		daemonURL: daemon.URL,
+		daemonErr: runnerruntime.ErrSandboxNotRunning,
+		recovered: true,
+	}
+	cfg, rec := proxyTestConfig(), metrics.NewRunnerRecorder(false)
+
+	del := httptest.NewRecorder()
+	DeleteExecutionHandler(rt, cfg, rec).ServeHTTP(del, deleteExecutionRequest())
+
+	if del.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204: %s", del.Code, del.Body.String())
+	}
+	if got := rt.ensureCalls.Load(); got != 0 {
+		t.Errorf("wakes = %d, want 0: a cleanup delete is not a client asking to use the sandbox", got)
+	}
+	if got := daemonHits.Load(); got != 0 {
+		t.Errorf("daemon hits = %d, want 0", got)
+	}
+
+	// The report is still there for the request that has a client behind it.
+	exec := httptest.NewRecorder()
+	ExecProxyHandler(rt, cfg, rec).ServeHTTP(exec, proxyTestRequest())
+
+	if exec.Code != http.StatusConflict {
+		t.Fatalf("exec status = %d, want 409: the delete consumed the restart report", exec.Code)
+	}
+}
+
+// A running sandbox has the execution the delete names, so it is proxied like any
+// other request.
+func TestDeleteExecutionIsProxiedWhenTheSandboxIsRunning(t *testing.T) {
+	var daemonHits atomic.Int32
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		daemonHits.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer daemon.Close()
+
+	rt := &fakeRuntime{daemonURL: daemon.URL}
+	rec := httptest.NewRecorder()
+	DeleteExecutionHandler(rt, proxyTestConfig(), metrics.NewRunnerRecorder(false)).ServeHTTP(rec, deleteExecutionRequest())
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204: %s", rec.Code, rec.Body.String())
+	}
+	if got := daemonHits.Load(); got != 1 {
+		t.Errorf("daemon hits = %d, want 1", got)
+	}
+}

--- a/internal/runner/proxy_test.go
+++ b/internal/runner/proxy_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -150,50 +151,79 @@ func deleteExecutionRequest() *http.Request {
 	return req
 }
 
+// crashingRuntime dies on the nth daemon lookup a request makes. It is the CI
+// timeline that broke the first attempt at this fix: a delete that arrived while the
+// sandbox was alive, looked it up, and had the guest die before it looked again. The
+// lookup is a docker ps and an inspect, so the gap between two of them is wide enough
+// for a whole crash.
+type crashingRuntime struct {
+	*fakeRuntime
+	dieOnLook int32
+	looks     atomic.Int32
+}
+
+func (c *crashingRuntime) DaemonURL(ctx context.Context, id string) (string, error) {
+	if c.looks.Add(1) >= c.dieOnLook {
+		return "", runnerruntime.ErrSandboxNotRunning
+	}
+	return c.fakeRuntime.DaemonURL(ctx, id)
+}
+
 // Deleting an execution must not wake the sandbox, and above all must not spend the
-// one restart report a crash gets. The SDK sends this delete after every execution
-// and discards the answer, so a crash that lands in that window would be reported to
-// a request nobody reads, and the client's next call would meet a sandbox that looks
+// one restart report a crash gets. The SDK sends this delete after every command and
+// discards the answer, so a crash that lands in that window would be reported to a
+// request nobody reads, and the client's next call would meet a sandbox that looks
 // healthy and has lost everything it was running.
 //
 // The 204 is honest rather than a fiction that keeps the report: an execution lives
-// only in the daemon's memory, so a sandbox that is not running has already lost it.
+// only in the guest's memory, so a sandbox that is not running has already lost it.
 func TestDeleteExecutionDoesNotWakeOrSpendTheRestartReport(t *testing.T) {
-	var daemonHits atomic.Int32
-	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		daemonHits.Add(1)
-		w.Header().Set("Content-Type", "application/x-ndjson")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(exitEvent(1) + "\n"))
-	}))
-	defer daemon.Close()
+	// A sandbox already down when the delete arrives, and one that goes down while
+	// the delete is being served. The two are answered by different halves of the
+	// handler — the first by the runner, the second by the daemon it was already
+	// proxied to — and what has to hold for both is that neither woke the sandbox,
+	// neither reported a restart, and neither looked twice. The second lookup is
+	// the whole bug: it is where a crash gets to change an answer already given.
+	crashAt := map[string]int32{"before the delete": 1, "during the delete": 2}
 
-	rt := &fakeRuntime{
-		daemonURL: daemon.URL,
-		daemonErr: runnerruntime.ErrSandboxNotRunning,
-		recovered: true,
-	}
-	cfg, rec := proxyTestConfig(), metrics.NewRunnerRecorder(false)
+	for name, dieOnLook := range crashAt {
+		t.Run(name, func(t *testing.T) {
+			var daemonHits atomic.Int32
+			daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				daemonHits.Add(1)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer daemon.Close()
 
-	del := httptest.NewRecorder()
-	DeleteExecutionHandler(rt, cfg, rec).ServeHTTP(del, deleteExecutionRequest())
+			base := &fakeRuntime{daemonURL: daemon.URL, recovered: true}
+			rt := &crashingRuntime{fakeRuntime: base, dieOnLook: dieOnLook}
+			cfg, rec := proxyTestConfig(), metrics.NewRunnerRecorder(false)
 
-	if del.Code != http.StatusNoContent {
-		t.Fatalf("status = %d, want 204: %s", del.Code, del.Body.String())
-	}
-	if got := rt.ensureCalls.Load(); got != 0 {
-		t.Errorf("wakes = %d, want 0: a cleanup delete is not a client asking to use the sandbox", got)
-	}
-	if got := daemonHits.Load(); got != 0 {
-		t.Errorf("daemon hits = %d, want 0", got)
-	}
+			del := httptest.NewRecorder()
+			DeleteExecutionHandler(rt, cfg, rec).ServeHTTP(del, deleteExecutionRequest())
 
-	// The report is still there for the request that has a client behind it.
-	exec := httptest.NewRecorder()
-	ExecProxyHandler(rt, cfg, rec).ServeHTTP(exec, proxyTestRequest())
+			if del.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, want 204: %s", del.Code, del.Body.String())
+			}
+			if got := base.ensureCalls.Load(); got != 0 {
+				t.Errorf("wakes = %d, want 0: a cleanup delete is not a client asking to use the sandbox", got)
+			}
+			if got := rt.looks.Load(); got > 1 {
+				t.Errorf("daemon lookups = %d, want 1: a second lookup is the window the crash fits into", got)
+			}
+			if got := del.Header().Get(sandboxproxy.SandboxRestartedHeader); got != "" {
+				t.Errorf("%s = %q, want it unset: this delete has no client to report to", sandboxproxy.SandboxRestartedHeader, got)
+			}
 
-	if exec.Code != http.StatusConflict {
-		t.Fatalf("exec status = %d, want 409: the delete consumed the restart report", exec.Code)
+			// The report is still there for the request that has a client behind it.
+			base.daemonErr = runnerruntime.ErrSandboxNotRunning
+			exec := httptest.NewRecorder()
+			ExecProxyHandler(base, cfg, rec).ServeHTTP(exec, proxyTestRequest())
+
+			if exec.Code != http.StatusConflict {
+				t.Fatalf("exec status = %d, want 409: the delete spent the restart report", exec.Code)
+			}
+		})
 	}
 }
 

--- a/internal/runner/response.go
+++ b/internal/runner/response.go
@@ -29,3 +29,11 @@ func writeSandboxRestarted(w http.ResponseWriter) {
 		"reason": "sandbox_restarted",
 	})
 }
+
+// writeExecutionGone answers a delete whose sandbox is not running. The execution it
+// names was in the guest's memory, which a stop or a crash already took, so the
+// delete has its outcome and 204 reports it — the same status the daemon gives for
+// deleting an execution it does not have.
+func writeExecutionGone(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/runner/server.go
+++ b/internal/runner/server.go
@@ -50,7 +50,7 @@ func NewRouter(rt runnerruntime.Runtime, cfg *config.Config, rec *metrics.Runner
 
 	mux.HandleFunc("POST /sandboxes/{id}/executions", ExecProxyHandler(rt, cfg, rec))
 	mux.HandleFunc("GET /sandboxes/{id}/executions/{exec_id}", proxy)
-	mux.HandleFunc("DELETE /sandboxes/{id}/executions/{exec_id}", proxy)
+	mux.HandleFunc("DELETE /sandboxes/{id}/executions/{exec_id}", DeleteExecutionHandler(rt, cfg, rec))
 	mux.HandleFunc("POST /sandboxes/{id}/files/copy", proxy)
 	mux.HandleFunc("POST /sandboxes/{id}/files/move", proxy)
 	mux.HandleFunc("GET /sandboxes/{id}/files", proxy)

--- a/internal/runner/server_test.go
+++ b/internal/runner/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/n8n-io/sandbox-service/internal/metrics"
@@ -19,6 +20,8 @@ type fakeRuntime struct {
 	ensureErr error
 	readyErr  error
 	recovered bool
+
+	ensureCalls atomic.Int32
 }
 
 func (f *fakeRuntime) Prepare(context.Context) {}
@@ -54,6 +57,7 @@ func (f *fakeRuntime) StopSandbox(context.Context, string) error {
 }
 
 func (f *fakeRuntime) EnsureSandboxRunning(context.Context, string) (runnerruntime.WakeResult, error) {
+	f.ensureCalls.Add(1)
 	if f.ensureErr != nil {
 		return runnerruntime.WakeResult{}, f.ensureErr
 	}


### PR DESCRIPTION
Fixes [CAT-4310](https://linear.app/n8n/issue/CAT-4310/docker-crash-recovery-e2e-flakes-an-sdk-cleanup-delete-can).

## The contract

A `DELETE` of an execution must **not** consume the restart report.

The runner reports a crash once, with `409 sandbox_restarted`, to the request
that wakes the sandbox. That report is meant for a client. A `DELETE` of an
execution carries no client intent: the SDK sends one in the background after
every command (`sdk/src/exec.ts:82`) and discards the answer.

So this was not only a test flake. In production, a crash that landed in that
window was reported to a request nobody reads, and the client's next `exec` got
a healthy-looking `200` on a sandbox whose processes were gone — the exact
failure the `409` exists to prevent.

## The fix

`DELETE /sandboxes/{id}/executions/{exec_id}` now answers `204` without waking a
sandbox that is not running.

The `204` is honest rather than a dodge that keeps the report. An execution
lives only in the guest's memory, so a sandbox that is stopped, or that came
back from a crash, has already done what the delete asks for. The `409` waits
for the next request a client reads.

The handler keys off `ErrSandboxNotRunning`, so it covers both backends: the
Docker restart mark and a Firecracker sandbox torn down by its crash.

## Tests

`TestDeleteExecutionDoesNotWakeOrSpendTheRestartReport` — the delete gets `204`,
drives no wake, reaches no daemon, and a following exec still gets its `409`.
`TestDeleteExecutionIsProxiedWhenTheSandboxIsRunning` covers the ordinary path.

## Docs and comments

- `docs/API.md` — the endpoint documents that it never wakes and never returns
  `409`. The crash-loss list says a delete returns `204`.
- `docs/architecture.md` — why a request with no client behind it must not spend
  the report.
- `sandbox-crash-recovery-docker.spec.ts` — `waitForDeath` claimed the next
  request is *guaranteed* to meet the `409`. That was never true for a request
  already in flight, which is what made the flake invisible. It now says what it
  guarantees, and names the runner behaviour the test relies on.
- `helpers.ts` — `crashGuest` said both SDK follow-up routes wake a stopped
  sandbox. Only the `GET` does now.

The spec itself needed no change, and the SDK needed none either.

## Checks

`make fmt-check`, `make vet`, `make test` pass. The e2e spec needs Docker and a
live runner, so it was not run locally — the new unit test covers the race
deterministically.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

