### PR TITLE
fix(chart): bound the sysbox data root and refuse a PVC in a user namespace

### DIFF
--- a/charts/n8n-sandbox-service/Chart.yaml
+++ b/charts/n8n-sandbox-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: n8n-sandbox-service
 description: n8n Sandbox Service control plane with optional in-cluster Docker-in-Docker runner
 type: application
-version: "0.6.2"
+version: "0.6.3"
 # The single release version shared by the API, runner, and sandbox images. Image
 # tags default to it, so this is the set that is supported together.
 # It intentionally lags VERSION until the first unified release, because the

--- a/charts/n8n-sandbox-service/README.md
+++ b/charts/n8n-sandbox-service/README.md
@@ -64,7 +64,7 @@ Requirements and recommendations:
 - Prefer a dedicated node pool for the runner via `runner.privileged.scheduling`.
 - Platforms that block privileged containers outright (for example GKE Autopilot) cannot use this isolation; use `dataPlane.mode: external` there.
 
-When `runner.dockerDataRoot.persistence` is disabled, the chart mounts an `emptyDir` with `runner.dockerDataRoot.emptyDir.sizeLimit` at `/var/lib/docker`, so the inner Docker daemon's layers are bounded. With disk quotas the volume holds the quota pool image instead; see [Disk Quotas](#disk-quotas).
+The chart bounds the inner Docker daemon's data root for both isolations; see [Docker Data Root](#docker-data-root).
 
 Two hardening options:
 
@@ -144,6 +144,37 @@ runner:
           effect: NoSchedule
 ```
 
+## Docker Data Root
+
+The runner always gets a volume for the inner Docker daemon's data root, so its image layers and sandbox filesystems cannot fill the node disk. Which volume depends on `runner.dockerDataRoot.persistence.enabled`:
+
+| `persistence.enabled` | Volume | Bounded by |
+| --- | --- | --- |
+| `false` (default) | `emptyDir`, created fresh for each pod | `runner.dockerDataRoot.emptyDir.sizeLimit` |
+| `true` | `PersistentVolumeClaim`, one per runner pod | `runner.dockerDataRoot.persistence.size` |
+
+The volume mounts at `/var/lib/docker`, or at `/var/lib/docker-pool` when `runner.config.defaultDiskQuotaMb` is above 0, because the quota pool image needs the bounded volume then. See [Disk Quotas](#disk-quotas).
+
+Persistence buys one thing: a warm image cache. It does not carry sandboxes across a runner restart. The runner deletes every sandbox container it finds when it starts, and again when it shuts down, so no sandbox survives a rollout either way.
+
+### Persistence and user namespaces
+
+Do not enable persistence for a runner in a user namespace. The inner Docker daemon chmods its data root at startup. A `PersistentVolume` root belongs to a UID outside the pod's mapping, so the chmod fails and the daemon exits:
+
+```
+level=info msg="Daemon shutdown complete" error="chmod /var/lib/docker: operation not permitted"
+```
+
+The runner then never becomes ready. The pod's UID range can also change when the pod is recreated, so a runner that works today can fail on the next rollout.
+
+The chart fails the render for `runner.isolation: sysbox` with `runner.sysbox.runtime.hostUsers: false` and persistence enabled, unless disk quotas are on. Quotas move the volume to `/var/lib/docker-pool` and give the daemon a freshly made xfs image as its data root, which the container owns.
+
+Three ways out, best first:
+
+- Leave persistence disabled. The `emptyDir` is created and owned by the kubelet for each pod, so there is no stale ownership, and `sizeLimit` still bounds it. You give up the image cache.
+- Set `runner.sysbox.runtime.hostUsers: null` on CRI-O nodes, and add the annotation Sysbox documents. Sysbox then shifts the volume's ownership itself. On containerd this is not supported; see [quickstart-k8s.md](../../docs/quickstart-k8s.md).
+- Set `runner.dockerDataRoot.persistence.acknowledgeUserNamespace: true` if your CSI driver id-maps volumes and you have verified the combination on your cluster.
+
 ## Disk Quotas
 
 `runner.config.defaultDiskQuotaMb` above 0 caps the writable layer of each sandbox. To enforce the cap, the runner allocates a loopback xfs image, mounts it with `prjquota` at `/var/lib/docker`, and runs the inner Docker daemon against that mount.
@@ -179,9 +210,8 @@ runner:
 
 `runner.config.diskQuotaPoolPath` overrides the image path. When it points at a volume you mount yourself (for example through `runner.extraVolumes`), the chart skips the size comparison. You then own the fit between the pool and that volume. Keep the override on a volume with a size limit; the mount that the image backs does not bound the image.
 
-The render fails in three cases:
+The render fails in two cases:
 
-- No volume holds the pool image. This happens when `runner.dockerDataRoot.persistence` is disabled, isolation is `sysbox`, and `diskQuotaPoolPath` is empty. It is the default configuration, so enable persistence or set an explicit path.
 - `runner.config.diskQuotaPoolSizeGb` is not a positive whole number of GB. The chart never falls back to the derived pool size, because that size scales with `runner.config.capacityTotal`. A 2048 MB per-sandbox quota and the default `capacityTotal` of 1000 derive a 2400 GB pool.
 - `runner.config.diskQuotaPoolSizeGb` is larger than the chart-owned volume.
 

--- a/charts/n8n-sandbox-service/render-tests.sh
+++ b/charts/n8n-sandbox-service/render-tests.sh
@@ -80,6 +80,45 @@ must_fail "positive whole number" "${privileged[@]}" \
 must_fail "positive whole number" "${privileged[@]}" \
 	--set runner.config.defaultDiskQuotaMb=2048
 
+# Sysbox isolation gets the bounded emptyDir data root when persistence is off,
+# the same as privileged isolation. This is the default configuration.
+manifests=$(render)
+echo "$manifests" | grep -q 'mountPath: "/var/lib/docker"'
+echo "$manifests" | grep -q 'sizeLimit: 64Gi'
+
+# Persistence replaces the emptyDir with a volume claim, and the claim is the
+# only data-root volume.
+manifests=$(render \
+	--set runner.dockerDataRoot.persistence.enabled=true \
+	--set runner.sysbox.runtime.hostUsers=null)
+echo "$manifests" | grep -q 'mountPath: "/var/lib/docker"'
+echo "$manifests" | grep -q "volumeClaimTemplates"
+if echo "$manifests" | grep -q 'sizeLimit:'; then
+	echo "expected no emptyDir sizeLimit when persistence is enabled" >&2
+	exit 1
+fi
+
+# A PersistentVolume data root inside a user namespace must fail the render:
+# dockerd cannot chmod a volume root it does not own.
+must_fail "operation not permitted" \
+	--set runner.dockerDataRoot.persistence.enabled=true
+# The acknowledgement is the way through.
+render \
+	--set runner.dockerDataRoot.persistence.enabled=true \
+	--set runner.dockerDataRoot.persistence.acknowledgeUserNamespace=true >/dev/null
+# hostUsers=null leaves the shifting to sysbox, so the guard does not apply.
+render \
+	--set runner.dockerDataRoot.persistence.enabled=true \
+	--set runner.sysbox.runtime.hostUsers=null >/dev/null
+# Privileged isolation does not read runner.sysbox, so it is unaffected.
+render "${privileged[@]}" \
+	--set runner.dockerDataRoot.persistence.enabled=true >/dev/null
+# Disk quotas move the data root onto an xfs image the container owns.
+render \
+	--set runner.dockerDataRoot.persistence.enabled=true \
+	--set runner.config.defaultDiskQuotaMb=2048 \
+	--set runner.config.diskQuotaPoolSizeGb=60 >/dev/null
+
 # A missing or unsupported volume size must fail, not skip the guard.
 must_fail "whole number of G or Gi" "${privileged[@]}" \
 	--set runner.config.defaultDiskQuotaMb=2048 \
@@ -97,14 +136,19 @@ manifests=$(render "${privileged[@]}" \
 	--set runner.config.diskQuotaPoolPath=/mnt/pool/docker.img)
 echo "$manifests" | grep -q 'SANDBOX_RUNNER_DISK_QUOTA_POOL_PATH: "/mnt/pool/docker.img"'
 
-# Default sysbox isolation has no volume for the pool image. Quotas must not
-# render, because the runner would put a pool sized from capacityTotal on the
-# container filesystem.
-must_fail "needs a bounded volume" \
+# Default sysbox isolation now holds the pool image on its bounded emptyDir,
+# so quotas render without persistence.
+manifests=$(render \
 	--set runner.config.defaultDiskQuotaMb=2048 \
-	--set runner.config.diskQuotaPoolSizeGb=60
-must_fail "needs a bounded volume" \
+	--set runner.config.diskQuotaPoolSizeGb=60)
+echo "$manifests" | grep -q 'mountPath: "/var/lib/docker-pool"'
+echo "$manifests" | grep -q 'SANDBOX_RUNNER_DISK_QUOTA_POOL_PATH: "/var/lib/docker-pool/docker.img"'
+# The pool size is still mandatory, and still checked against that volume.
+must_fail "positive whole number" \
 	--set runner.config.defaultDiskQuotaMb=2048
+must_fail "must not exceed the docker data root size" \
+	--set runner.config.defaultDiskQuotaMb=2048 \
+	--set runner.config.diskQuotaPoolSizeGb=100
 
 # An explicit pool path covers that case: the operator owns the volume.
 manifests=$(render \

--- a/charts/n8n-sandbox-service/templates/configmap.yaml
+++ b/charts/n8n-sandbox-service/templates/configmap.yaml
@@ -50,7 +50,7 @@ data:
   {{- if $runner.config.diskQuotaPoolSizeGb }}
   SANDBOX_RUNNER_DISK_QUOTA_POOL_SIZE_GB: {{ $runner.config.diskQuotaPoolSizeGb | quote }}
   {{- end }}
-  {{- $quotaVolume := and (gt (int $runner.config.defaultDiskQuotaMb) 0) (or $runner.dockerDataRoot.persistence.enabled (eq $runner.isolation "privileged")) }}
+  {{- $quotaVolume := gt (int $runner.config.defaultDiskQuotaMb) 0 }}
   {{- if $runner.config.diskQuotaPoolPath }}
   SANDBOX_RUNNER_DISK_QUOTA_POOL_PATH: {{ $runner.config.diskQuotaPoolPath | quote }}
   {{- else if $quotaVolume }}

--- a/charts/n8n-sandbox-service/templates/runner-statefulset.yaml
+++ b/charts/n8n-sandbox-service/templates/runner-statefulset.yaml
@@ -3,7 +3,7 @@
 {{- $iso := index $runner $runner.isolation }}
 {{- $component := include "n8n-sandbox-service.runnerComponent" . }}
 {{- $runnerName := include "n8n-sandbox-service.runnerName" . }}
-{{- $dockerEmptyDir := and $privileged (not $runner.dockerDataRoot.persistence.enabled) }}
+{{- $dockerEmptyDir := not $runner.dockerDataRoot.persistence.enabled }}
 {{- if eq .Values.dataPlane.mode "in-cluster" }}
 {{- $runnerRegistration := .Values.tls.certificates.runnerRegistrationClient -}}
 {{- $runnerControl := .Values.tls.certificates.runnerControlServer -}}
@@ -143,10 +143,8 @@ spec:
               subPath: config.json
               readOnly: true
             {{- end }}
-            {{- if or $runner.dockerDataRoot.persistence.enabled $dockerEmptyDir }}
             - name: docker-data
               mountPath: {{ include "n8n-sandbox-service.runnerDockerDataMountPath" . | quote }}
-            {{- end }}
             {{- with $runner.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/n8n-sandbox-service/templates/validation.yaml
+++ b/charts/n8n-sandbox-service/templates/validation.yaml
@@ -48,16 +48,24 @@
 {{- fail "runner.config.controlGrpcListenAddr port must match runner.service.controlGrpcPort" -}}
 {{- end -}}
 {{- end -}}
+{{- if eq .Values.dataPlane.mode "in-cluster" -}}
+{{- $dockerDataRoot := .Values.runner.dockerDataRoot -}}
+{{- $sysboxUserns := and (eq .Values.runner.isolation "sysbox") (kindIs "bool" .Values.runner.sysbox.runtime.hostUsers) (not .Values.runner.sysbox.runtime.hostUsers) -}}
+{{- /* Disk quotas move the volume to /var/lib/docker-pool and give dockerd a
+       freshly made xfs image as its data root, which the container owns, so
+       that path does not hit the chmod below. */ -}}
+{{- if and $sysboxUserns $dockerDataRoot.persistence.enabled (le (int .Values.runner.config.defaultDiskQuotaMb) 0) -}}
+{{- if ne $dockerDataRoot.persistence.acknowledgeUserNamespace true -}}
+{{- fail "runner.dockerDataRoot.persistence.enabled with runner.sysbox.runtime.hostUsers=false mounts a PersistentVolume at /var/lib/docker inside a user namespace. The inner Docker daemon chmods its data root at startup, and the volume root belongs to a UID outside the pod's mapping, so dockerd exits with `chmod /var/lib/docker: operation not permitted` and the runner never becomes ready. The pod's UID range can also change when the pod is recreated, so a runner that works today can fail on the next rollout. Disable persistence to use the bounded emptyDir instead, or set runner.sysbox.runtime.hostUsers=null on CRI-O nodes. Set runner.dockerDataRoot.persistence.acknowledgeUserNamespace=true if your CSI driver id-maps volumes and this combination works on your cluster. See the chart README section 'Docker Data Root'" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- if and (eq .Values.dataPlane.mode "in-cluster") (gt (int .Values.runner.config.defaultDiskQuotaMb) 0) -}}
 {{- $dockerDataRoot := .Values.runner.dockerDataRoot -}}
-{{- $chartVolume := or $dockerDataRoot.persistence.enabled (eq .Values.runner.isolation "privileged") -}}
-{{- if and (not $chartVolume) (not .Values.runner.config.diskQuotaPoolPath) -}}
-{{- fail "runner.config.defaultDiskQuotaMb above 0 needs a bounded volume for the disk-quota pool image, and this configuration has none. The image would land on the container filesystem and could fill the node disk. Set runner.dockerDataRoot.persistence.enabled=true, or set runner.config.diskQuotaPoolPath to a path on a volume you supply through runner.extraVolumes. See the chart README section 'Disk Quotas'" -}}
-{{- end -}}
 {{- if not (regexMatch "^[1-9][0-9]*$" (toString .Values.runner.config.diskQuotaPoolSizeGb)) -}}
 {{- fail (printf "runner.config.diskQuotaPoolSizeGb must be a positive whole number of GB when runner.config.defaultDiskQuotaMb is above 0 (got %q): the derived pool size scales with runner.config.capacityTotal and can outgrow the volume that holds the pool image. See the chart README section 'Disk Quotas'" (toString .Values.runner.config.diskQuotaPoolSizeGb)) -}}
 {{- end -}}
-{{- if and $chartVolume (not .Values.runner.config.diskQuotaPoolPath) -}}
+{{- if not .Values.runner.config.diskQuotaPoolPath -}}
 {{- $volumeSize := ternary $dockerDataRoot.persistence.size (($dockerDataRoot.emptyDir | default dict).sizeLimit | default "") $dockerDataRoot.persistence.enabled | toString -}}
 {{- $volumeKey := ternary "runner.dockerDataRoot.persistence.size" "runner.dockerDataRoot.emptyDir.sizeLimit" $dockerDataRoot.persistence.enabled -}}
 {{- if not (regexMatch "^[0-9]+Gi?$" $volumeSize) -}}

--- a/charts/n8n-sandbox-service/values.yaml
+++ b/charts/n8n-sandbox-service/values.yaml
@@ -207,6 +207,10 @@ runner:
   # /var/lib/docker-pool when config.defaultDiskQuotaMb is above 0, because the
   # quota pool image needs the bounded volume then. See the chart README
   # section 'Disk Quotas'.
+  #
+  # Both isolations always get a volume: the PersistentVolume below when
+  # persistence is enabled, the emptyDir otherwise. See the chart README
+  # section 'Docker Data Root'.
   dockerDataRoot:
     persistence:
       enabled: false
@@ -214,8 +218,16 @@ runner:
       storageClass: ""
       accessModes:
         - ReadWriteOnce
-    # Used only with isolation=privileged when persistence is disabled.
-    # Bounds the inner Docker daemon's image layers and sandbox filesystems.
+      # A PersistentVolume at /var/lib/docker breaks the inner Docker daemon
+      # inside a user namespace: the daemon chmods its data root and does not
+      # own the volume root, so it exits with `chmod /var/lib/docker:
+      # operation not permitted`. The render fails on that combination
+      # (isolation=sysbox with sysbox.runtime.hostUsers=false, and no disk
+      # quotas). Set this to true if your CSI driver id-maps volumes and the
+      # combination works on your cluster.
+      acknowledgeUserNamespace: false
+    # Used when persistence is disabled. Bounds the inner Docker daemon's
+    # image layers and sandbox filesystems.
     emptyDir:
       sizeLimit: 64Gi
 

--- a/docs/quickstart-k8s.md
+++ b/docs/quickstart-k8s.md
@@ -142,6 +142,8 @@ Two hardening options, both described in the chart [README](../charts/n8n-sandbo
 
 ## Troubleshooting
 
+**The runner logs `chmod /var/lib/docker: operation not permitted`.** The inner Docker daemon cannot chmod its data root, so it exits and the runner never becomes ready. A `PersistentVolume` is mounted at `/var/lib/docker` and the pod runs in a user namespace, so the volume root belongs to a UID outside the pod's mapping. Chart 0.6.3 and later fail the render on this combination. Disable `runner.dockerDataRoot.persistence` to use the bounded `emptyDir` instead, and see the chart README section [Docker Data Root](../charts/n8n-sandbox-service/README.md#docker-data-root).
+
 **Install succeeds but no runner pod appears.** Admission denied the pod, so `kubectl get pods` shows nothing and the error lands on the StatefulSet. Inspect the StatefulSet events:
 
 ```bash


### PR DESCRIPTION
Two problems in the same place, found while debugging a sysbox runner that failed to start after an upgrade.

## Problem 1: the sysbox data root was unbounded

`runner-statefulset.yaml` withheld the data root volume from sysbox isolation:

```gotemplate
{{- $dockerEmptyDir := and $privileged (not $runner.dockerDataRoot.persistence.enabled) }}
```

So a sysbox runner without persistence — the chart default — had **no volume at all** at `/var/lib/docker`. Image layers and sandbox filesystems went to the container filesystem with no size limit, where they can fill the node disk. Privileged isolation got a bounded `emptyDir` for exactly that reason; sysbox did not.

## Problem 2: persistence breaks inside a user namespace

The reverse case fails outright. `persistence.enabled` with `sysbox.runtime.hostUsers: false` mounts a PersistentVolume at `/var/lib/docker` inside a user namespace. dockerd chmods its data root at startup and does not own the volume root, so it exits immediately:

```
level=info msg="Starting up"
level=info msg="Daemon shutdown complete" error="chmod /var/lib/docker: operation not permitted"
```

The runner never becomes ready. The pod UID range can also change when the pod is recreated, so a runner that works today can fail on the next rollout.

This is a configuration the docs recommend. `render-tests.sh` even covered "the README example with persistence", but with `defaultDiskQuotaMb=2048`, which moves the volume to `/var/lib/docker-pool` and misses the broken path. Sysbox + persistence + no quotas had no test.

## Changes

**1. Both isolations always hold a data root volume.**

```diff
-{{- $dockerEmptyDir := and $privileged (not $runner.dockerDataRoot.persistence.enabled) }}
+{{- $dockerEmptyDir := not $runner.dockerDataRoot.persistence.enabled }}
```

The claim when persistence is on, the bounded `emptyDir` otherwise. Three knock-ons followed, and the render tests caught two of them:

- `configmap.yaml` duplicated the old condition and withheld `SANDBOX_RUNNER_DISK_QUOTA_POOL_PATH` from the same configurations.
- The statefulset volume mount condition became `or X (not X)`, so it is now unconditional.
- The quota guard that failed the render when no volume held the pool image can no longer happen, so it and its two tests go. Sysbox with quotas and no persistence now renders, with the pool on the bounded `emptyDir`.

**2. The broken combination fails the render.**

`validation.yaml` refuses sysbox + `hostUsers: false` + persistence, unless quotas are on. The message names the dockerd error so an operator who already hit it can search for it. Quotas are exempt because they give dockerd a freshly made xfs image as its data root, which the container owns.

`runner.dockerDataRoot.persistence.acknowledgeUserNamespace: true` keeps the combination available, following the existing `runner.acknowledgePrivileged` idiom. A CSI driver that id-maps volumes handles this correctly and the chart cannot tell, so an unconditional failure would break clusters that work today.

**3. Docs.** A new README section, `Docker Data Root`, covers which volume you get and why persistence and user namespaces do not mix. It also records something worth knowing: persistence buys a warm image cache and nothing else. It does not carry sandboxes across a restart, because `reconcileContainers` deletes every sandbox container the runner finds at startup and again at shutdown. `quickstart-k8s.md` gets a troubleshooting entry for the runtime symptom.

I also moved the `emptyDir` paragraph out of the Privileged Isolation section, where it was correct but now applies to both isolations.

## Verification

`charts/n8n-sandbox-service/render-tests.sh` passes, with new cases for:

- the default sysbox render mounting `emptyDir` at `/var/lib/docker` with its `sizeLimit`
- persistence replacing that with a claim, and no `sizeLimit` left behind
- the userns combination failing, the acknowledgement letting it through, and `hostUsers: null` not tripping the guard
- privileged isolation being unaffected
- sysbox with quotas and no persistence landing the pool on the bounded volume

`helm lint` is clean. `shfmt` and `shellcheck` are clean on `render-tests.sh`, with the CI-pinned 3.13.1 and 0.11.0. Chart version bumped 0.6.2 → 0.6.3. No Go files changed.

## What this does not fix, and what I could not verify

**Persistence stays unusable in a user namespace** without the acknowledgement. The real fix needs a pod `fsGroup` plus a data root in a subdirectory the container creates, so dockerd chmods a directory it owns. That belongs in its own PR because it silently migrates existing data roots, and because whether the kubelet applies `fsGroup` to a CSI PVC in a userns pod depends on the driver and Kubernetes version.

**Change 1 is a runtime behaviour change I could only verify by rendering.** Mounting an `emptyDir` at `/var/lib/docker` for sysbox is new. Sysbox may currently back that path with a host directory it manages, so this moves where the data lives and brings it under the pod's ephemeral-storage accounting — which is the intent, but it needs one test on a sysbox node before merge. I have no sysbox cluster.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

