### PR TITLE
Update sandbox base image to Node.js 24

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -13,15 +13,15 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /out/daemon ./cmd/daemon
 # =============================================================================
 # Stage 2: Sandbox image
 # =============================================================================
-# Node >=22 is required by @n8n/workflow-sdk → isolated-vm. Debian bookworm's
-# apt nodejs is still 18, so install the official Node 22 binary instead.
+# Node >=24 is required by @n8n/workflow-sdk → isolated-vm. Debian bookworm's
+# apt nodejs is still 18, so install the official Node 24 binary instead.
 FROM debian:bookworm-slim
 
 ARG TARGETARCH
-ARG NODE_VERSION=22.16.0
+ARG NODE_VERSION=24.21.0
 # From https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt
-ARG NODE_X64_SHA256=f4cb75bb036f0d0eddf6b79d9596df1aaab9ddccd6a20bf489be5abe9467e84e
-ARG NODE_ARM64_SHA256=eab80cb88f8fda1e65f5e8d0420c9809bdb320b03fd34976ab7161b6e703b910
+ARG NODE_X64_SHA256=fd8e59d5a511510f6a298afb548f18c7d2b1be404d8b4a27d94fbe49f56cb2d6
+ARG NODE_ARM64_SHA256=6ad1325edbdb5649c379b75a237147a666c95d4f9ae8d340fef2d1575d289ad2
 
 # build-essential and python3-dev are here because the sandbox has no root, so it
 # cannot apt-get a compiler later. Source builds need one.


### PR DESCRIPTION
## Summary

Updates the sandbox base image from Node.js 22.16.0 to Node.js 24.21.0 and refreshes the pinned x64 and arm64 checksums.

Verified with an amd64 Docker build and runtime version check.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4517

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without a test.
-->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-sandbox-service/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

