### PR TITLE
chore: decouple sandbox create from client cancellations

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -159,6 +159,8 @@ Create a sandbox. With no request body, the service generates a UUID. Callers ma
 
 If that ID still belongs to the caller and is within its idle-delete window, the existing sandbox is returned. If it has passed the window, the stale sandbox is deleted before the ID is reused. If the ID belongs to another tenant (or to admin when the caller is a tenant), the request fails with `409`.
 
+Disconnecting before the response does not cancel the create: the sandbox is still created and tracked, and can be found by listing or by repeating the request with the same `id`.
+
 **Request body fields** (all optional):
 
 - `id` — lowercase UUID to create or reconnect to, as above.

--- a/e2e/tests/sandbox-create-disconnect.spec.ts
+++ b/e2e/tests/sandbox-create-disconnect.spec.ts
@@ -9,19 +9,18 @@ import {
   waitForSandboxStatus,
 } from './helpers';
 
-// How long after sending POST /sandboxes the client hangs up, tried largest
-// first. The API hands the create to the runner within a few ms and the runner
-// takes ~0.7-0.9s on both lanes, so the first offset lands mid-create. If the
-// create answers first, the next attempt hangs up earlier rather than failing
-// on a speedup. Below the last offset the API's own pre-runner work (auth, id
-// lock) is a comparable share of the request, and a hang-up that lands before
-// the runner is asked is indistinguishable from the bug this guards, so the
-// test gives up and says so instead of passing vacuously.
+// Delays (ms) between sending POST /sandboxes and hanging up, tried in order.
+// The hang-up has to happen while the runner is still building the sandbox.
+// Creates take ~0.7-0.9s, so 150ms is normally enough; if the API answers
+// before the hang-up, the next shorter delay is tried. Below 20ms the hang-up
+// may land before the API has even called the runner, so if every delay is
+// answered the test fails rather than pretending it tested anything.
 const DISCONNECT_OFFSETS_MS = [150, 75, 40, 20];
 
-// A raw fetch with an aborted signal closes the socket, which is what makes the
-// API's request context cancel; the SDK never disconnects mid-create. Resolves
-// to the status if the API answered first, undefined if the client hung up first.
+// POST /sandboxes and hang up after afterMs. Uses fetch rather than the SDK
+// because aborting a fetch closes the socket, which is what cancels the API's
+// request context. Returns the status if the API answered first, undefined if
+// the hang-up won.
 async function createAndHangUp(apiKey: string, id: string, afterMs: number): Promise<number | undefined> {
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), afterMs);
@@ -46,8 +45,8 @@ test.describe('client disconnect during create', () => {
     test.setTimeout(120_000);
     const apiKey = await getApiKey();
 
-    // Find an offset that hangs up mid-create. An answered 201 is a real sandbox
-    // that has to go; any other answer is an infrastructure failure, not a miss.
+    // Find a delay that hangs up mid-create. A 201 means the sandbox was created
+    // and must be cleaned up; any other status is an unrelated failure.
     let id: string | undefined;
     let disconnectAfterMs = 0;
     const answers: string[] = [];
@@ -69,25 +68,25 @@ test.describe('client disconnect during create', () => {
     }
     if (id === undefined) {
       throw new Error(
-        `create answered before every disconnect offset (${answers.join(', ')}): ` +
-          'creates are now too fast for a client to hang up mid-create, so this test no longer exercises one',
+        `the API answered before every hang-up delay (${answers.join(', ')}): ` +
+          'creates are too fast for this test to hang up mid-create',
       );
     }
 
     try {
-      // The runner finishes the create regardless of the disconnect, so the row
-      // must follow: a sandbox the runner has and the API does not is a slot no
-      // quota or sweeper can ever reclaim.
+      // The runner finishes the create despite the hang-up, so the API must
+      // store the row too. A sandbox the runner has but the API does not know
+      // about holds a slot forever: quota and the idle sweeper never see it.
       try {
         await waitForSandboxStatus(request, id, 'running', 60_000);
       } catch (err) {
         throw new Error(
-          `create aborted at ${disconnectAfterMs}ms left no row: the runner-side sandbox is untracked, ` +
-            `or the hang-up landed before the API reached the runner: ${String(err)}`,
+          `no sandbox after hanging up at ${disconnectAfterMs}ms: either the runner-side sandbox ` +
+            `is untracked, or the hang-up landed before the API called the runner: ${String(err)}`,
         );
       }
 
-      // And the row names a live sandbox, not just a record.
+      // The sandbox is live, not just a row.
       expect(await execWithTransientRetry(id, 'echo tracked')).toHaveSucceeded();
     } finally {
       await deleteSandbox(id);

--- a/e2e/tests/sandbox-create-disconnect.spec.ts
+++ b/e2e/tests/sandbox-create-disconnect.spec.ts
@@ -9,56 +9,82 @@ import {
   waitForSandboxStatus,
 } from './helpers';
 
-// How long after sending POST /sandboxes the client hangs up. The API hands the
-// create to the runner within a few ms, and the runner takes ~0.7-0.9s on both
-// lanes, so this lands while the runner is still building the sandbox. If the
-// create ever answers first, the test fails rather than passing vacuously; see
-// the first assertion.
-const DISCONNECT_AFTER_MS = 150;
+// How long after sending POST /sandboxes the client hangs up, tried largest
+// first. The API hands the create to the runner within a few ms and the runner
+// takes ~0.7-0.9s on both lanes, so the first offset lands mid-create. If the
+// create answers first, the next attempt hangs up earlier rather than failing
+// on a speedup. Below the last offset the API's own pre-runner work (auth, id
+// lock) is a comparable share of the request, and a hang-up that lands before
+// the runner is asked is indistinguishable from the bug this guards, so the
+// test gives up and says so instead of passing vacuously.
+const DISCONNECT_OFFSETS_MS = [150, 75, 40, 20];
+
+// A raw fetch with an aborted signal closes the socket, which is what makes the
+// API's request context cancel; the SDK never disconnects mid-create. Resolves
+// to the status if the API answered first, undefined if the client hung up first.
+async function createAndHangUp(apiKey: string, id: string, afterMs: number): Promise<number | undefined> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), afterMs);
+  try {
+    const res = await fetch(`${BASE_URL}/sandboxes`, {
+      method: 'POST',
+      headers: { 'X-Api-Key': apiKey, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+      signal: ac.signal,
+    });
+    return res.status;
+  } catch (err) {
+    if ((err as Error).name !== 'AbortError') throw err;
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 test.describe('client disconnect during create', () => {
   test('leaves a tracked sandbox, never an untracked one', async ({ request }) => {
     test.setTimeout(120_000);
-    const id = randomUUID();
     const apiKey = await getApiKey();
 
-    // A raw fetch with an aborted signal closes the socket, which is what makes
-    // the API's request context cancel; the SDK never disconnects mid-create.
-    const ac = new AbortController();
-    const timer = setTimeout(() => ac.abort(), DISCONNECT_AFTER_MS);
-    const started = Date.now();
-    let answered: number | undefined;
-    try {
-      const res = await fetch(`${BASE_URL}/sandboxes`, {
-        method: 'POST',
-        headers: { 'X-Api-Key': apiKey, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id }),
-        signal: ac.signal,
-      });
-      answered = res.status;
-    } catch (err) {
-      if ((err as Error).name !== 'AbortError') throw err;
-    } finally {
-      clearTimeout(timer);
+    // Find an offset that hangs up mid-create. An answered 201 is a real sandbox
+    // that has to go; any other answer is an infrastructure failure, not a miss.
+    let id: string | undefined;
+    let disconnectAfterMs = 0;
+    const answers: string[] = [];
+    for (const afterMs of DISCONNECT_OFFSETS_MS) {
+      const candidate = randomUUID();
+      const started = Date.now();
+      const answered = await createAndHangUp(apiKey, candidate, afterMs);
+      if (answered === undefined) {
+        id = candidate;
+        disconnectAfterMs = afterMs;
+        break;
+      }
+      const elapsedMs = Date.now() - started;
+      if (answered !== 201) {
+        throw new Error(`create answered ${answered} after ${elapsedMs}ms`);
+      }
+      await deleteSandbox(candidate);
+      answers.push(`${elapsedMs}ms < ${afterMs}ms`);
     }
-    const elapsedMs = Date.now() - started;
+    if (id === undefined) {
+      throw new Error(
+        `create answered before every disconnect offset (${answers.join(', ')}): ` +
+          'creates are now too fast for a client to hang up mid-create, so this test no longer exercises one',
+      );
+    }
 
     try {
-      // The API answered before the client hung up: creates are now faster than
-      // DISCONNECT_AFTER_MS and this test no longer exercises a mid-create
-      // disconnect. Lower the constant.
-      expect(
-        answered,
-        `create answered ${answered} after ${elapsedMs}ms, before the ${DISCONNECT_AFTER_MS}ms disconnect`,
-      ).toBeUndefined();
-
       // The runner finishes the create regardless of the disconnect, so the row
       // must follow: a sandbox the runner has and the API does not is a slot no
       // quota or sweeper can ever reclaim.
       try {
         await waitForSandboxStatus(request, id, 'running', 60_000);
       } catch (err) {
-        throw new Error(`aborted create left no row, the runner-side sandbox is untracked: ${String(err)}`);
+        throw new Error(
+          `create aborted at ${disconnectAfterMs}ms left no row: the runner-side sandbox is untracked, ` +
+            `or the hang-up landed before the API reached the runner: ${String(err)}`,
+        );
       }
 
       // And the row names a live sandbox, not just a record.

--- a/e2e/tests/sandbox-create-disconnect.spec.ts
+++ b/e2e/tests/sandbox-create-disconnect.spec.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from 'node:crypto';
+import { test, expect } from '@playwright/test';
+import './matchers';
+import {
+  BASE_URL,
+  deleteSandbox,
+  execWithTransientRetry,
+  getApiKey,
+  waitForSandboxStatus,
+} from './helpers';
+
+// How long after sending POST /sandboxes the client hangs up. The API hands the
+// create to the runner within a few ms, and the runner takes ~0.7-0.9s on both
+// lanes, so this lands while the runner is still building the sandbox. If the
+// create ever answers first, the test fails rather than passing vacuously; see
+// the first assertion.
+const DISCONNECT_AFTER_MS = 150;
+
+test.describe('client disconnect during create', () => {
+  test('leaves a tracked sandbox, never an untracked one', async ({ request }) => {
+    test.setTimeout(120_000);
+    const id = randomUUID();
+    const apiKey = await getApiKey();
+
+    // A raw fetch with an aborted signal closes the socket, which is what makes
+    // the API's request context cancel; the SDK never disconnects mid-create.
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), DISCONNECT_AFTER_MS);
+    const started = Date.now();
+    let answered: number | undefined;
+    try {
+      const res = await fetch(`${BASE_URL}/sandboxes`, {
+        method: 'POST',
+        headers: { 'X-Api-Key': apiKey, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id }),
+        signal: ac.signal,
+      });
+      answered = res.status;
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+    const elapsedMs = Date.now() - started;
+
+    try {
+      // The API answered before the client hung up: creates are now faster than
+      // DISCONNECT_AFTER_MS and this test no longer exercises a mid-create
+      // disconnect. Lower the constant.
+      expect(
+        answered,
+        `create answered ${answered} after ${elapsedMs}ms, before the ${DISCONNECT_AFTER_MS}ms disconnect`,
+      ).toBeUndefined();
+
+      // The runner finishes the create regardless of the disconnect, so the row
+      // must follow: a sandbox the runner has and the API does not is a slot no
+      // quota or sweeper can ever reclaim.
+      try {
+        await waitForSandboxStatus(request, id, 'running', 60_000);
+      } catch (err) {
+        throw new Error(`aborted create left no row, the runner-side sandbox is untracked: ${String(err)}`);
+      }
+
+      // And the row names a live sandbox, not just a record.
+      expect(await execWithTransientRetry(id, 'echo tracked')).toHaveSucceeded();
+    } finally {
+      await deleteSandbox(id);
+    }
+  });
+});

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -227,9 +227,7 @@ func runnerControlTLS(cfg *config.APIConfig) *runnerctl.TLS {
 // connection. A client that disconnects mid-create must not cancel the RPC:
 // the runner would finish the create anyway, and with no store row the sandbox
 // would be invisible to quota and the idle sweeper while still holding a slot.
-// Three minutes sits above Firecracker's own 2-minute create budget, so the
-// runner always answers before the API gives up.
-const runnerCreateBudget = 3 * time.Minute
+var runnerCreateBudget = 3 * time.Minute
 
 func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg *config.APIConfig, rec *metrics.APIRecorder) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -378,7 +376,19 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 			Ephemeral:             req.Ephemeral,
 		}
 		if err := s.Create(record); err != nil {
-			_ = runnerctl.DeleteSandbox(createCtx, controlAddr, cfg.RunnerAPIKey, tlsCfg, sandboxID)
+			deleteCtx, cancelDelete := context.WithTimeout(context.WithoutCancel(r.Context()), runnerCreateBudget)
+			delErr := runnerctl.DeleteSandbox(deleteCtx, controlAddr, cfg.RunnerAPIKey, tlsCfg, sandboxID)
+			cancelDelete()
+			if delErr != nil {
+				slog.ErrorContext(
+					r.Context(),
+					"create sandbox failed: compensating runner delete, sandbox is untracked",
+					"sandbox_id", sandboxID,
+					"runner_id", run.ID,
+					"runner_control_grpc_addr", controlAddr,
+					"error", delErr,
+				)
+			}
 			if existing, getErr := s.Get(sandboxID); getErr == nil && existing != nil {
 				if canAccessSandbox(r, existing) {
 					writeJSON(w, http.StatusOK, sandboxResponse(existing))

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -222,6 +223,14 @@ func runnerControlTLS(cfg *config.APIConfig) *runnerctl.TLS {
 	}
 }
 
+// runnerCreateBudget bounds the runner create RPC independently of the client
+// connection. A client that disconnects mid-create must not cancel the RPC:
+// the runner would finish the create anyway, and with no store row the sandbox
+// would be invisible to quota and the idle sweeper while still holding a slot.
+// Three minutes sits above Firecracker's own 2-minute create budget, so the
+// runner always answers before the API gives up.
+const runnerCreateBudget = 3 * time.Minute
+
 func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg *config.APIConfig, rec *metrics.APIRecorder) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		success := false
@@ -338,7 +347,9 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 			"tenant_id", tenantID,
 			"ephemeral", req.Ephemeral,
 		)
-		gresp, err := runnerctl.CreateSandbox(r.Context(), controlAddr, cfg.RunnerAPIKey, tlsCfg, sandboxID, "{}")
+		createCtx, cancelCreate := context.WithTimeout(context.WithoutCancel(r.Context()), runnerCreateBudget)
+		defer cancelCreate()
+		gresp, err := runnerctl.CreateSandbox(createCtx, controlAddr, cfg.RunnerAPIKey, tlsCfg, sandboxID, "{}")
 		if err != nil {
 			slog.ErrorContext(
 				r.Context(),
@@ -367,7 +378,7 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 			Ephemeral:             req.Ephemeral,
 		}
 		if err := s.Create(record); err != nil {
-			_ = runnerctl.DeleteSandbox(r.Context(), controlAddr, cfg.RunnerAPIKey, tlsCfg, sandboxID)
+			_ = runnerctl.DeleteSandbox(createCtx, controlAddr, cfg.RunnerAPIKey, tlsCfg, sandboxID)
 			if existing, getErr := s.Get(sandboxID); getErr == nil && existing != nil {
 				if canAccessSandbox(r, existing) {
 					writeJSON(w, http.StatusOK, sandboxResponse(existing))

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/n8n-io/sandbox-service/internal/grpctls"
 	"github.com/n8n-io/sandbox-service/internal/metrics"
 	"github.com/n8n-io/sandbox-service/internal/obs"
+	runnerruntime "github.com/n8n-io/sandbox-service/internal/runner/runtime"
 	"github.com/n8n-io/sandbox-service/internal/sandboxproxy"
 )
 
@@ -227,7 +228,9 @@ func runnerControlTLS(cfg *config.APIConfig) *runnerctl.TLS {
 // connection. A client that disconnects mid-create must not cancel the RPC:
 // the runner would finish the create anyway, and with no store row the sandbox
 // would be invisible to quota and the idle sweeper while still holding a slot.
-var runnerCreateBudget = 3 * time.Minute
+// It is the runtime's own create budget plus a margin for the dial and round
+// trip, so a create that succeeds always answers before the API gives up.
+const runnerCreateBudget = runnerruntime.CreateBudget + time.Minute
 
 func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg *config.APIConfig, rec *metrics.APIRecorder) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -224,12 +224,11 @@ func runnerControlTLS(cfg *config.APIConfig) *runnerctl.TLS {
 	}
 }
 
-// runnerCreateBudget bounds the runner create RPC independently of the client
-// connection. A client that disconnects mid-create must not cancel the RPC:
-// the runner would finish the create anyway, and with no store row the sandbox
-// would be invisible to quota and the idle sweeper while still holding a slot.
-// It is the runtime's own create budget plus a margin for the dial and round
-// trip, so a create that succeeds always answers before the API gives up.
+// runnerCreateBudget is the deadline for the runner create RPC, used instead of
+// the client's request context: a client disconnect must not cancel the RPC,
+// because the runner would finish the create anyway and the resulting sandbox,
+// with no store row, would hold a slot that quota and the idle sweeper cannot
+// see. The runtime's own create budget plus a margin for the round trip.
 const runnerCreateBudget = runnerruntime.CreateBudget + time.Minute
 
 func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg *config.APIConfig, rec *metrics.APIRecorder) http.HandlerFunc {
@@ -379,6 +378,7 @@ func handleCreateSandbox(s store.SandboxStore, reg registry.RunnerRegistry, cfg 
 			Ephemeral:             req.Ephemeral,
 		}
 		if err := s.Create(record); err != nil {
+			// Fresh deadline: the create may have used up most of createCtx.
 			deleteCtx, cancelDelete := context.WithTimeout(context.WithoutCancel(r.Context()), runnerCreateBudget)
 			delErr := runnerctl.DeleteSandbox(deleteCtx, controlAddr, cfg.RunnerAPIKey, tlsCfg, sandboxID)
 			cancelDelete()

--- a/internal/api/handlers_create_sandbox_test.go
+++ b/internal/api/handlers_create_sandbox_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -226,6 +227,10 @@ func newIdleTestGateway(t *testing.T, adminKey string, fake *fakeSandboxControl)
 func TestCreateSandboxClientDisconnectStillStoresRow(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
+	// Released on every exit path, so a failing run does not leave the fake's
+	// create blocked forever.
+	releaseRunner := sync.OnceFunc(func() { close(release) })
+	defer releaseRunner()
 	fake := &fakeSandboxControl{createHook: func(context.Context) {
 		close(started)
 		<-release
@@ -253,7 +258,7 @@ func TestCreateSandboxClientDisconnectStillStoresRow(t *testing.T) {
 		t.Fatal("timed out waiting for the runner create to start")
 	}
 	disconnect()
-	close(release)
+	releaseRunner()
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
@@ -275,43 +280,33 @@ func TestCreateSandboxClientDisconnectStillStoresRow(t *testing.T) {
 	}
 }
 
-// The Firecracker runner answers a successful create within its createBudget
-// (internal/runner/runtime/firecracker.ee/runtime.go). Giving up before that
-// would leave a live sandbox behind that no store row names.
-func TestRunnerCreateBudgetExceedsRunnerCreate(t *testing.T) {
-	const firecrackerCreateBudget = 2 * time.Minute
-	if runnerCreateBudget <= firecrackerCreateBudget {
-		t.Fatalf("runnerCreateBudget = %v, must stay above the Firecracker runner's createBudget of %v", runnerCreateBudget, firecrackerCreateBudget)
-	}
-}
-
 // A store write that fails after the runner has created the sandbox must still
 // get the runner-side sandbox deleted, or it holds a slot nothing can reclaim.
 // The create RPC may have used most of the create budget, so the compensating
-// delete cannot run on what is left of it: here the create drains 70% of the
-// budget and the delete needs 60%, which only completes on a budget of its own.
+// delete cannot run on what is left of it: the deadline the runner sees on the
+// delete has to be set after the create finished, not inherited from the create.
 func TestCreateSandboxStoreFailureDeletesRunnerSandbox(t *testing.T) {
-	restore := runnerCreateBudget
-	runnerCreateBudget = time.Second
-	t.Cleanup(func() { runnerCreateBudget = restore })
-
+	const createTakes = 200 * time.Millisecond
 	var s store.SandboxStore
 	var tenantID string
+	createDeadline := make(chan time.Time, 1)
+	deleteDeadline := make(chan time.Time, 1)
 	fake := &fakeSandboxControl{}
-	fake.createHook = func(context.Context) {
-		time.Sleep(700 * time.Millisecond)
+	fake.createHook = func(ctx context.Context) {
+		deadline, _ := ctx.Deadline()
+		createDeadline <- deadline
+		// Long enough that a delete deadline inherited from the create sits
+		// measurably before one set after it.
+		time.Sleep(createTakes)
 		// The tenant goes away mid-create, so the store refuses the row.
 		if err := s.DeleteTenant(tenantID); err != nil {
 			t.Errorf("delete tenant: %v", err)
 		}
 	}
 	fake.deleteHook = func(ctx context.Context) error {
-		select {
-		case <-time.After(600 * time.Millisecond):
-			return nil
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		deadline, _ := ctx.Deadline()
+		deleteDeadline <- deadline
+		return nil
 	}
 	var router http.Handler
 	router, s, _ = newIdleTestGateway(t, "admin-key", fake)
@@ -323,7 +318,12 @@ func TestCreateSandboxStoreFailureDeletesRunnerSandbox(t *testing.T) {
 		t.Fatalf("create with tenant deleted mid-create: expected %d, got %d body=%s", http.StatusConflict, rr.Code, rr.Body.String())
 	}
 	if _, deleted := fake.calls(); len(deleted) != 1 {
-		t.Fatalf("runner deletes = %v, want the compensating delete to complete", deleted)
+		t.Fatalf("runner deletes = %v, want the compensating delete", deleted)
+	}
+	// A delete on the create's leftover budget carries the create's deadline; one
+	// on a budget of its own is later by at least the time the create took.
+	if gap := (<-deleteDeadline).Sub(<-createDeadline); gap < createTakes/2 {
+		t.Fatalf("delete deadline is %v after the create's, want at least %v: the delete inherited the create's budget", gap, createTakes/2)
 	}
 }
 

--- a/internal/api/handlers_create_sandbox_test.go
+++ b/internal/api/handlers_create_sandbox_test.go
@@ -220,15 +220,13 @@ func newIdleTestGateway(t *testing.T, adminKey string, fake *fakeSandboxControl)
 	return router, s, cfg
 }
 
-// A client that disconnects while the runner is still creating must not
-// cancel the runner call: the runner finishes either way, and without a store
-// row the sandbox would hold a slot that neither quota nor the idle sweeper can
-// see. The create runs to completion and the row is stored.
+// A client hanging up mid-create must not cancel the runner call: the runner
+// finishes the create either way, and without a store row the sandbox would
+// hold a slot that quota and the idle sweeper cannot see.
 func TestCreateSandboxClientDisconnectStillStoresRow(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
-	// Released on every exit path, so a failing run does not leave the fake's
-	// create blocked forever.
+	// Release on every exit path so a failed assertion cannot leave the fake blocked.
 	releaseRunner := sync.OnceFunc(func() { close(release) })
 	defer releaseRunner()
 	fake := &fakeSandboxControl{createHook: func(context.Context) {
@@ -248,8 +246,8 @@ func TestCreateSandboxClientDisconnectStillStoresRow(t *testing.T) {
 		router.ServeHTTP(rr, req)
 	}()
 
-	// Bounded waits: if the create returns before reaching the runner, started
-	// never closes, and the suite must fail here rather than stall.
+	// If the create returns without reaching the runner, started never closes;
+	// fail rather than hang.
 	select {
 	case <-started:
 	case <-done:
@@ -280,10 +278,10 @@ func TestCreateSandboxClientDisconnectStillStoresRow(t *testing.T) {
 	}
 }
 
-// createWithTenantDeletedMidCreate posts a tenant create whose tenant is deleted
-// while the runner is still creating, so the store refuses the row and the
-// handler has to compensate on the runner. inCreate, if set, runs first inside
-// the runner create. The create must answer with the 409 for the lost tenant.
+// createWithTenantDeletedMidCreate posts a create and deletes the tenant while
+// the runner is still creating, so storing the row fails and the handler has to
+// delete the sandbox on the runner again. inCreate, if set, runs inside the
+// runner create first. Asserts the 409 for the lost tenant.
 func createWithTenantDeletedMidCreate(t *testing.T, fake *fakeSandboxControl, inCreate func(context.Context)) {
 	t.Helper()
 	var s store.SandboxStore
@@ -306,11 +304,9 @@ func createWithTenantDeletedMidCreate(t *testing.T, fake *fakeSandboxControl, in
 	}
 }
 
-// A store write that fails after the runner has created the sandbox must still
-// get the runner-side sandbox deleted, or it holds a slot nothing can reclaim.
-// The create RPC may have used most of the create budget, so the compensating
-// delete cannot run on what is left of it: it has to reach the runner with a
-// budget of its own.
+// If storing the row fails after the runner created the sandbox, the handler
+// must delete it on the runner, or it holds a slot nothing can reclaim. That
+// delete needs its own deadline: the create may have used up most of its own.
 func TestCreateSandboxStoreFailureDeletesRunnerSandbox(t *testing.T) {
 	const createTakes = 200 * time.Millisecond
 	remaining := make(chan time.Duration, 1)
@@ -318,7 +314,7 @@ func TestCreateSandboxStoreFailureDeletesRunnerSandbox(t *testing.T) {
 		deadline, _ := ctx.Deadline()
 		remaining <- time.Until(deadline)
 	}}
-	// Long enough that a delete on the create's leftover is measurably short.
+	// Long enough that a delete reusing the create's deadline is measurably short.
 	createWithTenantDeletedMidCreate(t, fake, func(context.Context) { time.Sleep(createTakes) })
 
 	if _, deleted := fake.calls(); len(deleted) != 1 {
@@ -329,8 +325,8 @@ func TestCreateSandboxStoreFailureDeletesRunnerSandbox(t *testing.T) {
 	}
 }
 
-// A compensating delete that fails is what leaves an untracked sandbox behind,
-// so it has to be reported, not swallowed.
+// If that delete fails, the sandbox is now untracked; the failure must be
+// logged, not swallowed.
 func TestCreateSandboxStoreFailureLogsFailedRunnerDelete(t *testing.T) {
 	logs := captureLogs(t)
 	fake := &fakeSandboxControl{}

--- a/internal/api/handlers_create_sandbox_test.go
+++ b/internal/api/handlers_create_sandbox_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -191,8 +192,8 @@ func TestCreateSandboxQuotaExceeded(t *testing.T) {
 	}
 }
 
-// newIdleTestGateway is newTestGateway with idle windows and a fake runner.
-func newIdleTestGateway(t *testing.T, adminKey string) (http.Handler, store.SandboxStore, *config.APIConfig) {
+// newIdleTestGateway is newTestGateway with idle windows and a runner serving fake.
+func newIdleTestGateway(t *testing.T, adminKey string, fake *fakeSandboxControl) (http.Handler, store.SandboxStore, *config.APIConfig) {
 	t.Helper()
 	s, err := store.New(":memory:")
 	if err != nil {
@@ -206,7 +207,7 @@ func newIdleTestGateway(t *testing.T, adminKey string) (http.Handler, store.Sand
 	cfg.DefaultMaxSandboxes = 50
 
 	reg := registry.New(45 * time.Second)
-	reg.Upsert("runner-1", "https://127.0.0.1:9", startFakeRunnerControl(t, &fakeSandboxControl{}), true, 10, 0, 0)
+	reg.Upsert("runner-1", "https://127.0.0.1:9", startFakeRunnerControl(t, fake), true, 10, 0, 0)
 
 	router, err := NewGatewayRouter(s, cfg, reg, metrics.NewAPIRecorder(false))
 	if err != nil {
@@ -215,8 +216,52 @@ func newIdleTestGateway(t *testing.T, adminKey string) (http.Handler, store.Sand
 	return router, s, cfg
 }
 
+// A client that disconnects while the runner is still creating must not
+// cancel the runner call: the runner finishes either way, and without a store
+// row the sandbox would hold a slot that neither quota nor the idle sweeper can
+// see. The create runs to completion and the row is stored.
+func TestCreateSandboxClientDisconnectStillStoresRow(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	fake := &fakeSandboxControl{createHook: func(context.Context) {
+		close(started)
+		<-release
+	}}
+	router, s, _ := newIdleTestGateway(t, "admin-key", fake)
+
+	ctx, disconnect := context.WithCancel(context.Background())
+	defer disconnect()
+	req := httptest.NewRequest(http.MethodPost, "/sandboxes", nil).WithContext(ctx)
+	req.Header.Set("X-Api-Key", "admin-key")
+	rr := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		router.ServeHTTP(rr, req)
+	}()
+
+	<-started
+	disconnect()
+	close(release)
+	<-done
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create after disconnect: expected %d, got %d body=%s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+	var resp SandboxResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if rec, err := s.Get(resp.ID); err != nil || rec == nil {
+		t.Fatalf("stored row = %+v err=%v, want the created sandbox", rec, err)
+	}
+	if _, deleted := fake.calls(); len(deleted) != 0 {
+		t.Fatalf("runner deletes = %v, want none", deleted)
+	}
+}
+
 func TestCreateSandboxPersistsEphemeral(t *testing.T) {
-	router, s, _ := newIdleTestGateway(t, "admin-key")
+	router, s, _ := newIdleTestGateway(t, "admin-key", &fakeSandboxControl{})
 
 	rr := postCreateSandbox(t, router, "admin-key", `{"ephemeral":true}`)
 	if rr.Code != http.StatusCreated {
@@ -245,7 +290,7 @@ func TestCreateSandboxPersistsEphemeral(t *testing.T) {
 }
 
 func TestGetSandboxFencesEphemeralAtStopWindow(t *testing.T) {
-	router, s, cfg := newIdleTestGateway(t, "admin-key")
+	router, s, cfg := newIdleTestGateway(t, "admin-key", &fakeSandboxControl{})
 
 	get := func(id string) *httptest.ResponseRecorder {
 		req := httptest.NewRequest(http.MethodGet, "/sandboxes/"+id, nil)

--- a/internal/api/handlers_create_sandbox_test.go
+++ b/internal/api/handlers_create_sandbox_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/n8n-io/sandbox-service/internal/api/config"
 	"github.com/n8n-io/sandbox-service/internal/api/registry"
 	"github.com/n8n-io/sandbox-service/internal/api/store"
@@ -240,10 +243,22 @@ func TestCreateSandboxClientDisconnectStillStoresRow(t *testing.T) {
 		router.ServeHTTP(rr, req)
 	}()
 
-	<-started
+	// Bounded waits: if the create returns before reaching the runner, started
+	// never closes, and the suite must fail here rather than stall.
+	select {
+	case <-started:
+	case <-done:
+		t.Fatalf("create returned before reaching the runner: status %d body=%s", rr.Code, rr.Body.String())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the runner create to start")
+	}
 	disconnect()
 	close(release)
-	<-done
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("create did not finish after the runner was released")
+	}
 
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create after disconnect: expected %d, got %d body=%s", http.StatusCreated, rr.Code, rr.Body.String())
@@ -258,6 +273,90 @@ func TestCreateSandboxClientDisconnectStillStoresRow(t *testing.T) {
 	if _, deleted := fake.calls(); len(deleted) != 0 {
 		t.Fatalf("runner deletes = %v, want none", deleted)
 	}
+}
+
+// The Firecracker runner answers a successful create within its createBudget
+// (internal/runner/runtime/firecracker.ee/runtime.go). Giving up before that
+// would leave a live sandbox behind that no store row names.
+func TestRunnerCreateBudgetExceedsRunnerCreate(t *testing.T) {
+	const firecrackerCreateBudget = 2 * time.Minute
+	if runnerCreateBudget <= firecrackerCreateBudget {
+		t.Fatalf("runnerCreateBudget = %v, must stay above the Firecracker runner's createBudget of %v", runnerCreateBudget, firecrackerCreateBudget)
+	}
+}
+
+// A store write that fails after the runner has created the sandbox must still
+// get the runner-side sandbox deleted, or it holds a slot nothing can reclaim.
+// The create RPC may have used most of the create budget, so the compensating
+// delete cannot run on what is left of it: here the create drains 70% of the
+// budget and the delete needs 60%, which only completes on a budget of its own.
+func TestCreateSandboxStoreFailureDeletesRunnerSandbox(t *testing.T) {
+	restore := runnerCreateBudget
+	runnerCreateBudget = time.Second
+	t.Cleanup(func() { runnerCreateBudget = restore })
+
+	var s store.SandboxStore
+	var tenantID string
+	fake := &fakeSandboxControl{}
+	fake.createHook = func(context.Context) {
+		time.Sleep(700 * time.Millisecond)
+		// The tenant goes away mid-create, so the store refuses the row.
+		if err := s.DeleteTenant(tenantID); err != nil {
+			t.Errorf("delete tenant: %v", err)
+		}
+	}
+	fake.deleteHook = func(ctx context.Context) error {
+		select {
+		case <-time.After(600 * time.Millisecond):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	var router http.Handler
+	router, s, _ = newIdleTestGateway(t, "admin-key", fake)
+	tenant := mintTenantKey(t, router, `{"name":"t"}`)
+	tenantID = tenant.Tenant.ID
+
+	rr := postCreateSandbox(t, router, tenant.Key.APIKey, "")
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("create with tenant deleted mid-create: expected %d, got %d body=%s", http.StatusConflict, rr.Code, rr.Body.String())
+	}
+	if _, deleted := fake.calls(); len(deleted) != 1 {
+		t.Fatalf("runner deletes = %v, want the compensating delete to complete", deleted)
+	}
+}
+
+// A compensating delete that fails is what leaves an untracked sandbox behind,
+// so it has to be reported, not swallowed.
+func TestCreateSandboxStoreFailureLogsFailedRunnerDelete(t *testing.T) {
+	logs := captureLogs(t)
+	var s store.SandboxStore
+	var tenantID string
+	fake := &fakeSandboxControl{}
+	fake.createHook = func(context.Context) {
+		if err := s.DeleteTenant(tenantID); err != nil {
+			t.Errorf("delete tenant: %v", err)
+		}
+	}
+	fake.failDeletes(status.Error(codes.Unavailable, "runner busy"))
+	var router http.Handler
+	router, s, _ = newIdleTestGateway(t, "admin-key", fake)
+	tenant := mintTenantKey(t, router, `{"name":"t"}`)
+	tenantID = tenant.Tenant.ID
+
+	if rr := postCreateSandbox(t, router, tenant.Key.APIKey, ""); rr.Code != http.StatusConflict {
+		t.Fatalf("create with tenant deleted mid-create: expected %d, got %d body=%s", http.StatusConflict, rr.Code, rr.Body.String())
+	}
+	for _, event := range logs() {
+		if msg, _ := event["msg"].(string); strings.HasPrefix(msg, "create sandbox failed: compensating runner delete") {
+			if event["sandbox_id"] == nil || !strings.Contains(event["error"].(string), "runner busy") {
+				t.Fatalf("delete failure event = %v, want sandbox_id and the runner error", event)
+			}
+			return
+		}
+	}
+	t.Fatal("no log event for the failed compensating delete")
 }
 
 func TestCreateSandboxPersistsEphemeral(t *testing.T) {

--- a/internal/api/handlers_create_sandbox_test.go
+++ b/internal/api/handlers_create_sandbox_test.go
@@ -280,66 +280,22 @@ func TestCreateSandboxClientDisconnectStillStoresRow(t *testing.T) {
 	}
 }
 
-// A store write that fails after the runner has created the sandbox must still
-// get the runner-side sandbox deleted, or it holds a slot nothing can reclaim.
-// The create RPC may have used most of the create budget, so the compensating
-// delete cannot run on what is left of it: the deadline the runner sees on the
-// delete has to be set after the create finished, not inherited from the create.
-func TestCreateSandboxStoreFailureDeletesRunnerSandbox(t *testing.T) {
-	const createTakes = 200 * time.Millisecond
+// createWithTenantDeletedMidCreate posts a tenant create whose tenant is deleted
+// while the runner is still creating, so the store refuses the row and the
+// handler has to compensate on the runner. inCreate, if set, runs first inside
+// the runner create. The create must answer with the 409 for the lost tenant.
+func createWithTenantDeletedMidCreate(t *testing.T, fake *fakeSandboxControl, inCreate func(context.Context)) {
+	t.Helper()
 	var s store.SandboxStore
 	var tenantID string
-	createDeadline := make(chan time.Time, 1)
-	deleteDeadline := make(chan time.Time, 1)
-	fake := &fakeSandboxControl{}
 	fake.createHook = func(ctx context.Context) {
-		deadline, _ := ctx.Deadline()
-		createDeadline <- deadline
-		// Long enough that a delete deadline inherited from the create sits
-		// measurably before one set after it.
-		time.Sleep(createTakes)
-		// The tenant goes away mid-create, so the store refuses the row.
+		if inCreate != nil {
+			inCreate(ctx)
+		}
 		if err := s.DeleteTenant(tenantID); err != nil {
 			t.Errorf("delete tenant: %v", err)
 		}
 	}
-	fake.deleteHook = func(ctx context.Context) error {
-		deadline, _ := ctx.Deadline()
-		deleteDeadline <- deadline
-		return nil
-	}
-	var router http.Handler
-	router, s, _ = newIdleTestGateway(t, "admin-key", fake)
-	tenant := mintTenantKey(t, router, `{"name":"t"}`)
-	tenantID = tenant.Tenant.ID
-
-	rr := postCreateSandbox(t, router, tenant.Key.APIKey, "")
-	if rr.Code != http.StatusConflict {
-		t.Fatalf("create with tenant deleted mid-create: expected %d, got %d body=%s", http.StatusConflict, rr.Code, rr.Body.String())
-	}
-	if _, deleted := fake.calls(); len(deleted) != 1 {
-		t.Fatalf("runner deletes = %v, want the compensating delete", deleted)
-	}
-	// A delete on the create's leftover budget carries the create's deadline; one
-	// on a budget of its own is later by at least the time the create took.
-	if gap := (<-deleteDeadline).Sub(<-createDeadline); gap < createTakes/2 {
-		t.Fatalf("delete deadline is %v after the create's, want at least %v: the delete inherited the create's budget", gap, createTakes/2)
-	}
-}
-
-// A compensating delete that fails is what leaves an untracked sandbox behind,
-// so it has to be reported, not swallowed.
-func TestCreateSandboxStoreFailureLogsFailedRunnerDelete(t *testing.T) {
-	logs := captureLogs(t)
-	var s store.SandboxStore
-	var tenantID string
-	fake := &fakeSandboxControl{}
-	fake.createHook = func(context.Context) {
-		if err := s.DeleteTenant(tenantID); err != nil {
-			t.Errorf("delete tenant: %v", err)
-		}
-	}
-	fake.failDeletes(status.Error(codes.Unavailable, "runner busy"))
 	var router http.Handler
 	router, s, _ = newIdleTestGateway(t, "admin-key", fake)
 	tenant := mintTenantKey(t, router, `{"name":"t"}`)
@@ -348,6 +304,39 @@ func TestCreateSandboxStoreFailureLogsFailedRunnerDelete(t *testing.T) {
 	if rr := postCreateSandbox(t, router, tenant.Key.APIKey, ""); rr.Code != http.StatusConflict {
 		t.Fatalf("create with tenant deleted mid-create: expected %d, got %d body=%s", http.StatusConflict, rr.Code, rr.Body.String())
 	}
+}
+
+// A store write that fails after the runner has created the sandbox must still
+// get the runner-side sandbox deleted, or it holds a slot nothing can reclaim.
+// The create RPC may have used most of the create budget, so the compensating
+// delete cannot run on what is left of it: it has to reach the runner with a
+// budget of its own.
+func TestCreateSandboxStoreFailureDeletesRunnerSandbox(t *testing.T) {
+	const createTakes = 200 * time.Millisecond
+	remaining := make(chan time.Duration, 1)
+	fake := &fakeSandboxControl{deleteHook: func(ctx context.Context) {
+		deadline, _ := ctx.Deadline()
+		remaining <- time.Until(deadline)
+	}}
+	// Long enough that a delete on the create's leftover is measurably short.
+	createWithTenantDeletedMidCreate(t, fake, func(context.Context) { time.Sleep(createTakes) })
+
+	if _, deleted := fake.calls(); len(deleted) != 1 {
+		t.Fatalf("runner deletes = %v, want the compensating delete", deleted)
+	}
+	if got := <-remaining; got < runnerCreateBudget-createTakes/2 {
+		t.Fatalf("delete reached the runner with %v left, want about %v: it ran on the create's leftover budget", got, runnerCreateBudget)
+	}
+}
+
+// A compensating delete that fails is what leaves an untracked sandbox behind,
+// so it has to be reported, not swallowed.
+func TestCreateSandboxStoreFailureLogsFailedRunnerDelete(t *testing.T) {
+	logs := captureLogs(t)
+	fake := &fakeSandboxControl{}
+	fake.failDeletes(status.Error(codes.Unavailable, "runner busy"))
+	createWithTenantDeletedMidCreate(t, fake, nil)
+
 	for _, event := range logs() {
 		if msg, _ := event["msg"].(string); strings.HasPrefix(msg, "create sandbox failed: compensating runner delete") {
 			if event["sandbox_id"] == nil || !strings.Contains(event["error"].(string), "runner busy") {

--- a/internal/api/handlers_proxy_activity_test.go
+++ b/internal/api/handlers_proxy_activity_test.go
@@ -198,7 +198,7 @@ func TestSandboxProxyRefusesPlaintextRunnerBase(t *testing.T) {
 // routing validation: a row that predates runner_http_base_url has no base,
 // but once it is past its window the proxy still answers 404, not 502.
 func TestSandboxProxyFencesExpiredSandboxWithoutRunnerBase(t *testing.T) {
-	router, s, cfg := newIdleTestGateway(t, "admin-key")
+	router, s, cfg := newIdleTestGateway(t, "admin-key", &fakeSandboxControl{})
 
 	stale := time.Now().Add(-cfg.IdleStopAfter - time.Second).Unix()
 	const sid = "eeeeeeee-5555-4555-8555-eeeeeeeeeeee"

--- a/internal/api/ttl_test.go
+++ b/internal/api/ttl_test.go
@@ -29,7 +29,7 @@ type fakeSandboxControl struct {
 	deleted    []string
 	deleteErr  error
 	createHook func(ctx context.Context)
-	deleteHook func(ctx context.Context) error
+	deleteHook func(ctx context.Context)
 }
 
 func (f *fakeSandboxControl) CreateSandbox(ctx context.Context, _ *pb.CreateSandboxRequest) (*pb.CreateSandboxResponse, error) {
@@ -48,9 +48,7 @@ func (f *fakeSandboxControl) StopSandbox(_ context.Context, req *pb.StopSandboxR
 
 func (f *fakeSandboxControl) DeleteSandbox(ctx context.Context, req *pb.DeleteSandboxRequest) (*pb.DeleteSandboxResponse, error) {
 	if f.deleteHook != nil {
-		if err := f.deleteHook(ctx); err != nil {
-			return nil, err
-		}
+		f.deleteHook(ctx)
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/api/ttl_test.go
+++ b/internal/api/ttl_test.go
@@ -29,6 +29,7 @@ type fakeSandboxControl struct {
 	deleted    []string
 	deleteErr  error
 	createHook func(ctx context.Context)
+	deleteHook func(ctx context.Context) error
 }
 
 func (f *fakeSandboxControl) CreateSandbox(ctx context.Context, _ *pb.CreateSandboxRequest) (*pb.CreateSandboxResponse, error) {
@@ -45,7 +46,12 @@ func (f *fakeSandboxControl) StopSandbox(_ context.Context, req *pb.StopSandboxR
 	return &pb.StopSandboxResponse{}, nil
 }
 
-func (f *fakeSandboxControl) DeleteSandbox(_ context.Context, req *pb.DeleteSandboxRequest) (*pb.DeleteSandboxResponse, error) {
+func (f *fakeSandboxControl) DeleteSandbox(ctx context.Context, req *pb.DeleteSandboxRequest) (*pb.DeleteSandboxResponse, error) {
+	if f.deleteHook != nil {
+		if err := f.deleteHook(ctx); err != nil {
+			return nil, err
+		}
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.deleteErr != nil {

--- a/internal/api/ttl_test.go
+++ b/internal/api/ttl_test.go
@@ -24,10 +24,11 @@ import (
 // which lifecycle calls reached it.
 type fakeSandboxControl struct {
 	pb.UnimplementedSandboxControlServer
-	mu         sync.Mutex
-	stopped    []string
-	deleted    []string
-	deleteErr  error
+	mu        sync.Mutex
+	stopped   []string
+	deleted   []string
+	deleteErr error
+	// Run at the start of the RPC, on the server-side context, when set.
 	createHook func(ctx context.Context)
 	deleteHook func(ctx context.Context)
 }

--- a/internal/api/ttl_test.go
+++ b/internal/api/ttl_test.go
@@ -24,13 +24,17 @@ import (
 // which lifecycle calls reached it.
 type fakeSandboxControl struct {
 	pb.UnimplementedSandboxControlServer
-	mu        sync.Mutex
-	stopped   []string
-	deleted   []string
-	deleteErr error
+	mu         sync.Mutex
+	stopped    []string
+	deleted    []string
+	deleteErr  error
+	createHook func(ctx context.Context)
 }
 
-func (f *fakeSandboxControl) CreateSandbox(_ context.Context, _ *pb.CreateSandboxRequest) (*pb.CreateSandboxResponse, error) {
+func (f *fakeSandboxControl) CreateSandbox(ctx context.Context, _ *pb.CreateSandboxRequest) (*pb.CreateSandboxResponse, error) {
+	if f.createHook != nil {
+		f.createHook(ctx)
+	}
 	return &pb.CreateSandboxResponse{ContainerIp: "10.0.0.2"}, nil
 }
 

--- a/internal/runner/register/register.go
+++ b/internal/runner/register/register.go
@@ -109,7 +109,7 @@ func connectOnce(ctx context.Context, cfg *config.Config, rt runnerruntime.Runti
 	send := func() error {
 		capacity, err := rt.Capacity(ctx)
 		if err != nil {
-			slog.Debug("runtime capacity failed", "error", err)
+			slog.Warn("runtime capacity failed", "error", err)
 			capacity = runnerruntime.Capacity{Total: cfg.CapacityTotal}
 		}
 		healthy := true

--- a/internal/runner/runtime/docker/runtime.go
+++ b/internal/runner/runtime/docker/runtime.go
@@ -37,6 +37,10 @@ const (
 	containerStatusRemoving   = "removing"
 	containerStatusDead       = "dead"
 	daemonPort                = 8081
+
+	// cleanupBudget bounds the removal of a half-built container after a
+	// failed create, independently of the create context.
+	cleanupBudget = 2 * time.Minute
 )
 
 // CreateOptions holds optional parameters for sandbox creation.
@@ -258,7 +262,9 @@ func (m *Runtime) CreateContainer(ctx context.Context, sandboxID string, opts *C
 	}
 
 	cleanupOnError := func() {
-		_ = m.removeContainerAndTeardownRules(ctx, containerID)
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupBudget)
+		defer cancel()
+		_ = m.removeContainerAndTeardownRules(cleanupCtx, containerID)
 	}
 
 	if err := m.docker.startContainer(ctx, containerID); err != nil {
@@ -558,7 +564,7 @@ func (m *Runtime) removeContainerAndTeardownRules(ctx context.Context, container
 		slog.Warn("remove sandbox container", "container_id", containerID, "err", err)
 		return err
 	}
-	if err := netrules.Teardown(containerID); err != nil {
+	if err := m.teardownRules(containerID); err != nil {
 		// TODO: consider adding metrics to track this in the future.
 		slog.Warn("teardown network rules", "container_id", containerID, "err", err)
 	}

--- a/internal/runner/runtime/docker/runtime.go
+++ b/internal/runner/runtime/docker/runtime.go
@@ -38,8 +38,8 @@ const (
 	containerStatusDead       = "dead"
 	daemonPort                = 8081
 
-	// cleanupBudget bounds the removal of a half-built container after a
-	// failed create, independently of the create context.
+	// cleanupBudget is the deadline for removing a half-built container after a
+	// failed create. The create context cannot be used: it may be what failed.
 	cleanupBudget = 2 * time.Minute
 )
 

--- a/internal/runner/runtime/docker/runtime_test.go
+++ b/internal/runner/runtime/docker/runtime_test.go
@@ -23,7 +23,8 @@ func (f *fakeDockerBackend) ping(context.Context) error {
 }
 
 func (f *fakeDockerBackend) createContainer(context.Context, string, string, string, *ResourceLimits, bool) (string, error) {
-	return "", errors.New("unexpected createContainer")
+	*f.events = append(*f.events, "create")
+	return f.containerID, nil
 }
 
 func (f *fakeDockerBackend) startContainer(context.Context, string) error {
@@ -36,8 +37,12 @@ func (f *fakeDockerBackend) stopContainer(context.Context, string) error {
 	return f.stopErr
 }
 
-func (f *fakeDockerBackend) removeContainer(context.Context, string) error {
-	return errors.New("unexpected removeContainer")
+func (f *fakeDockerBackend) removeContainer(ctx context.Context, _ string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	*f.events = append(*f.events, "remove")
+	return nil
 }
 
 func (f *fakeDockerBackend) containerIP(context.Context, string) (string, error) {
@@ -349,6 +354,40 @@ func TestEnsureSandboxRunningCleansUpStartedContainerOnWakeFailures(t *testing.T
 				t.Fatalf("events = %v, want %v", events, tc.wantEvents)
 			}
 		})
+	}
+}
+
+func TestCreateContainerCleansUpAfterContextCancellation(t *testing.T) {
+	events := []string{}
+	const containerID = "container-1"
+	m := newRuntime(&config.Config{}, Config{}, &fakeDockerBackend{
+		events:      &events,
+		containerID: containerID,
+		ip:          "172.18.0.2",
+	})
+	m.imageReady.Store(true)
+	m.applyPolicy = func(string, string, string, string, int) error {
+		events = append(events, "applyPolicy")
+		return nil
+	}
+	m.teardownRules = func(string) error {
+		events = append(events, "teardown")
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.waitForDaemon = func(ctx context.Context, _ string) error {
+		events = append(events, "waitForDaemon")
+		cancel()
+		return ctx.Err()
+	}
+
+	if _, err := m.CreateContainer(ctx, "sandbox-id-1234", nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("CreateContainer() error = %v, want %v", err, context.Canceled)
+	}
+	wantEvents := []string{"create", "start", "containerIP", "applyPolicy", "waitForDaemon", "remove", "teardown"}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("events = %v, want %v", events, wantEvents)
 	}
 }
 

--- a/internal/runner/runtime/firecracker.ee/README.md
+++ b/internal/runner/runtime/firecracker.ee/README.md
@@ -157,9 +157,10 @@ files, so that accident stops covering it.
 
 A claim comes with a budget: `beginTransition` returns the context its operation
 must run under, which is the caller's detached from cancellation and capped at two
-minutes (create claims in `reserveSandbox` instead, under the same cap). Returning
-the two together is deliberate — a new lifecycle operation cannot acquire a claim
-without also bounding it.
+minutes (create claims in `reserveSandbox` instead and gets three, since it clones
+the rootfs and snapshot before booting; the API sizes its create RPC deadline from
+the same constant). Returning the two together is deliberate — a new lifecycle
+operation cannot acquire a claim without also bounding it.
 
 That budget starts when the claim is won. Waiting for another operation to finish
 is bounded separately and more generously, by `transitionWaitBudget`, so that

--- a/internal/runner/runtime/firecracker.ee/README.md
+++ b/internal/runner/runtime/firecracker.ee/README.md
@@ -158,8 +158,8 @@ files, so that accident stops covering it.
 A claim comes with a budget: `beginTransition` returns the context its operation
 must run under, which is the caller's detached from cancellation and capped at two
 minutes (create claims in `reserveSandbox` instead and gets three, since it clones
-the rootfs and snapshot before booting; the API sizes its create RPC deadline from
-the same constant). Returning the two together is deliberate — a new lifecycle
+the rootfs and snapshot before booting; the API derives its create RPC deadline
+from the same constant). Returning the two together is deliberate — a new lifecycle
 operation cannot acquire a claim without also bounding it.
 
 That budget starts when the claim is won. Waiting for another operation to finish

--- a/internal/runner/runtime/firecracker.ee/README.md
+++ b/internal/runner/runtime/firecracker.ee/README.md
@@ -157,9 +157,9 @@ files, so that accident stops covering it.
 
 A claim comes with a budget: `beginTransition` returns the context its operation
 must run under, which is the caller's detached from cancellation and capped at two
-minutes (create claims in `reserveSandbox` instead and gets three, since it clones
-the rootfs and snapshot before booting). Returning the two together is deliberate —
-a new lifecycle operation cannot acquire a claim without also bounding it.
+minutes (create claims in `reserveSandbox` instead, under the same cap). Returning
+the two together is deliberate — a new lifecycle operation cannot acquire a claim
+without also bounding it.
 
 That budget starts when the claim is won. Waiting for another operation to finish
 is bounded separately and more generously, by `transitionWaitBudget`, so that

--- a/internal/runner/runtime/firecracker.ee/runtime.go
+++ b/internal/runner/runtime/firecracker.ee/runtime.go
@@ -104,8 +104,12 @@ const (
 // RPCs carry the API request context, the idle sweeper's context lives until the
 // API exits), so a wedged host command would otherwise hold the claim forever and
 // fail every later operation on that sandbox.
+//
+// Create gets the runtime contract's larger budget because it clones the rootfs
+// and snapshot before booting; the API sizes its create RPC deadline from the
+// same constant. Vars rather than consts so tests can shrink them.
 var (
-	createBudget     = 2 * time.Minute
+	createBudget     = runnerruntime.CreateBudget
 	transitionBudget = 2 * time.Minute
 )
 

--- a/internal/runner/runtime/firecracker.ee/runtime.go
+++ b/internal/runner/runtime/firecracker.ee/runtime.go
@@ -106,11 +106,12 @@ const (
 // fail every later operation on that sandbox.
 //
 // beginTransition applies transitionBudget to stop, wake, and delete. Create has
-// its own, larger budget because it clones the rootfs and snapshot before booting,
-// and it claims the sandbox in reserveSandbox rather than through beginTransition.
+// its own because it claims the sandbox in reserveSandbox rather than through
+// beginTransition. The API caps its create RPC at three minutes and must stay
+// above createBudget, so the runner always answers before the API gives up.
 // Vars rather than consts so tests can shrink them.
 var (
-	createBudget     = 3 * time.Minute
+	createBudget     = 2 * time.Minute
 	transitionBudget = 2 * time.Minute
 )
 

--- a/internal/runner/runtime/firecracker.ee/runtime.go
+++ b/internal/runner/runtime/firecracker.ee/runtime.go
@@ -104,12 +104,6 @@ const (
 // RPCs carry the API request context, the idle sweeper's context lives until the
 // API exits), so a wedged host command would otherwise hold the claim forever and
 // fail every later operation on that sandbox.
-//
-// beginTransition applies transitionBudget to stop, wake, and delete. Create has
-// its own because it claims the sandbox in reserveSandbox rather than through
-// beginTransition. The API caps its create RPC at three minutes and must stay
-// above createBudget, so the runner always answers before the API gives up.
-// Vars rather than consts so tests can shrink them.
 var (
 	createBudget     = 2 * time.Minute
 	transitionBudget = 2 * time.Minute

--- a/internal/runner/runtime/firecracker.ee/runtime.go
+++ b/internal/runner/runtime/firecracker.ee/runtime.go
@@ -105,9 +105,11 @@ const (
 // API exits), so a wedged host command would otherwise hold the claim forever and
 // fail every later operation on that sandbox.
 //
-// Create gets the runtime contract's larger budget because it clones the rootfs
-// and snapshot before booting; the API sizes its create RPC deadline from the
-// same constant. Vars rather than consts so tests can shrink them.
+// beginTransition applies transitionBudget to stop, wake, and delete. Create
+// claims in reserveSandbox and gets the larger runnerruntime.CreateBudget, since
+// it clones the rootfs and snapshot before booting; the API derives its create
+// RPC deadline from the same constant. Vars rather than consts so tests can
+// shrink them.
 var (
 	createBudget     = runnerruntime.CreateBudget
 	transitionBudget = 2 * time.Minute

--- a/internal/runner/runtime/firecracker.ee/runtime_test.go
+++ b/internal/runner/runtime/firecracker.ee/runtime_test.go
@@ -868,3 +868,14 @@ func TestRuntimeEnsureSandboxRunningWakesStoppedSandbox(t *testing.T) {
 		t.Fatalf("DaemonURL() = %s", url)
 	}
 }
+
+// The API gives up on a create RPC after runnerCreateBudget (internal/api/
+// handlers.go). A create that succeeds answers within createBudget, so that cap
+// must stay above it: an API that gave up on a create that then succeeded would
+// report a failure for a sandbox that is live here and named by no store row.
+func TestCreateBudgetStaysBelowAPICap(t *testing.T) {
+	const apiRunnerCreateBudget = 3 * time.Minute
+	if createBudget >= apiRunnerCreateBudget {
+		t.Fatalf("createBudget = %v, must stay below the API's runnerCreateBudget of %v", createBudget, apiRunnerCreateBudget)
+	}
+}

--- a/internal/runner/runtime/firecracker.ee/runtime_test.go
+++ b/internal/runner/runtime/firecracker.ee/runtime_test.go
@@ -868,14 +868,3 @@ func TestRuntimeEnsureSandboxRunningWakesStoppedSandbox(t *testing.T) {
 		t.Fatalf("DaemonURL() = %s", url)
 	}
 }
-
-// The API gives up on a create RPC after runnerCreateBudget (internal/api/
-// handlers.go). A create that succeeds answers within createBudget, so that cap
-// must stay above it: an API that gave up on a create that then succeeded would
-// report a failure for a sandbox that is live here and named by no store row.
-func TestCreateBudgetStaysBelowAPICap(t *testing.T) {
-	const apiRunnerCreateBudget = 3 * time.Minute
-	if createBudget >= apiRunnerCreateBudget {
-		t.Fatalf("createBudget = %v, must stay below the API's runnerCreateBudget of %v", createBudget, apiRunnerCreateBudget)
-	}
-}

--- a/internal/runner/runtime/runtime.go
+++ b/internal/runner/runtime/runtime.go
@@ -6,13 +6,11 @@ import (
 	"time"
 )
 
-// CreateBudget bounds how long CreateSandbox may run before the runtime gives up
-// on it. It is part of the contract because the API sizes its create RPC
-// deadline from it: the API has to keep waiting for as long as a create can
-// still succeed, or a create it gave up on finishes as a live sandbox that no
-// store row names. Firecracker applies it as its own ceiling, detached from the
-// caller, and needs the headroom because it clones the rootfs and snapshot
-// before booting; the Docker runtime inherits its caller's deadline instead.
+// CreateBudget is how long a runtime may spend on CreateSandbox. It is part of
+// the contract because the API derives its create RPC deadline from it: giving
+// up earlier than the runtime would leave a sandbox that finishes creating with
+// no store row. Firecracker enforces it itself, detached from the caller;
+// Docker inherits the caller's deadline.
 const CreateBudget = 3 * time.Minute
 
 // ErrSandboxNotFound is returned when a sandbox ID is not found.

--- a/internal/runner/runtime/runtime.go
+++ b/internal/runner/runtime/runtime.go
@@ -3,7 +3,17 @@ package runtime
 import (
 	"context"
 	"errors"
+	"time"
 )
+
+// CreateBudget bounds how long CreateSandbox may run before the runtime gives up
+// on it. It is part of the contract because the API sizes its create RPC
+// deadline from it: the API has to keep waiting for as long as a create can
+// still succeed, or a create it gave up on finishes as a live sandbox that no
+// store row names. Firecracker applies it as its own ceiling, detached from the
+// caller, and needs the headroom because it clones the rootfs and snapshot
+// before booting; the Docker runtime inherits its caller's deadline instead.
+const CreateBudget = 3 * time.Minute
 
 // ErrSandboxNotFound is returned when a sandbox ID is not found.
 var ErrSandboxNotFound = errors.New("sandbox not found")


### PR DESCRIPTION
## Summary

If creating a sandbox is cancelled from the client, currently the runner still finishes creating the sandbox on the runner, but the API doesn't insert a row into the db and therefore cannot track the sandbox. This PR makes sure the API does insert the row.