### PR TITLE
chore: run firecracker and sysbox e2e lanes on release

### DIFF
--- a/.github/workflows/e2e-firecracker.yml
+++ b/.github/workflows/e2e-firecracker.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     types: [labeled]
+  workflow_call:
 
 permissions:
   id-token: write
@@ -23,9 +24,7 @@ jobs:
   e2e-firecracker:
     runs-on: ubuntu-latest
     environment: e2e
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'e2e-firecracker')
+    if: github.event.action != 'labeled' || github.event.label.name == 'e2e-firecracker'
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/e2e-sysbox.yml
+++ b/.github/workflows/e2e-sysbox.yml
@@ -12,6 +12,7 @@ on:
           - e2e/run.sh
   pull_request:
     types: [labeled]
+  workflow_call:
 
 permissions:
   id-token: write
@@ -31,9 +32,7 @@ jobs:
   e2e-sysbox:
     runs-on: ubuntu-latest
     environment: e2e
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'e2e-sysbox')
+    if: github.event.action != 'labeled' || github.event.label.name == 'e2e-sysbox'
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/release-service-validate.yml
+++ b/.github/workflows/release-service-validate.yml
@@ -37,3 +37,17 @@ jobs:
           make docker-runner-amd64
           make docker-firecracker-runner-amd64
           make docker-sandbox-amd64
+
+  e2e-sysbox:
+    uses: ./.github/workflows/e2e-sysbox.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
+  e2e-firecracker:
+    uses: ./.github/workflows/e2e-firecracker.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -32,7 +32,7 @@ flowchart TD
 
     subgraph versioned ["Versioned Release (all deployable images)"]
         E[Manual: Run Release Prep] --> F[Bump VERSION + chart appVersion\nCreate release branch + PR]
-        F --> G[Release Validate CI]
+        F --> G[Release Validate CI\n+ Sysbox and Firecracker e2e on Azure]
         G --> H{Merge PR}
         H --> I[Run tests]
         I --> J[Build + push multi-arch\nimages to Docker Hub]
@@ -141,7 +141,14 @@ unable to rebuild their snapshot.
    order would move `latest` and `stable` backwards. Until publish enforces that
    itself, merge open release PRs in ascending version order.
 3. The `Service Release Validate` workflow runs CI on the PR and fails if `VERSION`
-   and the chart `appVersion` disagree.
+   and the chart `appVersion` disagree. It also runs the Sysbox and Firecracker
+   e2e suites on Azure VMs — the same workflows the `e2e-sysbox` and
+   `e2e-firecracker` labels trigger on ordinary PRs, called as jobs of the
+   validate run. CI on `main` only exercises the privileged-Docker lane, so this
+   is where both shipped runners get covered before their images are built. The
+   Azure lanes run in parallel with the unit tests and image builds and are the
+   long pole: allow about an hour. To retry a flaky lane, re-run the failed job
+   from the validate run; there is no need to re-prep.
 4. Merge the PR. This triggers the `Service Publish` workflow, whose
    `publish-images` job runs tests and then builds and pushes the multi-arch images
    to Docker Hub, sandbox image included.

--- a/e2e/infra/README.md
+++ b/e2e/infra/README.md
@@ -4,14 +4,16 @@ Terraform config that provisions an ephemeral Ubuntu 24.04 VM in Azure for runni
 
 In CI, the Sysbox workflow uses `e2e/infra/scripts/provision-e2e-vm.sh` and
 `e2e/infra/scripts/cleanup-e2e-vm.sh` to manage the Azure VM. That workflow runs
-on manual dispatch and on PRs labeled `e2e-sysbox`.
+on manual dispatch, on PRs labeled `e2e-sysbox`, and as a job of `Service
+Release Validate` on every service release PR.
 
 The same Terraform VM shape is also reused by the Firecracker e2e lane via
 `e2e/infra/scripts/provision-firecracker-e2e-vm.sh`. That path runs
 `scripts/firecracker.ee/setup-firecracker-e2e-vm.sh` on the VM (nested KVM
 preflight, Firecracker/jailer, rootfs from `Dockerfile.sandbox` + CI `vmlinux`,
-golden snapshot). The Firecracker workflow runs on manual dispatch and on PRs
-labeled `e2e-firecracker`.
+golden snapshot). The Firecracker workflow runs on manual dispatch, on PRs
+labeled `e2e-firecracker`, and as a job of `Service Release Validate` on every
+service release PR.
 
 ## Prerequisites
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Runs the Sysbox and Firecracker e2e suites on every service release PR as part of Release Validate, so both shipped runners get tested before their images are built. Previously these lanes only ran on manual dispatch or when a PR carried the matching `e2e-sysbox` or `e2e-firecracker` label.

- The e2e workflows now expose a `workflow_call` trigger and are invoked from `release-service-validate.yml` with inherited secrets and `id-token` permissions.
- Their `if` conditions changed so label-triggered runs still respect the label, while workflow-call runs always execute.
- Release PRs now take about an hour longer; the Azure lanes run in parallel with unit tests and image builds, and a flaky lane can be retried by re-running the failed job from the validate run.
- Updated `docs/RELEASE.md` and `e2e/infra/README.md` to document the new trigger paths.

<sup>Written for commit 7d2df4b9ef7c511d1c93133ffdf3e7441c582261. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

