### PR TITLE
fix: concurrency on e2e lanes

### DIFF
--- a/.github/workflows/e2e-firecracker.yml
+++ b/.github/workflows/e2e-firecracker.yml
@@ -10,10 +10,6 @@ permissions:
   id-token: write
   contents: read
 
-concurrency:
-  group: e2e-firecracker-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   ARM_USE_OIDC: "true"
   ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
@@ -25,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: e2e
     if: github.event.action != 'labeled' || github.event.label.name == 'e2e-firecracker'
+    concurrency:
+      group: ${{ github.workflow }}-e2e-firecracker-${{ github.ref }}
+      cancel-in-progress: true
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/e2e-sysbox.yml
+++ b/.github/workflows/e2e-sysbox.yml
@@ -18,10 +18,6 @@ permissions:
   id-token: write
   contents: read
 
-concurrency:
-  group: e2e-sysbox-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   ARM_USE_OIDC: "true"
   ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
@@ -33,6 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: e2e
     if: github.event.action != 'labeled' || github.event.label.name == 'e2e-sysbox'
+    concurrency:
+      group: ${{ github.workflow }}-e2e-sysbox-${{ github.ref }}
+      cancel-in-progress: true
     timeout-minutes: 45
 
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moves e2e concurrency control from workflow level to job level so firecracker and sysbox e2e runs no longer cancel each other on the same branch.

<sup>Written for commit 6fc9fc7e9c3d8fe37371f9731c39d4f2151628c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

