### PR TITLE
fix: refuse runner originated redirects in the api proxy and stop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6
         with:
-          version: 10
+          package_json_file: sdk/package.json
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-sdk-prep.yml
+++ b/.github/workflows/release-sdk-prep.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6
         with:
-          version: 10
+          package_json_file: sdk/package.json
 
       - name: Generate GitHub App Token
         id: generate-token

--- a/.github/workflows/release-sdk-publish.yml
+++ b/.github/workflows/release-sdk-publish.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6
         with:
-          version: 10
+          package_json_file: sdk/package.json
 
       - name: Read version
         id: version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,15 @@ bash charts/n8n-sandbox-service/render-tests.sh
 Remember to update any relevant documentation in the docs/ folder if any of the changes affect them.
 
 Document what the code does today, never what is planned.
+Keep documentation as short as possible.
 
 `docs/examples/compose.*.yaml` are not exercised by CI: when changing the API ↔ runner env or TLS contract, check for inconsistencies.
+
+## Security review before reporting done
+
+After changing anything other than docs or tests, review the diff for security
+regressions before you report the work done. Use a fresh context where the
+tooling allows.
 
 ## Firecracker runner
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -42,7 +42,7 @@ log events. See [observability.md](observability.md).
 The API and runner use two buckets so clients (including the SDK) can decide **when to retry the same request** vs **when to change strategy** (e.g. create a new sandbox, fix routing, surface an error to the user).
 
 - **503 Service Unavailable** — **Transient / retry**: overload, no capacity yet, network or upstream not ready, or the sandbox daemon is not reachable *for the moment* while the container is otherwise expected to be usable. Safe to back off and retry the same operation.
-- **502 Bad Gateway** — **Not retryable as “wait and retry”**: the request does not make sense to repeat unchanged; fix state first (new sandbox, repair registry/routing, or handle the reported error). Examples: stored sandbox has **no runner HTTP base URL**, **delete** failed on the runner control plane, or the runner answered a proxied route with a **redirect** (`runner returned a redirect`). The API relays no 3xx from the runner, and the SDK follows no redirect (`maxRedirects: 0`, a 3xx is a `SandboxServiceError`), so an API key is never re-sent to another host.
+- **502 Bad Gateway** — **Not retryable as “wait and retry”**: the request does not make sense to repeat unchanged; fix state first (new sandbox, repair registry/routing, or handle the reported error). Examples: stored sandbox has **no runner HTTP base URL** or **delete** failed on the runner control plane.
 
 ### HTTP 409 `sandbox_restarted` — the sandbox came back without its memory
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -42,7 +42,7 @@ log events. See [observability.md](observability.md).
 The API and runner use two buckets so clients (including the SDK) can decide **when to retry the same request** vs **when to change strategy** (e.g. create a new sandbox, fix routing, surface an error to the user).
 
 - **503 Service Unavailable** — **Transient / retry**: overload, no capacity yet, network or upstream not ready, or the sandbox daemon is not reachable *for the moment* while the container is otherwise expected to be usable. Safe to back off and retry the same operation.
-- **502 Bad Gateway** — **Not retryable as “wait and retry”**: the request does not make sense to repeat unchanged; fix state first (new sandbox, repair registry/routing, or handle the reported error). Examples: stored sandbox has **no runner HTTP base URL**, or **delete** failed on the runner control plane.
+- **502 Bad Gateway** — **Not retryable as “wait and retry”**: the request does not make sense to repeat unchanged; fix state first (new sandbox, repair registry/routing, or handle the reported error). Examples: stored sandbox has **no runner HTTP base URL**, **delete** failed on the runner control plane, or the runner answered a proxied route with a **redirect** (`runner returned a redirect`). The API relays no 3xx from the runner, and the SDK follows no redirect (`maxRedirects: 0`, a 3xx is a `SandboxServiceError`), so an API key is never re-sent to another host.
 
 ### HTTP 409 `sandbox_restarted` — the sandbox came back without its memory
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -46,7 +46,7 @@ Cross-tenant and non-existent sandboxes both return `404`, so a tenant cannot
 use the status code to learn whether an ID exists.
 
 Error bodies the API generates itself have runner-side sandbox paths stripped
-before they are returned; responses proxied from a runner are relayed as-is.
+before they are returned.
 
 ## API to runner
 
@@ -83,7 +83,9 @@ what one runner holds drives every runner.
 The proxy replaces the caller's `X-Api-Key` with the runner API key before
 forwarding, so tenant and admin keys never reach a runner, and it forwards the
 trace context it established rather than the caller's header. Responses are
-relayed to the client as the runner returned them.
+relayed to the client as the runner returned them, except a 3xx, which is
+refused with `502` so a runner cannot redirect a client, and the API key it
+holds, to another host.
 
 The API keeps the TLS guarantee from being negotiated away by the runner. A
 runner names its own address in heartbeats, and Go applies a transport's

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -466,6 +466,11 @@ func isValidUUID(id string) bool {
 	return id != "" && uuidRegex.MatchString(id)
 }
 
+// errRunnerRedirect marks a 3xx from the runner, which the proxy refuses: no
+// runner route redirects, and relaying one would send a client, and the API key
+// it holds, wherever a compromised runner points.
+var errRunnerRedirect = errors.New("runner returned a redirect")
+
 func newRunnerReverseProxy(runnerURL *url.URL, runnerAPIKey string, transport http.RoundTripper, onResponse func(*http.Response)) *httputil.ReverseProxy {
 	target := *runnerURL
 	return &httputil.ReverseProxy{
@@ -489,6 +494,15 @@ func newRunnerReverseProxy(runnerURL *url.URL, runnerAPIKey string, transport ht
 			}
 		},
 		ModifyResponse: func(resp *http.Response) error {
+			// Before onResponse, so a redirect never counts as sandbox activity.
+			if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+				loc := resp.Header.Get("Location")
+				if len(loc) > 200 {
+					loc = loc[:200]
+				}
+				obs.FieldsFrom(resp.Request.Context()).Add("runner_redirect_status", resp.StatusCode, "runner_redirect_location", loc)
+				return errRunnerRedirect
+			}
 			if onResponse != nil {
 				onResponse(resp)
 			}
@@ -496,6 +510,10 @@ func newRunnerReverseProxy(runnerURL *url.URL, runnerAPIKey string, transport ht
 		},
 		FlushInterval: -1,
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			if errors.Is(err, errRunnerRedirect) {
+				writeError(w, http.StatusBadGateway, err.Error())
+				return
+			}
 			var maxBytesErr *http.MaxBytesError
 			if errors.As(err, &maxBytesErr) {
 				writeError(w, http.StatusBadRequest, "failed to read request body: "+maxBytesErr.Error())

--- a/internal/api/handlers_proxy_redirect_test.go
+++ b/internal/api/handlers_proxy_redirect_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/n8n-io/sandbox-service/internal/api/store"
+)
+
+// TestSandboxProxyRefusesRunnerRedirect: a runner answering a proxied route
+// with a 3xx must not have that response relayed, or a compromised runner could
+// send the client, and the API key it holds, to a host of its choosing.
+func TestSandboxProxyRefusesRunnerRedirect(t *testing.T) {
+	logs := captureLogs(t)
+	var (
+		status       atomic.Int32
+		upstreamHits atomic.Int64
+	)
+	// Long enough that logging it uncapped would be visible in the event.
+	location := "https://attacker.example/" + strings.Repeat("a", 4096)
+	runner := newTestRunnerServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits.Add(1)
+		w.Header().Set("Location", location)
+		w.WriteHeader(int(status.Load()))
+		_, _ = w.Write([]byte("moved"))
+	}))
+	defer runner.Close()
+
+	router, s := newTestGateway(t, "admin-key")
+	sid := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	if err := s.Create(&store.SandboxRecord{
+		ID: sid, Status: "running", CreatedAt: 1, LastActiveAt: 1, RunnerHTTPBase: runner.URL,
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	for i, code := range []int{301, 302, 303, 307, 308} {
+		status.Store(int32(code))
+		req := httptest.NewRequest(http.MethodGet, "/sandboxes/"+sid+"/files", nil)
+		req.Header.Set("X-Api-Key", "admin-key")
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusBadGateway {
+			t.Errorf("runner %d: expected %d, got %d body=%s", code, http.StatusBadGateway, rr.Code, rr.Body.String())
+		}
+		if loc := rr.Header().Get("Location"); loc != "" {
+			t.Errorf("runner %d: Location relayed: %q", code, loc)
+		}
+		var body APIError
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil || body.Error != errRunnerRedirect.Error() {
+			t.Errorf("runner %d: unexpected body %s (err=%v)", code, rr.Body.String(), err)
+		}
+		if hits := upstreamHits.Load(); hits != int64(i+1) {
+			t.Fatalf("runner %d: expected %d upstream requests, got %d", code, i+1, hits)
+		}
+	}
+
+	// The refusal must not count as activity, or a retrying client would keep
+	// the idle sweeper from ever reclaiming a sandbox on a misbehaving runner.
+	rec, err := s.Get(sid)
+	if err != nil || rec == nil {
+		t.Fatalf("get sandbox: rec=%v err=%v", rec, err)
+	}
+	if rec.LastActiveAt != 1 {
+		t.Fatalf("LastActiveAt = %d, want 1 unchanged", rec.LastActiveAt)
+	}
+
+	// The runner chooses the Location, so the log keeps only a bounded prefix.
+	logged := 0
+	for _, event := range logs() {
+		loc, ok := event["runner_redirect_location"].(string)
+		if !ok {
+			continue
+		}
+		logged++
+		if len(loc) != 200 {
+			t.Fatalf("logged runner_redirect_location has %d bytes, want capped at 200", len(loc))
+		}
+	}
+	if logged != int(upstreamHits.Load()) {
+		t.Fatalf("expected %d events with runner_redirect_location, got %d", upstreamHits.Load(), logged)
+	}
+}

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -160,6 +160,8 @@ try {
 
 `deleteSandbox` treats HTTP 404 as success (already gone), so a retried delete after a dropped `204` does not fail.
 
+The client never follows redirects: a 3xx is thrown as `SandboxServiceError` like any other non-2xx, so the API key is never re-sent to a different host. Point `baseUrl` at the service directly, not at something that redirects to it.
+
 ### Sandbox restarts
 
 If a sandbox's guest crashes, the service recovers it by rebooting its filesystem and then fails the request that triggered the recovery with `SandboxCrashedError` (HTTP 409). The files are intact; everything that was in memory is not. Retry the request once — the sandbox is already running again — and relaunch whatever it was running in the background:

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -36,8 +36,9 @@
   },
   "engines": {
     "node": ">=22.16",
-    "pnpm": ">=10.22.0"
+    "pnpm": ">=12.3.4"
   },
+  "packageManager": "pnpm@12.3.4",
   "dependencies": {
     "axios": "^1.20.0"
   },

--- a/sdk/pnpm-lock.yaml
+++ b/sdk/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    optional: true
+
+  pnpm@12.3.4:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/sdk/pnpm-workspace.yaml
+++ b/sdk/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# pnpm fails the install on a build script nobody has ruled on. esbuild's
+# postinstall only re-checks the platform binary that @esbuild/* already ships,
+# so keep it off.
+allowBuilds:
+  esbuild: false

--- a/sdk/src/http.ts
+++ b/sdk/src/http.ts
@@ -33,6 +33,7 @@ export class HttpClient {
     this.instance = axios.create({
       baseURL: normalizedBase,
       headers: apiKey ? { "X-Api-Key": apiKey } : {},
+      maxRedirects: 0,
     });
     this.retry = {
       attempts: Math.max(0, retry?.attempts ?? 3),
@@ -80,7 +81,7 @@ export class HttpClient {
           validateStatus: () => true,
         });
 
-        if (response.status >= 400) {
+        if (response.status >= 300) {
           const body = await this.drainStream(response.data);
           throw createErrorFromResponse(response.status, this.tryParseJson(body), response.headers);
         }
@@ -111,7 +112,7 @@ export class HttpClient {
         });
 
         const body = Buffer.from(response.data);
-        if (response.status >= 400) {
+        if (response.status >= 300) {
           throw createErrorFromResponse(
             response.status,
             this.tryParseJson(body.toString("utf-8")),

--- a/sdk/test/http.test.ts
+++ b/sdk/test/http.test.ts
@@ -250,4 +250,33 @@ describe("HttpClient", () => {
       await postServer.close();
     }
   });
+
+  it("never follows a redirect, so the API key never reaches another origin", async () => {
+    let targetHits = 0;
+    const target = await startTestServer((_req, res) => {
+      targetHits += 1;
+      res.writeHead(200);
+      res.end();
+    });
+    const redirecting = await startTestServer((_req, res) => {
+      res.writeHead(302, { Location: `${target.baseUrl}/steal` });
+      res.end();
+    });
+
+    try {
+      const client = new HttpClient(redirecting.baseUrl, "secret-key", { attempts: 0 });
+      const calls = [
+        client.requestJson("GET", "/redirect"),
+        client.requestStream("GET", "/redirect"),
+        client.requestBuffer("GET", "/redirect"),
+      ];
+      for (const call of calls) {
+        await expect(call).rejects.toMatchObject({ name: "SandboxServiceError", status: 302 });
+      }
+      expect(targetHits).toBe(0);
+    } finally {
+      await redirecting.close();
+      await target.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

* API doesn't proxy redirects, but returns an error
* SDK doesn't follow redirects
* Update pnpm to 12.3.4 (same as n8n)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

