### PR TITLE
fix: check the runner bridge with netlink, not sysfs

### DIFF
--- a/internal/runner/runtime/docker/netrules/netrules.go
+++ b/internal/runner/runtime/docker/netrules/netrules.go
@@ -3,7 +3,7 @@ package netrules
 import (
 	"bytes"
 	"fmt"
-	"os"
+	"net"
 	"os/exec"
 	"strings"
 	"sync"
@@ -136,7 +136,14 @@ func ensureBridgePolicy(bridgeIface string) error {
 	// iptables accepts a rule naming an interface that does not exist, and that
 	// rule then matches nothing. Every sandbox would run unfiltered with no
 	// error anywhere, so refuse to build the policy instead.
-	if _, err := os.Stat("/sys/class/net/" + bridgeIface); err != nil {
+	//
+	// Ask netlink, not /sys/class/net. The kernel ties a sysfs mount to the
+	// network namespace of the process that mounted it. Sysbox 0.7.1 mounts the
+	// container's sysfs from a helper that stays in the host namespace, so
+	// /sys/class/net inside the runner lists the host's interfaces and the
+	// bridge looks absent. net.InterfaceByName asks the caller's namespace.
+	// Upstream: https://github.com/nestybox/sysbox-runc/commit/87af3d5
+	if _, err := net.InterfaceByName(bridgeIface); err != nil {
 		return fmt.Errorf("bridge interface %q not found: %w", bridgeIface, err)
 	}
 

--- a/scripts/start-runner.sh
+++ b/scripts/start-runner.sh
@@ -138,6 +138,7 @@ if ! docker network inspect runner-bridge >/dev/null 2>&1; then
 	docker network create \
 		--driver bridge \
 		--opt "com.docker.network.bridge.enable_icc=false" \
+		--opt "com.docker.network.bridge.name=runner-bridge" \
 		runner-bridge >/dev/null
 fi
 


### PR DESCRIPTION
## Problem

The runner checked its bridge with `stat /sys/class/net/<iface>`, and refused to
start under sysbox 0.7.1:

```
ensure bridge policy: bridge interface "br-9bb6a143f3a4" not found:
stat /sys/class/net/br-9bb6a143f3a4: no such file or directory
```

## Cause

The kernel ties a sysfs mount to the network namespace of the process that
mounted it. Sysbox 0.7.1 mounts the container's sysfs from a helper that joins
the mount and pid namespaces but not `net`
([sysbox-runc 87af3d5](https://github.com/nestybox/sysbox-runc/commit/87af3d515500e8bda6739f88a33cae5633e134e0)),
so `/sys/class/net` in the runner lists the host's interfaces. The bridge exists;
sysfs looks in the wrong namespace.

## Fix

1. Use `net.InterfaceByName`. Netlink answers for the caller's namespace. The
   check stays strict: iptables silently accepts a rule naming a missing
   interface, and every sandbox would then run unfiltered.
2. Set `com.docker.network.bridge.name` in `start-runner.sh` so a new deployment
   gets a fixed device name instead of one derived from the network ID. Hygiene,
   not the cause. An existing `runner-bridge` keeps its derived name, since the
   script sets options only when it creates the network; `bridgeInterface`
   already handles both shapes and the netlink check validates whichever name
   results.

Correct on 0.7.0 and `--privileged` too. Split out of #162 so it lands first —
a 0.7.1 runner cannot start without it. Verifying needs the sysbox e2e suite
with #162 on top.
