### PR TITLE
fix: update example compose files for tls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ Remember to update any relevant documentation in the docs/ folder if any of the 
 
 Document what the code does today, never what is planned.
 
+`docs/examples/compose.*.yaml` are not exercised by CI: when changing the API ↔ runner env or TLS contract, check for inconsistencies.
+
 ## Firecracker runner
 
 All Firecracker runner related files should contain `.ee` or be in a directory that contains `.ee` in the name, so the enterprise license applies.

--- a/docs/examples/compose.linux.yaml
+++ b/docs/examples/compose.linux.yaml
@@ -21,7 +21,7 @@ services:
         bootstrap-mtls.sh
         --out-dir /tls
         --api-san n8n-sandbox-api-local
-        --control-san-prefix n8n-sandbox-runner-local
+        --control-san-prefix n8n-sandbox-runner
         && chown -R sandbox-api:sandbox-api /tls/api
     environment:
       NUM_RUNNERS: ${NUM_RUNNERS:-1}
@@ -49,7 +49,6 @@ services:
       SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CA_FILE: /tls/ca.crt
       SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CERT_FILE: /tls/control-grpc-api-client.crt
       SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_KEY_FILE: /tls/control-grpc-api-client.key
-      SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_SERVER_NAME: n8n-sandbox-runner-local-1
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8080/healthz"]
       interval: 5s

--- a/docs/examples/compose.macos.yaml
+++ b/docs/examples/compose.macos.yaml
@@ -16,7 +16,7 @@
 
 services:
   tls-init:
-    image: n8nio/n8n-sandbox-api:latest
+    image: n8nio/n8n-sandbox-service-api:latest
     user: "0:0"
     entrypoint: ["sh", "-c"]
     command:
@@ -24,7 +24,7 @@ services:
         bootstrap-mtls.sh
         --out-dir /tls
         --api-san n8n-sandbox-api-local
-        --control-san-prefix n8n-sandbox-runner-local
+        --control-san-prefix n8n-sandbox-runner
         && chown -R sandbox-api:sandbox-api /tls/api
     environment:
       NUM_RUNNERS: ${NUM_RUNNERS:-1}
@@ -34,7 +34,7 @@ services:
       - sandbox-service
 
   api:
-    image: n8nio/n8n-sandbox-api:latest
+    image: n8nio/n8n-sandbox-service-api:latest
     restart: unless-stopped
     depends_on:
       tls-init:
@@ -52,7 +52,6 @@ services:
       SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CA_FILE: /tls/ca.crt
       SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CERT_FILE: /tls/control-grpc-api-client.crt
       SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_KEY_FILE: /tls/control-grpc-api-client.key
-      SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_SERVER_NAME: n8n-sandbox-runner-local-1
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8080/healthz"]
       interval: 5s
@@ -65,7 +64,7 @@ services:
           - n8n-sandbox-api
 
   runner:
-    image: n8nio/n8n-sandbox-runner:latest
+    image: n8nio/n8n-sandbox-service-runner-dind:latest
     privileged: true
     restart: unless-stopped
     depends_on:
@@ -79,7 +78,7 @@ services:
       - ./.tls/runner:/tls:ro
     env_file: .env
     environment:
-      SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE: n8nio/n8n-sandbox:latest
+      SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE: n8nio/n8n-sandbox-service-sandbox:latest
       SANDBOX_RUNNER_API_GRPC_ADDR: n8n-sandbox-api:9090
       SANDBOX_RUNNER_HTTP_BASE_URL: https://n8n-sandbox-runner-1:8080
       SANDBOX_RUNNER_CONTROL_GRPC_LISTEN_ADDR: ":9091"

--- a/scripts/smoke-sandbox.sh
+++ b/scripts/smoke-sandbox.sh
@@ -2,7 +2,7 @@
 # Smoke test against a deployed or local sandbox API.
 #
 # Uses SANDBOX_API_KEY as an admin key to mint a tenant API key, then runs
-# create → exec → resolv.conf → DNS → HTTPS → file write/read → delete
+# create (ephemeral) → exec → resolv.conf → DNS → HTTPS → file write/read → delete
 # with that tenant key (not the admin key).
 #
 # Environment:
@@ -209,12 +209,12 @@ assert_exec() {
 
 create_sandbox() {
 	local label="$1"
-	local create_json="" attempt=0 new_sid=""
+	local create_json="" attempt=0 new_sid="" ephemeral=""
 
 	printf '==> %s\n' "${label}" >&2
 	while [ "${attempt}" -lt 5 ]; do
 		attempt=$((attempt + 1))
-		if create_json="$(api_json -X POST "${BASE}/sandboxes" -d '{}' 2>/dev/null)"; then
+		if create_json="$(api_json -X POST "${BASE}/sandboxes" -d '{"ephemeral":true}' 2>/dev/null)"; then
 			break
 		fi
 		sleep 2
@@ -226,7 +226,11 @@ create_sandbox() {
 	if [ -z "${new_sid}" ] || [ "${new_sid}" = "null" ]; then
 		fail "${label}: missing id"
 	fi
-	printf '    sandbox_id: %s\n' "${new_sid}" >&2
+	ephemeral="$(printf '%s' "${create_json}" | jq -r .ephemeral)"
+	if [ "${ephemeral}" != "true" ]; then
+		fail "${label}: ephemeral ${ephemeral:-<missing>}, want true"
+	fi
+	printf '    sandbox_id: %s (ephemeral)\n' "${new_sid}" >&2
 	printf '%s' "${new_sid}"
 }
 


### PR DESCRIPTION
## Summary

Fixes #166.

`docs/examples/compose.linux.yaml` and `compose.macos.yaml` issued the runner's SandboxControl certificate for `n8n-sandbox-runner-local-1` while the runner advertised `https://n8n-sandbox-runner-1:8080`. The API verifies HTTP connections against the dialed host, so every exec/file call failed with `tls: bad certificate and the caller saw runner unavailable`. The root `compose.yaml` was unaffected because its container names match the default SAN prefix.

## Changes

* `--control-san-prefix n8n-sandbox-runner` so the SAN is `n8n-sandbox-runner-1`, matching the HTTP base URL host, the gRPC advertise host, and the network alias.
* Dropped `SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_SERVER_NAME`. gRPC now verifies against the dial host, same as HTTP.
* `compose.macos.yaml`: replaced unpublished image names (`n8nio/n8n-sandbox-api`, `-runner`, `n8nio/n8n-sandbox`) with the published `n8nio/n8n-sandbox-service-{api,runner-dind,sandbox}`.
* `AGENTS.md`: note that the example compose files are not CI-tested.
* Added ephemeral sandboxes to the smoke script.

Upgrade note: existing deployments must `rm -rf .tls` before `docker compose up -d`. `bootstrap-mtls.sh` skips generation when certs exist, and the old cert does not carry the new SAN.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

