### PR TITLE
fix: keep the dockerd log out of /tmp

### DIFF
--- a/docs/quickstart-k8s.md
+++ b/docs/quickstart-k8s.md
@@ -142,15 +142,6 @@ Two hardening options, both described in the chart [README](../charts/n8n-sandbo
 
 ## Troubleshooting
 
-**The runner logs `cat: can't open '/tmp/dockerd.log'`.** The inner Docker daemon did not become ready, and the runner could not print its log. Releases up to 1.3.1 wrote that log to `/tmp`, and the dind wrapper mounts a tmpfs over `/tmp`, which hides the file. Set the path outside `/tmp` to read the real error:
-
-```yaml
-runner:
-  extraEnv:
-    - name: DOCKERD_LOG
-      value: /var/log/dockerd.log
-```
-
 **Install succeeds but no runner pod appears.** Admission denied the pod, so `kubectl get pods` shows nothing and the error lands on the StatefulSet. Inspect the StatefulSet events:
 
 ```bash

--- a/docs/quickstart-k8s.md
+++ b/docs/quickstart-k8s.md
@@ -142,6 +142,15 @@ Two hardening options, both described in the chart [README](../charts/n8n-sandbo
 
 ## Troubleshooting
 
+**The runner logs `cat: can't open '/tmp/dockerd.log'`.** The inner Docker daemon did not become ready, and the runner could not print its log. Releases up to 1.3.1 wrote that log to `/tmp`, and the dind wrapper mounts a tmpfs over `/tmp`, which hides the file. Set the path outside `/tmp` to read the real error:
+
+```yaml
+runner:
+  extraEnv:
+    - name: DOCKERD_LOG
+      value: /var/log/dockerd.log
+```
+
 **Install succeeds but no runner pod appears.** Admission denied the pod, so `kubectl get pods` shows nothing and the error lands on the StatefulSet. Inspect the StatefulSet events:
 
 ```bash

--- a/scripts/start-runner.sh
+++ b/scripts/start-runner.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 set -eu
 
-# Keep this log out of /tmp. dockerd-entrypoint.sh execs through the dind
-# wrapper, and that wrapper mounts a tmpfs over /tmp when /tmp is not already a
-# mount point. The mount hides this file from the shell, so the failure path
-# below printed "cat: can't open" and lost the reason dockerd never started.
 DOCKERD_LOG=${DOCKERD_LOG:-/var/log/dockerd.log}
 DOCKERD_CONFIG_DIR=${DOCKERD_CONFIG_DIR:-/etc/docker}
 DOCKERD_CONFIG_FILE=${DOCKERD_CONFIG_FILE:-${DOCKERD_CONFIG_DIR}/daemon.json}

--- a/scripts/start-runner.sh
+++ b/scripts/start-runner.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 set -eu
 
-DOCKERD_LOG=${DOCKERD_LOG:-/tmp/dockerd.log}
+# Keep this log out of /tmp. dockerd-entrypoint.sh execs through the dind
+# wrapper, and that wrapper mounts a tmpfs over /tmp when /tmp is not already a
+# mount point. The mount hides this file from the shell, so the failure path
+# below printed "cat: can't open" and lost the reason dockerd never started.
+DOCKERD_LOG=${DOCKERD_LOG:-/var/log/dockerd.log}
 DOCKERD_CONFIG_DIR=${DOCKERD_CONFIG_DIR:-/etc/docker}
 DOCKERD_CONFIG_FILE=${DOCKERD_CONFIG_FILE:-${DOCKERD_CONFIG_DIR}/daemon.json}
 


### PR DESCRIPTION
## Problem

`start-runner.sh` sends dockerd output to `/tmp/dockerd.log`, then prints that file when dockerd fails to become ready. The print never worked.

`dockerd-entrypoint.sh` execs through the `dind` wrapper, and that wrapper mounts a tmpfs over `/tmp` when `/tmp` is not already a mount point:

```sh
# Mount /tmp (conditionally)
if ! mountpoint -q /tmp; then
	mount -t tmpfs none /tmp
fi
```

The mount lands in the container mount namespace, so it covers the log file the shell created. dockerd keeps writing to the hidden inode. 