### PR TITLE
chore: handle non-TLS runner URLs

### DIFF
--- a/docs/cert-manager-k8s.md
+++ b/docs/cert-manager-k8s.md
@@ -26,7 +26,7 @@ Mount PEMs from `Certificate` secrets (often `tls.crt`, `tls.key`) plus a CA bun
 - Registration client (existing): `SANDBOX_RUNNER_REGISTRATION_GRPC_CA_FILE`, `SANDBOX_RUNNER_REGISTRATION_GRPC_CERT_FILE`, `SANDBOX_RUNNER_REGISTRATION_GRPC_KEY_FILE`, optional `SANDBOX_RUNNER_REGISTRATION_GRPC_SERVER_NAME` (must match a DNS SAN on the API registration server cert).
 - Control listener: `SANDBOX_RUNNER_CONTROL_GRPC_TLS_CERT_FILE`, `SANDBOX_RUNNER_CONTROL_GRPC_TLS_KEY_FILE`, `SANDBOX_RUNNER_CONTROL_GRPC_TLS_CLIENT_CA_FILE` (CA that signed **API control clients**). The runner's HTTP listener serves TLS with this same material, so its certificate needs a SAN for the HTTP host too, and the API's control client certificate authenticates both channels.
 
-Also set `SANDBOX_RUNNER_CONTROL_GRPC_LISTEN_ADDR` (for example `:9091`) and either `SANDBOX_RUNNER_CONTROL_GRPC_ADVERTISE_ADDR` or a usable `SANDBOX_RUNNER_HTTP_BASE_URL` so the runner can advertise `control_grpc_addr` in heartbeats. `SANDBOX_RUNNER_HTTP_BASE_URL` must be `https://`.
+Also set `SANDBOX_RUNNER_CONTROL_GRPC_LISTEN_ADDR` (for example `:9091`) and either `SANDBOX_RUNNER_CONTROL_GRPC_ADVERTISE_ADDR` or a usable `SANDBOX_RUNNER_HTTP_BASE_URL` so the runner can advertise `control_grpc_addr` in heartbeats. The runner serves `SANDBOX_RUNNER_HTTP_BASE_URL` over TLS, and upgrades an `http://` value to `https://` with a warning.
 
 Probes are the one exception to client-certificate enforcement: a kubelet `httpGet` probe cannot present one, so the runner negotiates with `VerifyClientCertIfGiven` and leaves `/livez`, `/readyz` and `/metrics` unauthenticated. Set `scheme: HTTPS` on those probes.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,7 @@ The idle sweeper waits `SANDBOX_API_ORPHAN_REAP_BUFFER` (default `5m`) after a r
 | `SANDBOX_RUNNER_LISTEN_ADDR` | `:8080` | HTTPS listen address; serves TLS with the `SANDBOX_RUNNER_CONTROL_GRPC_TLS_*` material |
 | `SANDBOX_RUNNER_API_GRPC_ADDR` | *(required)* | API `host:port` for gRPC registration |
 | `SANDBOX_RUNNER_REGISTRATION_TOKEN` | *(required)* | Must match `SANDBOX_API_RUNNER_REGISTRATION_TOKEN` on the API |
-| `SANDBOX_RUNNER_HTTP_BASE_URL` | *(required)* | Base URL the API uses to reach this runner; must be `https://` and its host must match a SAN on the runner's control cert (e.g. `https://runner:8080`) |
+| `SANDBOX_RUNNER_HTTP_BASE_URL` | *(required)* | Base URL the API uses to reach this runner; its host must match a SAN on the runner's control cert (e.g. `https://runner:8080`). An `http://` value is upgraded to `https://` with a warning, since the listener only serves TLS |
 | `SANDBOX_RUNNER_ID` | hostname | Stable runner id sent to the API |
 | `SANDBOX_RUNNER_CAPACITY_TOTAL` | `1000` | Reported capacity for placement (`0` = unlimited) |
 | `SANDBOX_RUNNER_DATA_DIR` | `/var/sandboxes` | Directory for SQLite state |

--- a/docs/quickstart-linux.md
+++ b/docs/quickstart-linux.md
@@ -91,7 +91,7 @@ The API and runners communicate with mutual TLS (mTLS), over both gRPC and HTTP.
 | SandboxControl gRPC server | `server auth` | Runner (listens on :9091, and on :8080 for HTTP) |
 | SandboxControl gRPC client | `client auth` | API (dials runner :9091, and :8080 for exec and file traffic) |
 
-The runner's HTTP listener reuses the SandboxControl pair rather than having its own, so `SANDBOX_RUNNER_HTTP_BASE_URL` must be `https://` and its host must be one of that certificate's SANs.
+The runner's HTTP listener reuses the SandboxControl pair rather than having its own, so the host in `SANDBOX_RUNNER_HTTP_BASE_URL` must be one of that certificate's SANs. The listener only serves TLS, so an `http://` value left over from an older deployment is upgraded to `https://` and logged as a warning at startup.
 
 Certificates are organized into per-service directories (`.tls/api/` and `.tls/runner/`) so each service only has access to its own material.
 

--- a/internal/runner/config/config.go
+++ b/internal/runner/config/config.go
@@ -285,7 +285,7 @@ func Load() (*Config, error) {
 		)
 		cfg.RunnerHTTPBaseURL = u.String()
 	}
-	if err != nil || !strings.EqualFold(u.Scheme, "https") || u.Host == "" {
+	if err != nil || !strings.EqualFold(u.Scheme, "https") || u.Hostname() == "" {
 		return nil, fmt.Errorf("SANDBOX_RUNNER_HTTP_BASE_URL must be an https:// URL with a host, got %q", cfg.RunnerHTTPBaseURL)
 	}
 

--- a/internal/runner/config/config.go
+++ b/internal/runner/config/config.go
@@ -262,13 +262,30 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("SANDBOX_RUNNER_HTTP_BASE_URL must be set")
 	}
 	// The HTTP listener serves TLS, and this URL is what the runner advertises
-	// to the API in heartbeats, so an http:// value would send every request to
-	// the wrong scheme. The host has to be checked separately: url.Parse reads
+	// to the API in heartbeats, so it has to name https or the API would send
+	// every request to the wrong scheme. The host has to be checked
+	// separately: url.Parse reads
 	// "https:runner:8080" as an opaque path and "https://" as empty, both with
 	// scheme https and no host, and either would leave the runner advertising
 	// an address nothing can dial and no host to derive the control gRPC
 	// advertise address from.
-	if u, err := url.Parse(cfg.RunnerHTTPBaseURL); err != nil || !strings.EqualFold(u.Scheme, "https") || u.Host == "" {
+	u, err := url.Parse(cfg.RunnerHTTPBaseURL)
+	// http:// is upgraded rather than refused. Deployments written before the
+	// listener served TLS still carry it, and refusing here exits before
+	// registration, so the operator sees a runner missing from the API rather
+	// than a scheme they can fix. Only the scheme changes, so certificate
+	// coverage is unaffected: a host the runner's certificate does not cover
+	// fails the first request with a TLS error either way.
+	if err == nil && u.Host != "" && strings.EqualFold(u.Scheme, "http") {
+		u.Scheme = "https"
+		slog.Warn(
+			"SANDBOX_RUNNER_HTTP_BASE_URL uses http://, which the runner HTTP listener does not serve; advertising https:// instead. Update the configuration.",
+			"configured", cfg.RunnerHTTPBaseURL,
+			"advertising", u.String(),
+		)
+		cfg.RunnerHTTPBaseURL = u.String()
+	}
+	if err != nil || !strings.EqualFold(u.Scheme, "https") || u.Host == "" {
 		return nil, fmt.Errorf("SANDBOX_RUNNER_HTTP_BASE_URL must be an https:// URL with a host, got %q", cfg.RunnerHTTPBaseURL)
 	}
 

--- a/internal/runner/config/config_test.go
+++ b/internal/runner/config/config_test.go
@@ -87,16 +87,29 @@ func TestLoadRejectsPartialControlGRPCTLS(t *testing.T) {
 	}
 }
 
-func TestLoadRejectsPlaintextHTTPBaseURL(t *testing.T) {
+// Deployments written before the runner's HTTP listener served TLS still set
+// http://. Load upgrades the scheme instead of exiting, so those runners keep
+// registering; only the scheme changes, so the host the API verifies the
+// runner's certificate against is the one that was configured.
+func TestLoadUpgradesPlaintextHTTPBaseURL(t *testing.T) {
 	setRequiredEnv(t)
 	t.Setenv("SANDBOX_RUNNER_HTTP_BASE_URL", "http://runner:8080")
 
-	if _, err := Load(); err == nil {
-		t.Fatal("expected Load to reject an http:// SANDBOX_RUNNER_HTTP_BASE_URL")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("expected Load to upgrade an http:// SANDBOX_RUNNER_HTTP_BASE_URL, got: %v", err)
+	}
+	if cfg.RunnerHTTPBaseURL != "https://runner:8080" {
+		t.Fatalf("expected https://runner:8080, got %q", cfg.RunnerHTTPBaseURL)
+	}
+	// The control gRPC advertise address is derived from this URL, so the
+	// upgrade must not disturb the host or it would be advertised wrong too.
+	if got := cfg.ResolvedControlGRPCAdvertiseAddr(); got != "runner:9091" {
+		t.Fatalf("expected the upgrade to leave the control gRPC advertise address at runner:9091, got %q", got)
 	}
 }
 
-// url.Parse reports scheme https for several forms that carry no host, so a
+// url.Parse reports a scheme for several forms that carry no host, so a
 // scheme-only check would let the runner boot advertising a base URL nothing
 // can dial.
 //
@@ -114,6 +127,11 @@ func TestLoadRejectsHTTPBaseURLWithoutHost(t *testing.T) {
 		"https://",
 		"https:",
 		"https:///files",
+		// The http:// upgrade must not become a way around the host check.
+		"http:runner:8080",
+		"http://",
+		"http:",
+		"http:///files",
 	} {
 		t.Run(base, func(t *testing.T) {
 			setRequiredEnv(t)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Changes `SANDBOX_RUNNER_HTTP_BASE_URL` handling so an `http://` value is upgraded to `https://` with a warning instead of being rejected at startup. Older deployments that still set `http://` will keep registering rather than exiting before registration; only the scheme changes, so the configured host, advertised control gRPC address, and certificate checks are unaffected. The docs now describe this upgrade and the warning.

<sup>Written for commit 6ae20fac350d68dff5fc65639efbc4fd26b47118. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

